### PR TITLE
build: allow using a build tree of dispatch, Foundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,5 +37,10 @@ if(BUILD_SHARED_LIBS)
   set(CMAKE_POSITION_INDEPENDENT_CODE YES)
 endif()
 
+if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
+  find_package(dispatch CONFIG)
+  find_package(Foundation CONFIG)
+endif()
+
 add_subdirectory(Sources)
 add_subdirectory(cmake/modules)

--- a/Sources/Crypto/CMakeLists.txt
+++ b/Sources/Crypto/CMakeLists.txt
@@ -80,6 +80,8 @@ target_include_directories(Crypto PRIVATE
   $<TARGET_PROPERTY:CCryptoBoringSSL,INCLUDE_DIRECTORIES>
   $<TARGET_PROPERTY:CCryptoBoringSSLShims,INCLUDE_DIRECTORIES>)
 target_link_libraries(Crypto PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:dispatch>
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
   CCryptoBoringSSL
   CCryptoBoringSSLShims)
 set_target_properties(Crypto PROPERTIES


### PR DESCRIPTION
When building swift-crypto from source for a toolchain build, it is
convenient to build it without building up a toolchain image.  This
additional knob allows for building swift-crypto with the build
artifacts of previous builds, allowing building up a toolchain image
while chaining multiple builds together.

_[One line description of your change]_

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [ ] I've run tests to see all new and existing tests pass
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_