### PR TITLE
Remove assembly on Apple ARM64

### DIFF
--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -237,9 +237,9 @@ echo "REMOVING libssl"
 
 mangle_symbols
 
-# Removing ASM on 32 bit Apple platforms
-echo "REMOVING assembly on 32-bit Apple platforms"
-gsed -i "/#define OPENSSL_HEADER_BASE_H/a#if defined(__APPLE__) && defined(__i386__)\n#define OPENSSL_NO_ASM\n#endif" "$DSTROOT/include/openssl/base.h"
+# Removing ASM on 32-bit and ARM64 Apple platforms
+echo "REMOVING assembly on 32-bit and ARM64 Apple platforms"
+gsed -i "/#define OPENSSL_HEADER_BASE_H/a#if defined(__APPLE__) && (defined(__i386__) || defined(__aarch64__))\n#define OPENSSL_NO_ASM\n#endif" "$DSTROOT/include/openssl/base.h"
 
 # Remove assembly on non-x86 Windows
 echo "REMOVING assembly on non-x86 Windows"


### PR DESCRIPTION
Motivation:
See https://github.com/apple/swift-crypto/issues/74.

Modification:
Set `OPENSSL_NO_ASM` on Apple ARM64 such that it will not force requirement of assembly routines.

Result:
Resolves https://github.com/apple/swift-crypto/issues/74.
