### PR TITLE
Add SECURITY.md for swift-crypto

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,12 @@
+# Security
+
+This document specifies the security process for Swift Crypto.
+
+## Disclosures
+
+To report a known or suspected vulnerability in Swift Crypto, [please report that vulnerability to Apple through the usual channel](https://support.apple.com/en-us/HT201220).
+
+**Do not file a public issue.**
+
+Fixes to Swift Crypto will be released simultaneously with any changes that need to be made in CryptoKit, to avoid the risk of having only partially fixed projects.
+


### PR DESCRIPTION
The SSWG requires that projects now prominently link to their security process. As ours is delegated to Apple, we should expand upon the existing text in our README and provide an obvious place to look for that process.