### PR TITLE
Clarify the location of the line to comment out for macOS development

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,5 +108,5 @@ SemVer and Swift Crypto's Public API guarantees should result in a working progr
 
 ### Developing Swift Crypto on macOS
 
-Swift Crypto normally defers to the OS implementation of CryptoKit on macOS. Naturally, this makes developing Swift Crypto on macOS tricky. To get Swift Crypto to build the open source implementation on macOS, uncomment the line that reads: `//.define("CRYPTO_IN_SWIFTPM_FORCE_BUILD_API")`, as this will force Swift Crypto to build its public API.
+Swift Crypto normally defers to the OS implementation of CryptoKit on macOS. Naturally, this makes developing Swift Crypto on macOS tricky. To get Swift Crypto to build the open source implementation on macOS, in `Package.swift`, uncomment the line that reads: `//.define("CRYPTO_IN_SWIFTPM_FORCE_BUILD_API")`, as this will force Swift Crypto to build its public API.
 


### PR DESCRIPTION
Update README to make it clear which file to change to enable macOS development

### Checklist
- [X] I've run tests to see all new and existing tests pass
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

Make it easier for people to start working on Swift Crypto

### Modifications:

Clarified the README

### Result:

Users will know which file to change the line in rather than digging around to find it