### PR TITLE
Hint to GitHub about vendored BoringSSL code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Sources/CCryptoBoringSSL/* linguist-vendored


### PR DESCRIPTION
This will fix the repo's language stats. BoringSSL should not be included in the repo's language stats as it's vendored code.

GitHub lets us give hints about the repo's code to improve its detection.
More info: https://github.com/github/linguist#vendored-code

Linguist is what GitHub uses for code detection.