### PR TITLE
Add ARM64 assembly files to cmake build

### DIFF
--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -318,48 +318,68 @@ add_library(CCryptoBoringSSL STATIC
   "crypto/x509v3/v3_skey.c"
   "crypto/x509v3/v3_utl.c")
 
-if(CMAKE_SYSTEM_PROCESSOR MATCHES "x86_64|amd64")
-  if(CMAKE_SYSTEM_NAME STREQUAL Darwin)
-    target_sources(CCryptoBoringSSL PRIVATE
-      crypto/chacha/chacha-x86_64.mac.x86_64.S
-      crypto/cipher_extra/aes128gcmsiv-x86_64.mac.x86_64.S
-      crypto/cipher_extra/chacha20_poly1305_x86_64.mac.x86_64.S
-      crypto/fipsmodule/aesni-gcm-x86_64.mac.x86_64.S
-      crypto/fipsmodule/aesni-x86_64.mac.x86_64.S
-      crypto/fipsmodule/ghash-ssse3-x86_64.mac.x86_64.S
-      crypto/fipsmodule/ghash-x86_64.mac.x86_64.S
-      crypto/fipsmodule/md5-x86_64.mac.x86_64.S
-      crypto/fipsmodule/p256-x86_64-asm.mac.x86_64.S
-      crypto/fipsmodule/p256_beeu-x86_64-asm.mac.x86_64.S
-      crypto/fipsmodule/rdrand-x86_64.mac.x86_64.S
-      crypto/fipsmodule/rsaz-avx2.mac.x86_64.S
-      crypto/fipsmodule/sha1-x86_64.mac.x86_64.S
-      crypto/fipsmodule/sha256-x86_64.mac.x86_64.S
-      crypto/fipsmodule/sha512-x86_64.mac.x86_64.S
-      crypto/fipsmodule/vpaes-x86_64.mac.x86_64.S
-      crypto/fipsmodule/x86_64-mont.mac.x86_64.S
-      crypto/fipsmodule/x86_64-mont5.mac.x86_64.S)
-  elseif(CMAKE_SYSTEM_NAME STREQUAL Linux)
-    target_sources(CCryptoBoringSSL PRIVATE
-      crypto/chacha/chacha-x86_64.linux.x86_64.S
-      crypto/cipher_extra/aes128gcmsiv-x86_64.linux.x86_64.S
-      crypto/cipher_extra/chacha20_poly1305_x86_64.linux.x86_64.S
-      crypto/fipsmodule/aesni-gcm-x86_64.linux.x86_64.S
-      crypto/fipsmodule/aesni-x86_64.linux.x86_64.S
-      crypto/fipsmodule/ghash-ssse3-x86_64.linux.x86_64.S
-      crypto/fipsmodule/ghash-x86_64.linux.x86_64.S
-      crypto/fipsmodule/md5-x86_64.linux.x86_64.S
-      crypto/fipsmodule/p256-x86_64-asm.linux.x86_64.S
-      crypto/fipsmodule/p256_beeu-x86_64-asm.linux.x86_64.S
-      crypto/fipsmodule/rdrand-x86_64.linux.x86_64.S
-      crypto/fipsmodule/rsaz-avx2.linux.x86_64.S
-      crypto/fipsmodule/sha1-x86_64.linux.x86_64.S
-      crypto/fipsmodule/sha256-x86_64.linux.x86_64.S
-      crypto/fipsmodule/sha512-x86_64.linux.x86_64.S
-      crypto/fipsmodule/vpaes-x86_64.linux.x86_64.S
-      crypto/fipsmodule/x86_64-mont.linux.x86_64.S
-      crypto/fipsmodule/x86_64-mont5.linux.x86_64.S)
-  endif()
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin AND CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64")
+  target_sources(CCryptoBoringSSL PRIVATE
+    crypto/chacha/chacha-x86_64.mac.x86_64.S
+    crypto/cipher_extra/aes128gcmsiv-x86_64.mac.x86_64.S
+    crypto/cipher_extra/chacha20_poly1305_x86_64.mac.x86_64.S
+    crypto/fipsmodule/aesni-gcm-x86_64.mac.x86_64.S
+    crypto/fipsmodule/aesni-x86_64.mac.x86_64.S
+    crypto/fipsmodule/ghash-ssse3-x86_64.mac.x86_64.S
+    crypto/fipsmodule/ghash-x86_64.mac.x86_64.S
+    crypto/fipsmodule/md5-x86_64.mac.x86_64.S
+    crypto/fipsmodule/p256-x86_64-asm.mac.x86_64.S
+    crypto/fipsmodule/p256_beeu-x86_64-asm.mac.x86_64.S
+    crypto/fipsmodule/rdrand-x86_64.mac.x86_64.S
+    crypto/fipsmodule/rsaz-avx2.mac.x86_64.S
+    crypto/fipsmodule/sha1-x86_64.mac.x86_64.S
+    crypto/fipsmodule/sha256-x86_64.mac.x86_64.S
+    crypto/fipsmodule/sha512-x86_64.mac.x86_64.S
+    crypto/fipsmodule/vpaes-x86_64.mac.x86_64.S
+    crypto/fipsmodule/x86_64-mont.mac.x86_64.S
+    crypto/fipsmodule/x86_64-mont5.mac.x86_64.S)
+elseif(CMAKE_SYSTEM_NAME STREQUAL Linux AND CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64")
+  target_sources(CCryptoBoringSSL PRIVATE
+    crypto/chacha/chacha-x86_64.linux.x86_64.S
+    crypto/cipher_extra/aes128gcmsiv-x86_64.linux.x86_64.S
+    crypto/cipher_extra/chacha20_poly1305_x86_64.linux.x86_64.S
+    crypto/fipsmodule/aesni-gcm-x86_64.linux.x86_64.S
+    crypto/fipsmodule/aesni-x86_64.linux.x86_64.S
+    crypto/fipsmodule/ghash-ssse3-x86_64.linux.x86_64.S
+    crypto/fipsmodule/ghash-x86_64.linux.x86_64.S
+    crypto/fipsmodule/md5-x86_64.linux.x86_64.S
+    crypto/fipsmodule/p256-x86_64-asm.linux.x86_64.S
+    crypto/fipsmodule/p256_beeu-x86_64-asm.linux.x86_64.S
+    crypto/fipsmodule/rdrand-x86_64.linux.x86_64.S
+    crypto/fipsmodule/rsaz-avx2.linux.x86_64.S
+    crypto/fipsmodule/sha1-x86_64.linux.x86_64.S
+    crypto/fipsmodule/sha256-x86_64.linux.x86_64.S
+    crypto/fipsmodule/sha512-x86_64.linux.x86_64.S
+    crypto/fipsmodule/vpaes-x86_64.linux.x86_64.S
+    crypto/fipsmodule/x86_64-mont.linux.x86_64.S
+    crypto/fipsmodule/x86_64-mont5.linux.x86_64.S)
+elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+  target_sources(CCryptoBoringSSL PRIVATE
+    crypto/chacha/chacha-armv8.ios.aarch64.S
+    crypto/fipsmodule/aesv8-armx64.ios.aarch64.S
+    crypto/fipsmodule/armv8-mont.ios.aarch64.S
+    crypto/fipsmodule/ghash-neon-armv8.ios.aarch64.S
+    crypto/fipsmodule/ghashv8-armx64.ios.aarch64.S
+    crypto/fipsmodule/sha1-armv8.ios.aarch64.S
+    crypto/fipsmodule/sha256-armv8.ios.aarch64.S
+    crypto/fipsmodule/sha512-armv8.ios.aarch64.S
+    crypto/fipsmodule/vpaes-armv8.ios.aarch64.S)
+elseif(CMAKE_SYSTEM_NAME STREQUAL Linux AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+  target_sources(CCryptoBoringSSL PRIVATE
+    crypto/chacha/chacha-armv8.linux.aarch64.S
+    crypto/fipsmodule/aesv8-armx64.linux.aarch64.S
+    crypto/fipsmodule/armv8-mont.linux.aarch64.S
+    crypto/fipsmodule/ghash-neon-armv8.linux.aarch64.S
+    crypto/fipsmodule/ghashv8-armx64.linux.aarch64.S
+    crypto/fipsmodule/sha1-armv8.linux.aarch64.S
+    crypto/fipsmodule/sha256-armv8.linux.aarch64.S
+    crypto/fipsmodule/sha512-armv8.linux.aarch64.S
+    crypto/fipsmodule/vpaes-armv8.linux.aarch64.S)
 endif()
 
 target_include_directories(CCryptoBoringSSL PUBLIC

--- a/scripts/update_cmakelists.sh
+++ b/scripts/update_cmakelists.sh
@@ -59,16 +59,22 @@ function update_cmakelists_assembly() {
     src_root="$here/Sources/$1"
     echo "Finding assembly files (.S) under $src_root"
 
-    mac_asms=$($find "${src_root}" -type f -name "*.mac.x86_64.S" -printf '      %P\n' | LC_ALL=POSIX sort)
-    linux_asms=$($find "${src_root}" -type f -name "*.linux.x86_64.S" -printf '      %P\n' | LC_ALL=POSIX sort)
-    echo "$mac_asms"
-    echo "$linux_asms"
+    mac_x86_64_asms=$($find "${src_root}" -type f -name "*.mac.x86_64.S" -printf '    %P\n' | LC_ALL=POSIX sort)
+    linux_x86_64_asms=$($find "${src_root}" -type f -name "*.linux.x86_64.S" -printf '    %P\n' | LC_ALL=POSIX sort)
+    mac_aarch64_asms=$($find "${src_root}" -type f -name "*.ios.aarch64.S" -printf '    %P\n' | LC_ALL=POSIX sort)
+    linux_aarch64_asms=$($find "${src_root}" -type f -name "*.linux.aarch64.S" -printf '    %P\n' | LC_ALL=POSIX sort)
+    echo "$mac_x86_64_asms"
+    echo "$linux_x86_64_asms"
+    echo "$mac_aarch64_asms"
+    echo "$linux_aarch64_asms"
     
     # Update list of assembly files in CMakeLists.txt
     # The first part in `BEGIN` (i.e., `undef $/;`) is for working with multi-line;
     # the second is so that we can pass in a variable to replace with.
-    perl -pi -e 'BEGIN { undef $/; $replace = shift } s/Darwin\)\n(.+)target_sources\(([^\n]+)\n([^\)]+)/Darwin\)\n$1target_sources\($2\n$replace/' "$mac_asms" "$src_root/CMakeLists.txt"
-    perl -pi -e 'BEGIN { undef $/; $replace = shift } s/Linux\)\n(.+)target_sources\(([^\n]+)\n([^\)]+)/Linux\)\n$1target_sources\($2\n$replace/' "$linux_asms" "$src_root/CMakeLists.txt"
+    perl -pi -e 'BEGIN { undef $/; $replace = shift } s/Darwin([^\)]+)x86_64"\)\n  target_sources\(([^\n]+)\n([^\)]+)/Darwin$1x86_64"\)\n  target_sources\($2\n$replace/' "$mac_x86_64_asms" "$src_root/CMakeLists.txt"
+    perl -pi -e 'BEGIN { undef $/; $replace = shift } s/Linux([^\)]+)x86_64"\)\n  target_sources\(([^\n]+)\n([^\)]+)/Linux$1x86_64"\)\n  target_sources\($2\n$replace/' "$linux_x86_64_asms" "$src_root/CMakeLists.txt"
+    perl -pi -e 'BEGIN { undef $/; $replace = shift } s/Darwin([^\)]+)aarch64"\)\n  target_sources\(([^\n]+)\n([^\)]+)/Darwin$1aarch64"\)\n  target_sources\($2\n$replace/' "$mac_aarch64_asms" "$src_root/CMakeLists.txt"
+    perl -pi -e 'BEGIN { undef $/; $replace = shift } s/Linux([^\)]+)aarch64"\)\n  target_sources\(([^\n]+)\n([^\)]+)/Linux$1aarch64"\)\n  target_sources\($2\n$replace/' "$linux_aarch64_asms" "$src_root/CMakeLists.txt"
     echo "Updated $src_root/CMakeLists.txt"
 }
 


### PR DESCRIPTION
Motivation:
See https://github.com/apple/swift-crypto/issues/74

Modifications:
- Add ARM64 assembly files to cmake build
- Update script to handle ARM64 assembly files

Result:
Resolves https://github.com/apple/swift-crypto/issues/74
