### PR TITLE
fix a typo in documentation

### DIFF
--- a/Sources/Crypto/Keys/Symmetric/SymmetricKeys.swift
+++ b/Sources/Crypto/Keys/Symmetric/SymmetricKeys.swift
@@ -25,7 +25,7 @@ public struct SymmetricKeySize {
         return self.init(bitCount: 128)
     }
 
-    /// Symmetric key size of 128 bits
+    /// Symmetric key size of 192 bits
     public static var bits192: SymmetricKeySize {
         return self.init(bitCount: 192)
     }


### PR DESCRIPTION
Fixes a typo in the documentation, where `SymmetricKeySize.bits192` is incorrectly described as having 128 bits

### Checklist
- [N/A] I've run tests to see all new and existing tests pass
- [N/A] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [N/A] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

Enhances clarity in the `SymmetricKeySize` enum

### Modifications:

Just changed 2 characters in the documentation to accurately reflect the key size

### Result:

Correct key size in the documentation