### PR TITLE
build: allow building on Windows

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -46,7 +46,17 @@ let package = Package(
     ],
     dependencies: [],
     targets: [
-        .target(name: "CCryptoBoringSSL"),
+        .target(
+          name: "CCryptoBoringSSL",
+          cSettings: [
+            /*
+             * This define is required on Windows, but because we need older
+             * versions of SPM, we cannot conditionally define this on Windows
+             * only.  Unconditionally define it instead.
+             */
+            .define("WIN32_LEAN_AND_MEAN"),
+          ]
+        ),
         .target(name: "CCryptoBoringSSLShims", dependencies: ["CCryptoBoringSSL"]),
         .target(name: "Crypto", dependencies: ["CCryptoBoringSSL", "CCryptoBoringSSLShims"], swiftSettings: swiftSettings),
         .target(name: "crypto-shasum", dependencies: ["Crypto"]),


### PR DESCRIPTION
This allows us to build on Windows, though not entirely.  The assembly
routines need to be generated for the Windows targets, but this is
required to get to that point.  With this set of changes, we are able to
get to the point where we can start linking the `crypto-shasum` target,
which exposes the missing symbols.

_[One line description of your change]_

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [x] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_