### PR TITLE
Stop referring to the missing master branch in BUG_REPORT.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/BUG_REPORT.md
+++ b/.github/ISSUE_TEMPLATE/BUG_REPORT.md
@@ -8,7 +8,7 @@ about: If something isn't working as expected
 
 ### New Issue Checklist
 
-- [ ] I'm using the latest version of Swift Crypto (master branch)
+- [ ] I'm using the latest version of Swift Crypto (`main` branch)
 - [ ] I read the [Contribution Guidelines](https://github.com/apple/swift-crypto/blob/master/CONTRIBUTING.md)
 - [ ] I searched for [existing GitHub issues](https://github.com/apple/swift-crypto/issues)
 


### PR DESCRIPTION
The `BUG_REPORT.md` template refers to a missing branch.

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [ ] I've run tests to see all new and existing tests pass
N/A
- [ ] I've followed the code style of the rest of the project
N/A
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request
N/A

### Motivation:

Current steps in `BUG_REPORT.md` are confusing as they refer to a branch that doesn't exist in this repository.

### Modifications:

The reference to the `master` branch was replaced with the reference to `main`.

### Result:

`BUG_REPORT.md` no longer refers to a missing branch.