### PR TITLE
DERTests: enable test function for Android

### DIFF
--- a/Tests/CryptoTests/Encodings/DERTests.swift
+++ b/Tests/CryptoTests/Encodings/DERTests.swift
@@ -49,7 +49,7 @@ class DERTests: XCTestCase {
     }
 
     func randomBytes(count: Int) -> [UInt8] {
-        #if (os(macOS) || os(iOS) || os(watchOS) || os(tvOS)) || os(Linux)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS) || os(Linux) || os(Android)
         var rng = SystemRandomNumberGenerator()
         return (0..<count).map { _ in rng.next() }
         #else


### PR DESCRIPTION
Enable single test erroring on Android

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

### Motivation:

No reason for this to error on Android

### Modifications:

Add Android to the list.

### Result:

All 153 tests pass when building natively on Android with a swift master snapshot from last month, instead of this lone test segfaulting before. Maybe it would be better if this list of systems were removed altogether, as it seems to include every system this codebase has been tested on.