### PR TITLE
build: add amd64 and aarch64 assembly files to CMake build for Android

### DIFF
--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -337,7 +337,7 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin AND CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x
     crypto/fipsmodule/vpaes-x86_64.mac.x86_64.S
     crypto/fipsmodule/x86_64-mont.mac.x86_64.S
     crypto/fipsmodule/x86_64-mont5.mac.x86_64.S)
-elseif(CMAKE_SYSTEM_NAME STREQUAL Linux AND CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64")
+elseif(CMAKE_SYSTEM_NAME MATCHES "Linux|Android" AND CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64")
   target_sources(CCryptoBoringSSL PRIVATE
     crypto/chacha/chacha-x86_64.linux.x86_64.S
     crypto/cipher_extra/aes128gcmsiv-x86_64.linux.x86_64.S
@@ -368,7 +368,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL Darwin AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm
     crypto/fipsmodule/sha256-armv8.ios.aarch64.S
     crypto/fipsmodule/sha512-armv8.ios.aarch64.S
     crypto/fipsmodule/vpaes-armv8.ios.aarch64.S)
-elseif(CMAKE_SYSTEM_NAME STREQUAL Linux AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
+elseif(CMAKE_SYSTEM_NAME MATCHES "Linux|Android" AND CMAKE_SYSTEM_PROCESSOR MATCHES "arm64|aarch64")
   target_sources(CCryptoBoringSSL PRIVATE
     crypto/chacha/chacha-armv8.linux.aarch64.S
     crypto/fipsmodule/aesv8-armx64.linux.aarch64.S


### PR DESCRIPTION
### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

### Motivation:

Get all needed functions built for Android.

### Modifications:

Two small CMake additions

### Result:

The CMake build of the May 3rd trunk snapshot of SPM on Android AArch64 works again.

The amd64 change has not been tested, but will likely be needed too.