### PR TITLE
fix possible over-indexing

### DIFF
--- a/Sources/Crypto/Util/PrettyBytes.swift
+++ b/Sources/Crypto/Util/PrettyBytes.swift
@@ -42,12 +42,10 @@ extension DataProtocol {
         let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: hexLen)
         var offset = 0
         
-        self.regions.forEach { (_) in
-            for i in self {
-                ptr[Int(offset * 2)] = itoh((i >> 4) & 0xF)
-                ptr[Int(offset * 2 + 1)] = itoh(i & 0xF)
-                offset += 1
-            }
+        for i in self {
+            ptr[Int(offset * 2)] = itoh((i >> 4) & 0xF)
+            ptr[Int(offset * 2 + 1)] = itoh(i & 0xF)
+            offset += 1
         }
         
         return String(bytesNoCopy: ptr, length: hexLen, encoding: .utf8, freeWhenDone: true)!


### PR DESCRIPTION
If a type conforming to DataProtocol has multiple regions then we would iterate over through the whole data multiple times, over-indexing the output array.

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [ ] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_