### PR TITLE
Fix path to environment script in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -33,7 +33,7 @@ _[the Swift Crypto tag/commit hash]_
 
 ### Environment
 
-Stand in the root of the repo and run `./scripts/environments.sh` and paste the output below
+Stand in the root of the repo and run `./scripts/environment.sh` and paste the output below
 
 <details>
   <pre>PLEASE_REPLACE_THIS_STIRNG_WITH_OUTPUT_OF_script_environments_THAT_IS_IN_YOUR_PASTEBOARD</pre>

--- a/.github/ISSUE_TEMPLATE/REGRESSION.md
+++ b/.github/ISSUE_TEMPLATE/REGRESSION.md
@@ -26,7 +26,7 @@ _[the Swift Crypto tag/commit hash]_
 
 ### Environment
 
-Stand in the root of the repo and run `./scripts/environments.sh` and paste the output below
+Stand in the root of the repo and run `./scripts/environment.sh` and paste the output below
 
 <details>
   <pre>PLEASE_REPLACE_THIS_STIRNG_WITH_OUTPUT_OF_script_environments_THAT_IS_IN_YOUR_PASTEBOARD</pre>


### PR DESCRIPTION
Fixes the path to the environment script in the issue templates so copy-paste works

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [X] I've run tests to see all new and existing tests pass
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

So copy-paste works and the issue templates are correct

### Modifications:

Fix a typo

### Result:

Script command works