### PR TITLE
Setup docker for cmake build

### DIFF
--- a/Sources/CCryptoBoringSSL/include/module.modulemap
+++ b/Sources/CCryptoBoringSSL/include/module.modulemap
@@ -1,0 +1,4 @@
+module CCryptoBoringSSL {
+    header "CCryptoBoringSSL.h"
+    export *
+}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,16 +12,11 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
-# Get lldb out of the way
-RUN if [ -d /usr/lib/python2.7/site-packages ]; then mv /usr/lib/python2.7/site-packages/* /usr/lib/python2.7/dist-packages && rmdir /usr/lib/python2.7/site-packages && ln -s /usr/lib/python2.7/dist-packages /usr/lib/python2.7/site-packages; fi
-
 # dependencies
 RUN apt-get update && apt-get install -y wget
-RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools curl jq python2.7 # used by integration tests
 
-# ruby and jazzy for docs generation
-RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev
-RUN gem install jazzy --no-ri --no-rdoc
+# cmake build
+RUN apt-get update && apt-get install -y cmake ninja-build
 
 # tools
 RUN mkdir -p $HOME/.tools

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,8 +12,16 @@ ENV LC_ALL en_US.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
 
+# Get lldb out of the way
+RUN if [ -d /usr/lib/python2.7/site-packages ]; then mv /usr/lib/python2.7/site-packages/* /usr/lib/python2.7/dist-packages && rmdir /usr/lib/python2.7/site-packages && ln -s /usr/lib/python2.7/dist-packages /usr/lib/python2.7/site-packages; fi
+
 # dependencies
 RUN apt-get update && apt-get install -y wget
+RUN apt-get update && apt-get install -y lsof dnsutils netcat-openbsd net-tools curl jq python2.7 # used by integration tests
+
+# ruby and jazzy for docs generation
+RUN apt-get update && apt-get install -y ruby ruby-dev libsqlite3-dev
+RUN if [ "${ubuntu_version}" != "focal" ] ; then gem install jazzy --no-document ; fi
 
 # cmake build
 RUN apt-get update && apt-get install -y cmake ninja-build

--- a/docker/docker-compose.2004.53.yaml
+++ b/docker/docker-compose.2004.53.yaml
@@ -1,0 +1,21 @@
+version: "3"
+
+services:
+
+  runtime-setup:
+    image: swift-crypto:20.04-5.3
+    build:
+      args:
+        ubuntu_version: "focal"
+        swift_version: "5.3"
+
+  test:
+    image: swift-crypto:20.04-5.3
+    environment: []
+      #- SANITIZER_ARG=--sanitize=thread
+
+  cmake:
+    image: swift-crypto:20.04-5.3
+
+  shell:
+    image: swift-crypto:20.04-5.3

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -31,6 +31,10 @@ services:
     # FIXME: get rid of existing warnings
     #command: /bin/bash -xcl "swift test --enable-test-discovery -Xswiftc -warnings-as-errors $${SANITIZER_ARG-}"
     command: /bin/bash -xcl "swift test --enable-test-discovery"
+    
+  cmake:
+    <<: *common
+    command: /bin/bash -xcl "cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -B out -S . && ninja -C out"
 
   # util
 


### PR DESCRIPTION
Motivation:
Be able to run cmake build in CI

Modifications:
- Add "cmake" service to `docker-compose.yaml`
- Update `Dockerfile` to install `cmake` and `ninja`. Remove unneeded dependencies.
- Add `docker-compose.2004.53.yaml`. `cmake` on previous Ubuntu versions are too old and it would be a pain to upgrade, so using Ubuntu 20.04 to simplify things.
- Add back modulemap to ensure cmake build is successful

Result:
Can run cmake in CI
