### PR TITLE
Update GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -13,8 +13,8 @@ _[what actually happened]_
 
 _[anything to help us reproducing the issue]_
 
-### SwiftLog version/commit hash
+### SwiftCrypto version/commit hash
 
-_[the SwiftLog tag/commit hash]_
+_[the SwiftCrypto tag/commit hash]_
 
 ### Swift & OS version (output of `swift --version && uname -a`)


### PR DESCRIPTION
Motivation:

The GitHub issue template asks for the SwiftLog version/commit hash.
This isn't the SwiftLog project.

Modifications:

Replace SwiftLog with SwiftCrypto in the issue template.

Result:

The GitHub issue template is more relevant to the project.