### PR TITLE
Make `memset_s` consistent with Darwin.

### DIFF
--- a/Sources/Crypto/Util/BoringSSL/Zeroization_boring.swift
+++ b/Sources/Crypto/Util/BoringSSL/Zeroization_boring.swift
@@ -14,11 +14,15 @@
 #if !(os(macOS) || os(iOS) || os(watchOS) || os(tvOS))
 @_implementationOnly import CCryptoBoringSSL
 
+typealias errno_t = CInt
+
 // This is a Swift wrapper for the libc function that does not exist on Linux. We shim it via a call to OPENSSL_cleanse.
 // We have the same syntax, but mostly ignore it.
-func memset_s(_ s: UnsafeMutableRawPointer!, _ smax: Int, _ byte: CInt, _ n: Int) {
+@discardableResult
+func memset_s(_ s: UnsafeMutableRawPointer!, _ smax: Int, _ byte: CInt, _ n: Int) -> errno_t {
     assert(smax == n, "memset_s invariant not met")
     assert(byte == 0, "memset_s used to not zero anything")
     CCryptoBoringSSL_OPENSSL_cleanse(s, smax)
+    return 0
 }
 #endif


### PR DESCRIPTION
Resolves [issue#51](https://github.com/apple/swift-crypto/issues/51).

In Swift 5.3, a warning is viewed on Linux because `memset_s` implemented in this module returns `Void`.
This PR let the function return the same type with Darwin.


### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary


### Result:

No warnings are viewed while building.