### PR TITLE
Add '.xcodesamplecode.plist' file to achieve proper markdown rendering

### DIFF
--- a/.xcodesamplecode.plist
+++ b/.xcodesamplecode.plist
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<array/>
+</plist>


### PR DESCRIPTION
Same contents as my [merged PR into swift-numerics](https://github.com/apple/swift-numerics/pull/34), giving proper markdown rendering inside Xcode.

### Motivation:

Reading of markdown becomes easier. Extra important in Swift packages, where the `README` is the first file opened by Xcode when opening said package.

### Modifications:

Just adding the `.xcodesamplecode.plist` file (to the root).

### Result:


As seen in [Apple's ARKit demo (inside `/ARKitExample.xcodeproj/` directory)](https://developer.apple.com/sample-code/wwdc/2017/PlacingObjects.zip)

### Before:
![before](https://user-images.githubusercontent.com/864410/73741969-aa176280-474b-11ea-8c03-afefc7b56711.png)

### After:
![after](https://user-images.githubusercontent.com/864410/73741982-af74ad00-474b-11ea-9622-1782320ea870.png)

