### PR TITLE
`// MARK:` delimiter in gyb generated files to allow overview in Xcode minimap 

### DIFF
--- a/Sources/Crypto/AEADs/Nonces.swift
+++ b/Sources/Crypto/AEADs/Nonces.swift
@@ -19,6 +19,7 @@ import Foundation
 // any edits of this file WILL be overwritten and thus discarded
 // see section `gyb` in `README` for details.
 
+// MARK: - AES.GCM + Nonce
 extension AES.GCM {
     public struct Nonce: ContiguousBytes, Sequence {
         let bytes: Data
@@ -48,6 +49,7 @@ extension AES.GCM {
     }
 }
 
+// MARK: - ChaChaPoly + Nonce
 extension ChaChaPoly {
     public struct Nonce: ContiguousBytes, Sequence {
         let bytes: Data

--- a/Sources/Crypto/AEADs/Nonces.swift.gyb
+++ b/Sources/Crypto/AEADs/Nonces.swift.gyb
@@ -28,6 +28,7 @@ nonceSize = cipher["recommendedNonceSize"]
 nonceValidation = cipher["nonceValidation"]
 }%
 
+// MARK: - ${name} + Nonce
 extension ${name} {
     public struct Nonce: ContiguousBytes, Sequence {
         let bytes: Data

--- a/Sources/Crypto/Digests/Digests.swift
+++ b/Sources/Crypto/Digests/Digests.swift
@@ -18,6 +18,7 @@
 // any edits of this file WILL be overwritten and thus discarded
 // see section `gyb` in `README` for details.
 
+// MARK: - SHA256Digest + DigestPrivate
 @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, macCatalyst 13.0, *)
 public struct SHA256Digest: DigestPrivate {
     let bytes: (UInt64, UInt64, UInt64, UInt64)
@@ -65,6 +66,7 @@ public struct SHA256Digest: DigestPrivate {
 }
 
 
+// MARK: - SHA384Digest + DigestPrivate
 @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, macCatalyst 13.0, *)
 public struct SHA384Digest: DigestPrivate {
     let bytes: (UInt64, UInt64, UInt64, UInt64, UInt64, UInt64)
@@ -114,6 +116,7 @@ public struct SHA384Digest: DigestPrivate {
 }
 
 
+// MARK: - SHA512Digest + DigestPrivate
 @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, macCatalyst 13.0, *)
 public struct SHA512Digest: DigestPrivate {
     let bytes: (UInt64, UInt64, UInt64, UInt64, UInt64, UInt64, UInt64, UInt64)
@@ -165,6 +168,7 @@ public struct SHA512Digest: DigestPrivate {
 }
 
 extension Insecure {
+// MARK: - SHA1Digest + DigestPrivate
 @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, macCatalyst 13.0, *)
 public struct SHA1Digest: DigestPrivate {
     let bytes: (UInt64, UInt64, UInt64)
@@ -211,6 +215,7 @@ public struct SHA1Digest: DigestPrivate {
 }
 }
 extension Insecure {
+// MARK: - MD5Digest + DigestPrivate
 @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, macCatalyst 13.0, *)
 public struct MD5Digest: DigestPrivate {
     let bytes: (UInt64, UInt64)

--- a/Sources/Crypto/Digests/Digests.swift.gyb
+++ b/Sources/Crypto/Digests/Digests.swift.gyb
@@ -35,6 +35,7 @@ digests_and_length = [{"name": "SHA256", "count": 32},{"name": "SHA384","count":
         protocol_suffix = ""
 }%
 ${protocol_prefix}
+// MARK: - ${name}Digest + DigestPrivate
 @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, macCatalyst 13.0, *)
 public struct ${name}Digest: DigestPrivate {
     let bytes: (${(wordsCount-1)*"UInt64, "+"UInt64"})

--- a/Sources/Crypto/Key Agreement/ECDH.swift
+++ b/Sources/Crypto/Key Agreement/ECDH.swift
@@ -23,12 +23,15 @@ typealias NISTCurvePrivateKeyImpl = OpenSSLNISTCurvePrivateKeyImpl
 #endif
 
 import Foundation
+
 // MARK: - Generated file, do NOT edit
 // any edits of this file WILL be overwritten and thus discarded
 // see section `gyb` in `README` for details.
 
+// MARK: - P256 + Signing
 extension P256 {
     public enum Signing {
+    
         public struct PublicKey: NISTECPublicKey {
             var impl: NISTCurvePublicKeyImpl<P256.CurveDetails>
 
@@ -81,9 +84,10 @@ extension P256 {
         }
     }
 }
-
+// MARK: - P256 + KeyAgreement
 extension P256 {
     public enum KeyAgreement {
+    
         public struct PublicKey: NISTECPublicKey {
             var impl: NISTCurvePublicKeyImpl<P256.CurveDetails>
 
@@ -136,9 +140,10 @@ extension P256 {
         }
     }
 }
-
+// MARK: - P384 + Signing
 extension P384 {
     public enum Signing {
+    
         public struct PublicKey: NISTECPublicKey {
             var impl: NISTCurvePublicKeyImpl<P384.CurveDetails>
 
@@ -191,9 +196,10 @@ extension P384 {
         }
     }
 }
-
+// MARK: - P384 + KeyAgreement
 extension P384 {
     public enum KeyAgreement {
+    
         public struct PublicKey: NISTECPublicKey {
             var impl: NISTCurvePublicKeyImpl<P384.CurveDetails>
 
@@ -246,9 +252,10 @@ extension P384 {
         }
     }
 }
-
+// MARK: - P521 + Signing
 extension P521 {
     public enum Signing {
+    
         public struct PublicKey: NISTECPublicKey {
             var impl: NISTCurvePublicKeyImpl<P521.CurveDetails>
 
@@ -301,9 +308,10 @@ extension P521 {
         }
     }
 }
-
+// MARK: - P521 + KeyAgreement
 extension P521 {
     public enum KeyAgreement {
+    
         public struct PublicKey: NISTECPublicKey {
             var impl: NISTCurvePublicKeyImpl<P521.CurveDetails>
 
@@ -357,6 +365,7 @@ extension P521 {
     }
 }
 
+// MARK: - P256 + DH
 extension P256.KeyAgreement.PrivateKey: DiffieHellmanKeyAgreement {
     /// Performs a key agreement with provided public key share.
     ///
@@ -371,6 +380,7 @@ extension P256.KeyAgreement.PrivateKey: DiffieHellmanKeyAgreement {
         #endif
     }
 }
+// MARK: - P384 + DH
 extension P384.KeyAgreement.PrivateKey: DiffieHellmanKeyAgreement {
     /// Performs a key agreement with provided public key share.
     ///
@@ -385,6 +395,7 @@ extension P384.KeyAgreement.PrivateKey: DiffieHellmanKeyAgreement {
         #endif
     }
 }
+// MARK: - P521 + DH
 extension P521.KeyAgreement.PrivateKey: DiffieHellmanKeyAgreement {
     /// Performs a key agreement with provided public key share.
     ///

--- a/Sources/Crypto/Key Agreement/ECDH.swift.gyb
+++ b/Sources/Crypto/Key Agreement/ECDH.swift.gyb
@@ -23,18 +23,21 @@ typealias NISTCurvePrivateKeyImpl = OpenSSLNISTCurvePrivateKeyImpl
 #endif
 
 import Foundation
+
 // MARK: - Generated file, do NOT edit
 // any edits of this file WILL be overwritten and thus discarded
 // see section `gyb` in `README` for details.
+
 %{
     NIST_CURVES = ["P256", "P384", "P521"]
     CURVES_FUNC = ["Signing", "KeyAgreement"]
 }%
 % for CURVE in NIST_CURVES:
 % for FUNC in CURVES_FUNC:
-
+// MARK: - ${CURVE} + ${FUNC}
 extension ${CURVE} {
     public enum ${FUNC} {
+    
         public struct PublicKey: NISTECPublicKey {
             var impl: NISTCurvePublicKeyImpl<${CURVE}.CurveDetails>
 
@@ -91,6 +94,7 @@ extension ${CURVE} {
 % end
 
 % for CURVE in NIST_CURVES:
+// MARK: - ${CURVE} + DH
 extension ${CURVE}.KeyAgreement.PrivateKey: DiffieHellmanKeyAgreement {
     /// Performs a key agreement with provided public key share.
     ///

--- a/Sources/Crypto/Signatures/ECDSA.swift
+++ b/Sources/Crypto/Signatures/ECDSA.swift
@@ -32,6 +32,7 @@ protocol NISTSigning {
     associatedtype ECDSASignature: NISTECDSASignature
 }
 
+// MARK: - P256 + Signing
 /// An ECDSA (Elliptic Curve Digital Signature Algorithm) Signature
 extension P256.Signing {
     public struct ECDSASignature: ContiguousBytes, NISTECDSASignature {
@@ -91,6 +92,7 @@ extension P256.Signing {
 
 extension P256.Signing: NISTSigning {}
 
+// MARK: - P256 + PrivateKey
 extension P256.Signing.PrivateKey: DigestSigner {
     ///  Generates an ECDSA signature over the P256 elliptic curve.
     ///
@@ -147,6 +149,7 @@ extension P256.Signing.PublicKey: DigestValidator {
     }
  }
 
+// MARK: - P384 + Signing
 /// An ECDSA (Elliptic Curve Digital Signature Algorithm) Signature
 extension P384.Signing {
     public struct ECDSASignature: ContiguousBytes, NISTECDSASignature {
@@ -206,6 +209,7 @@ extension P384.Signing {
 
 extension P384.Signing: NISTSigning {}
 
+// MARK: - P384 + PrivateKey
 extension P384.Signing.PrivateKey: DigestSigner {
     ///  Generates an ECDSA signature over the P384 elliptic curve.
     ///
@@ -262,6 +266,7 @@ extension P384.Signing.PublicKey: DigestValidator {
     }
  }
 
+// MARK: - P521 + Signing
 /// An ECDSA (Elliptic Curve Digital Signature Algorithm) Signature
 extension P521.Signing {
     public struct ECDSASignature: ContiguousBytes, NISTECDSASignature {
@@ -321,6 +326,7 @@ extension P521.Signing {
 
 extension P521.Signing: NISTSigning {}
 
+// MARK: - P521 + PrivateKey
 extension P521.Signing.PrivateKey: DigestSigner {
     ///  Generates an ECDSA signature over the P521 elliptic curve.
     ///

--- a/Sources/Crypto/Signatures/ECDSA.swift.gyb
+++ b/Sources/Crypto/Signatures/ECDSA.swift.gyb
@@ -40,6 +40,7 @@ protocol NISTSigning {
     CURVE = CURVE_AND_HF["curve"]
     HF    = CURVE_AND_HF["hf"]
 }%
+// MARK: - ${CURVE} + Signing
 /// An ECDSA (Elliptic Curve Digital Signature Algorithm) Signature
 extension ${CURVE}.Signing {
     public struct ECDSASignature: ContiguousBytes, NISTECDSASignature {
@@ -99,6 +100,7 @@ extension ${CURVE}.Signing {
 
 extension ${CURVE}.Signing: NISTSigning {}
 
+// MARK: - ${CURVE} + PrivateKey
 extension ${CURVE}.Signing.PrivateKey: DigestSigner {
     ///  Generates an ECDSA signature over the ${CURVE} elliptic curve.
     ///


### PR DESCRIPTION
**💡 WIP needs to decide format before merge**
Adding `// MARK:` delimiter on a different format (need to agree which format is best) for different curves within gyb generated files.

### Motivation:
Some of over gyb generated files are very long, without any `// MARK:` delimiter, making it hard to get an overview in the Xcode minimap.

### Modifications:

Just adding `// MARK:` in `gyb` files.

### Result:

#### before
This is is `ECDSA.swift` before `MARK` change
![before_no_mark](https://user-images.githubusercontent.com/864410/73879905-90664000-485d-11ea-95f6-836b6bbf43d1.png)

#### after (simple)
Same file -  `ECDSA.swift` - after, with simple `// MARK: - ${CURVE} + PrivateKey`
![after_simple_curve_name_](https://user-images.githubusercontent.com/864410/73879950-abd14b00-485d-11ea-9e17-b1fe902ef3e9.png)

#### after (decorated)
This is `ECDH.swift` with a more decorated variant. 

**TIL** (today I learned): You cannot put multiple `// MARK` on subsequent lines, Xcode will not render them all. E.g. 3 lines of MARK will result in Xcode only displaying the first. The "workaround" this is to put comment (non `// MARK` lines) in between the 3 `// MARK` lines, which is what I've done in this decorated variant.  Thus, in the source, the MARK takes up 9 lines, but might be worth it, because the rendered MARK in the minimap is a much more vibrant delimiter:

##### Code
```swift
// MARK: *************************
//===----------------------------------------------------------------------===//
//===----------------------------------------------------------------------===//
//===----------------------------------------------------------------------===//
// MARK: -~=*  Curve ${CURVE}   *=~-
//===----------------------------------------------------------------------===//
//===----------------------------------------------------------------------===//
//===----------------------------------------------------------------------===//
// MARK: *************************

```

##### minimap
![after_decorated](https://user-images.githubusercontent.com/864410/73880275-6f521f00-485e-11ea-9890-524f64ea57a0.png)
