### PR TITLE
build: attempt to workaround linker issues on Darwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,6 +37,11 @@ if(BUILD_SHARED_LIBS)
   set(CMAKE_POSITION_INDEPENDENT_CODE YES)
 endif()
 
+if(CMAKE_SYSTEM_NAME STREQUAL Darwin AND NOT CMAKE_CROSSCOMPILING)
+  set(CMAKE_AR "/usr/bin/ar")
+  set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> crs <TARGET> <LINK_FLAGS> <OBJECTS>")
+endif()
+
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)
   find_package(dispatch CONFIG)
   find_package(Foundation CONFIG)


### PR DESCRIPTION
The use of a non-cctools librarian causes ld64 some heartburn.
Explicitly opt into using the cctools librarian.

_[One line description of your change]_

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [ ] I've run tests to see all new and existing tests pass
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_