### PR TITLE
Fix typo in license header

### DIFF
--- a/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL.h
+++ b/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL.h
@@ -1,6 +1,6 @@
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwitCrypto open source project
+// This source file is part of the SwiftCrypto open source project
 //
 // Copyright (c) 2019 Apple Inc. and the SwiftCrypto project authors
 // Licensed under Apache License v2.0

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -285,7 +285,7 @@ echo "MODULARISING BoringSSL"
 cat << EOF > "$DSTROOT/include/CCryptoBoringSSL.h"
 //===----------------------------------------------------------------------===//
 //
-// This source file is part of the SwitCrypto open source project
+// This source file is part of the SwiftCrypto open source project
 //
 // Copyright (c) 2019 Apple Inc. and the SwiftCrypto project authors
 // Licensed under Apache License v2.0


### PR DESCRIPTION
Fixed a small typo in the generated header file