### PR TITLE
fix warnings in with newer Swift compilers

### DIFF
--- a/Sources/Crypto/Util/BoringSSL/ArbitraryPrecisionInteger_boring.swift
+++ b/Sources/Crypto/Util/BoringSSL/ArbitraryPrecisionInteger_boring.swift
@@ -193,7 +193,7 @@ extension ArbitraryPrecisionInteger {
     private static func withUnsafeBN_CTX<T>(_ body: (OpaquePointer) throws -> T) rethrows -> T {
         // We force unwrap here because this call can only fail if the allocator is broken, and if
         // the allocator fails we don't have long to live anyway.
-        var bnCtx = CCryptoBoringSSL_BN_CTX_new()!
+        let bnCtx = CCryptoBoringSSL_BN_CTX_new()!
         defer {
             CCryptoBoringSSL_BN_CTX_free(bnCtx)
         }

--- a/Tests/CryptoTests/Authenticated Encryption/AES-GCM-Runner.swift
+++ b/Tests/CryptoTests/Authenticated Encryption/AES-GCM-Runner.swift
@@ -148,7 +148,7 @@ class AESGCMTests: XCTestCase {
     }
 
     func testRoundTripDataProtocols() throws {
-        func roundTrip<Message: DataProtocol, AAD: DataProtocol>(message: Message, aad: AAD, file: StaticString = #file, line: UInt = #line) throws {
+        func roundTrip<Message: DataProtocol, AAD: DataProtocol>(message: Message, aad: AAD, file: StaticString = (#file), line: UInt = #line) throws {
             let key = SymmetricKey(size: .bits256)
             let nonce = AES.GCM.Nonce()
             let ciphertext = try orFail(file: file, line: line) { try AES.GCM.seal(message, using: key, nonce: nonce, authenticating: aad) }

--- a/Tests/CryptoTests/Authenticated Encryption/ChaChaPoly-Runner.swift
+++ b/Tests/CryptoTests/Authenticated Encryption/ChaChaPoly-Runner.swift
@@ -131,7 +131,7 @@ class ChaChaPolyTests: XCTestCase {
     }
 
     func testRoundTripDataProtocols() throws {
-        func roundTrip<Message: DataProtocol, AAD: DataProtocol>(message: Message, aad: AAD, file: StaticString = #file, line: UInt = #line) throws {
+        func roundTrip<Message: DataProtocol, AAD: DataProtocol>(message: Message, aad: AAD, file: StaticString = (#file), line: UInt = #line) throws {
             let key = SymmetricKey(size: .bits256)
             let nonce = ChaChaPoly.Nonce()
 

--- a/Tests/CryptoTests/Digests/DigestsTests.swift
+++ b/Tests/CryptoTests/Digests/DigestsTests.swift
@@ -50,7 +50,7 @@ func testVectorForAlgorithm<H: HashFunction>(hashFunction: H.Type) throws -> Str
 }
 
 class DigestsTests: XCTestCase {
-    func assertHashFunctionWithVector<H: HashFunction>(hf: H.Type, data: Data, testVector: String, file: StaticString = #file, line: UInt = #line) throws {
+    func assertHashFunctionWithVector<H: HashFunction>(hf: H.Type, data: Data, testVector: String, file: StaticString = (#file), line: UInt = #line) throws {
         var h = hf.init()
         h.update(data: data)
         let result = h.finalize()

--- a/Tests/CryptoTests/Utils/XCTestUtils.swift
+++ b/Tests/CryptoTests/Utils/XCTestUtils.swift
@@ -49,7 +49,7 @@ extension XCTestCase {
     /// been marked as `throws`.
     /// - Note: this is a replacement for `XCTUnwrap`, which is not availble
     /// in SPM command line builds as of this writing: <https://bugs.swift.org/browse/SR-11501>
-    func unwrap<T>(_ optional: T?, file: StaticString = #file, line: UInt = #line) throws -> T {
+    func unwrap<T>(_ optional: T?, file: StaticString = (#file), line: UInt = #line) throws -> T {
         guard let wrapped = optional else {
             XCTFail("Optional was nil", file: file, line: line)
             throw OptionalUnwrappingError(file: file, line: line)


### PR DESCRIPTION
Motiviation:

One `let` was hiding as a `var` and a few `#file` parameters have been
forwarded to (now) `#filePath` ones.

Modification:

- make the `var` a `let`
- silence the `#file`/`#filePath` warning by adding `(#file)` because we
  can't forward them properly right now
  (https://bugs.swift.org/browse/SR-12934). That's okay because even on
  the Swift master branch, `#file` == `#filePath`.

Result:

No warnings in newer Swift compilers.