### PR TITLE
Simplify development on macOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,12 +23,16 @@
 // BoringSSL Commit: 5298ef99bf2b2d77600b3bb74dd572027bf495be
 
 import PackageDescription
+import Foundation
 
-let swiftSettings: [SwiftSetting] = [
+var swiftSettings: [SwiftSetting] = [
     .define("CRYPTO_IN_SWIFTPM"),
-    // To develop this on Apple platforms, uncomment this define.
-    // .define("CRYPTO_IN_SWIFTPM_FORCE_BUILD_API"),
 ]
+
+// To develop this on Apple platforms, define this in your environment:
+if ProcessInfo.processInfo.environment["CRYPTO_IN_SWIFTPM_FORCE_BUILD_API"] != nil {
+  swiftSettings.append(.define("CRYPTO_IN_SWIFTPM_FORCE_BUILD_API"))
+}
 
 let package = Package(
     name: "swift-crypto",

--- a/README.md
+++ b/README.md
@@ -108,5 +108,5 @@ SemVer and Swift Crypto's Public API guarantees should result in a working progr
 
 ### Developing Swift Crypto on macOS
 
-Swift Crypto normally defers to the OS implementation of CryptoKit on macOS. Naturally, this makes developing Swift Crypto on macOS tricky. To get Swift Crypto to build the open source implementation on macOS, uncomment the line that reads: `//.define("CRYPTO_IN_SWIFTPM_FORCE_BUILD_API")`, as this will force Swift Crypto to build its public API.
+Swift Crypto normally defers to the OS implementation of CryptoKit on macOS. Naturally, this makes developing Swift Crypto on macOS tricky. To get Swift Crypto to build the open source implementation on macOS, define `CRYPTO_IN_SWIFTPM_FORCE_BUILD_API=1` as an environment variable when building, as this will force Swift Crypto to build its public API.
 


### PR DESCRIPTION
Support development on Apple platforms without editing Package.swift by
checking if the relevant setting has been set in the environment.

### Motivation:

Development of swift-crypto on Apple platforms currently requires manually editing Package.swift to set the required build setting `CRYPTO_IN_SWIFTPM_FORCE_BUILD_API`. The build setting change is undesirable in non-development scenarios.

### Modifications:

Alter Package.swift to conditionally set `CRYPTO_IN_SWIFTPM_FORCE_BUILD_API` if the environment variable of the same name is set during the build.

### Result:

Development on Apple platforms can be done without altering Package.swift.  For example:

```
$ CRYPTO_IN_SWIFTPM_FORCE_BUILD_API=1 swift build
```