### PR TITLE
Update BoringSSL to f961de5c47ed265c3e758ec70dd15ece20809962

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,7 @@
 // Sources/CCryptoBoringSSL directory. The source repository is at
 // https://boringssl.googlesource.com/boringssl.
 //
-// BoringSSL Commit: 2fc6d38391cb76839c76b2a462619e7d69fd998d
+// BoringSSL Commit: f961de5c47ed265c3e758ec70dd15ece20809962
 
 import PackageDescription
 

--- a/Sources/CCryptoBoringSSL/crypto/bytestring/cbs.c
+++ b/Sources/CCryptoBoringSSL/crypto/bytestring/cbs.c
@@ -279,6 +279,13 @@ static int parse_asn1_tag(CBS *cbs, unsigned *out) {
 
   tag |= tag_number;
 
+  // Tag [UNIVERSAL 0] is reserved for use by the encoding. Reject it here to
+  // avoid some ambiguity around ANY values and BER indefinite-length EOCs. See
+  // https://crbug.com/boringssl/455.
+  if ((tag & ~CBS_ASN1_CONSTRUCTED) == 0) {
+    return 0;
+  }
+
   *out = tag;
   return 1;
 }

--- a/Sources/CCryptoBoringSSL/crypto/fipsmodule/p256-armv8-asm.ios.aarch64.S
+++ b/Sources/CCryptoBoringSSL/crypto/fipsmodule/p256-armv8-asm.ios.aarch64.S
@@ -14,7 +14,7 @@
 #if defined(BORINGSSL_PREFIX)
 #include <CCryptoBoringSSL_boringssl_prefix_symbols_asm.h>
 #endif
-#include "openssl/arm_arch.h"
+#include "CCryptoBoringSSL_arm_arch.h"
 
 .text
 .align	5

--- a/Sources/CCryptoBoringSSL/crypto/fipsmodule/p256-armv8-asm.linux.aarch64.S
+++ b/Sources/CCryptoBoringSSL/crypto/fipsmodule/p256-armv8-asm.linux.aarch64.S
@@ -15,7 +15,7 @@
 #if defined(BORINGSSL_PREFIX)
 #include <CCryptoBoringSSL_boringssl_prefix_symbols_asm.h>
 #endif
-#include "openssl/arm_arch.h"
+#include "CCryptoBoringSSL_arm_arch.h"
 
 .text
 .align	5

--- a/Sources/CCryptoBoringSSL/crypto/fipsmodule/p256_beeu-armv8-asm.ios.aarch64.S
+++ b/Sources/CCryptoBoringSSL/crypto/fipsmodule/p256_beeu-armv8-asm.ios.aarch64.S
@@ -14,7 +14,7 @@
 #if defined(BORINGSSL_PREFIX)
 #include <CCryptoBoringSSL_boringssl_prefix_symbols_asm.h>
 #endif
-#include "openssl/arm_arch.h"
+#include "CCryptoBoringSSL_arm_arch.h"
 
 .text
 .globl	_beeu_mod_inverse_vartime

--- a/Sources/CCryptoBoringSSL/crypto/fipsmodule/p256_beeu-armv8-asm.linux.aarch64.S
+++ b/Sources/CCryptoBoringSSL/crypto/fipsmodule/p256_beeu-armv8-asm.linux.aarch64.S
@@ -15,7 +15,7 @@
 #if defined(BORINGSSL_PREFIX)
 #include <CCryptoBoringSSL_boringssl_prefix_symbols_asm.h>
 #endif
-#include "openssl/arm_arch.h"
+#include "CCryptoBoringSSL_arm_arch.h"
 
 .text
 .globl	beeu_mod_inverse_vartime

--- a/Sources/CCryptoBoringSSL/crypto/internal.h
+++ b/Sources/CCryptoBoringSSL/crypto/internal.h
@@ -126,10 +126,18 @@
 #endif
 
 #if !defined(__cplusplus)
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && !defined(__clang__)
 #define alignas(x) __declspec(align(x))
 #define alignof __alignof
 #else
+// With the exception of MSVC, we require C11 to build the library. C11 is a
+// prerequisite for improved refcounting performance. All our supported C
+// compilers have long implemented C11 and made it default. The most likely
+// cause of pre-C11 modes is stale -std=c99 or -std=gnu99 flags in build
+// configuration. Such flags can be removed.
+#if __STDC_VERSION__ < 201112L
+#error "BoringSSL must be built in C11 mode or higher."
+#endif
 #include <stdalign.h>
 #endif
 #endif

--- a/Sources/CCryptoBoringSSL/hash.txt
+++ b/Sources/CCryptoBoringSSL/hash.txt
@@ -1,1 +1,1 @@
-This directory is derived from BoringSSL cloned from https://boringssl.googlesource.com/boringssl at revision 2fc6d38391cb76839c76b2a462619e7d69fd998d
+This directory is derived from BoringSSL cloned from https://boringssl.googlesource.com/boringssl at revision f961de5c47ed265c3e758ec70dd15ece20809962

--- a/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_bytestring.h
+++ b/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_bytestring.h
@@ -265,6 +265,10 @@ OPENSSL_EXPORT int CBS_get_any_asn1_element(CBS *cbs, CBS *out,
 // also true for empty elements so |*out_indefinite| should be checked). If
 // |out_ber_found| is not NULL then it is set to one if any case of invalid DER
 // but valid BER is found, and to zero otherwise.
+//
+// This function will not successfully parse an end-of-contents (EOC) as an
+// element. Callers parsing indefinite-length encoding must check for EOC
+// separately.
 OPENSSL_EXPORT int CBS_get_any_ber_asn1_element(CBS *cbs, CBS *out,
                                                 unsigned *out_tag,
                                                 size_t *out_header_len,

--- a/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_span.h
+++ b/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_span.h
@@ -99,12 +99,11 @@ class Span : private internal::SpanBase<const T> {
   // Heuristically test whether C is a container type that can be converted into
   // a Span by checking for data() and size() member functions.
   //
-  // TODO(davidben): Require C++14 support and switch to std::enable_if_t.
-  // Perhaps even C++17 now?
+  // TODO(davidben): Require C++17 support for std::is_convertible_v, etc.
   template <typename C>
-  using EnableIfContainer = typename std::enable_if<
+  using EnableIfContainer = std::enable_if_t<
       std::is_convertible<decltype(std::declval<C>().data()), T *>::value &&
-      std::is_integral<decltype(std::declval<C>().size())>::value>::type;
+      std::is_integral<decltype(std::declval<C>().size())>::value>;
 
  public:
   constexpr Span() : Span(nullptr, 0) {}
@@ -113,14 +112,12 @@ class Span : private internal::SpanBase<const T> {
   template <size_t N>
   constexpr Span(T (&array)[N]) : Span(array, N) {}
 
-  template <
-      typename C, typename = EnableIfContainer<C>,
-      typename = typename std::enable_if<std::is_const<T>::value, C>::type>
+  template <typename C, typename = EnableIfContainer<C>,
+            typename = std::enable_if_t<std::is_const<T>::value, C>>
   Span(const C &container) : data_(container.data()), size_(container.size()) {}
 
-  template <
-      typename C, typename = EnableIfContainer<C>,
-      typename = typename std::enable_if<!std::is_const<T>::value, C>::type>
+  template <typename C, typename = EnableIfContainer<C>,
+            typename = std::enable_if_t<!std::is_const<T>::value, C>>
   explicit Span(C &container)
       : data_(container.data()), size_(container.size()) {}
 

--- a/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_stack.h
+++ b/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_stack.h
@@ -443,16 +443,14 @@ namespace internal {
 
 // Stacks defined with |DEFINE_CONST_STACK_OF| are freed with |sk_free|.
 template <typename Stack>
-struct DeleterImpl<
-    Stack, typename std::enable_if<StackTraits<Stack>::kIsConst>::type> {
+struct DeleterImpl<Stack, std::enable_if_t<StackTraits<Stack>::kIsConst>> {
   static void Free(Stack *sk) { sk_free(reinterpret_cast<_STACK *>(sk)); }
 };
 
 // Stacks defined with |DEFINE_STACK_OF| are freed with |sk_pop_free| and the
 // corresponding type's deleter.
 template <typename Stack>
-struct DeleterImpl<
-    Stack, typename std::enable_if<!StackTraits<Stack>::kIsConst>::type> {
+struct DeleterImpl<Stack, std::enable_if_t<!StackTraits<Stack>::kIsConst>> {
   static void Free(Stack *sk) {
     // sk_FOO_pop_free is defined by macros and bound by name, so we cannot
     // access it from C++ here.
@@ -502,18 +500,17 @@ class StackIteratorImpl {
 };
 
 template <typename Stack>
-using StackIterator = typename std::enable_if<StackTraits<Stack>::kIsStack,
-                                              StackIteratorImpl<Stack>>::type;
+using StackIterator =
+    std::enable_if_t<StackTraits<Stack>::kIsStack, StackIteratorImpl<Stack>>;
 
 }  // namespace internal
 
 // PushToStack pushes |elem| to |sk|. It returns true on success and false on
 // allocation failure.
 template <typename Stack>
-inline
-    typename std::enable_if<!internal::StackTraits<Stack>::kIsConst, bool>::type
-    PushToStack(Stack *sk,
-                UniquePtr<typename internal::StackTraits<Stack>::Type> elem) {
+inline std::enable_if_t<!internal::StackTraits<Stack>::kIsConst, bool>
+PushToStack(Stack *sk,
+            UniquePtr<typename internal::StackTraits<Stack>::Type> elem) {
   if (!sk_push(reinterpret_cast<_STACK *>(sk), elem.get())) {
     return false;
   }

--- a/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_type_check.h
+++ b/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_type_check.h
@@ -71,7 +71,12 @@ extern "C" {
 // C11 defines the |_Static_assert| keyword and the |static_assert| macro in
 // assert.h. While the former is available at all versions in Clang and GCC, the
 // later depends on libc and, in glibc, depends on being built in C11 mode. We
-// do not require this, for now, so use |_Static_assert| directly.
+// require C11 mode to build the library but, for now, do not require it in
+// public headers. Use |_Static_assert| directly.
+//
+// TODO(davidben): In July 2022, if the C11 change has not been reverted, switch
+// all uses of this macro within the library to C11 |static_assert|. This macro
+// will only be necessary in public headers.
 #define OPENSSL_STATIC_ASSERT(cond, msg) _Static_assert(cond, msg)
 #endif
 

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -271,7 +271,7 @@ echo "RENAMING header files"
     rmdir "include/openssl"
 
     # Now change the imports from "<openssl/X> to "<CCryptoBoringSSL_X>", apply the same prefix to the 'boringssl_prefix_symbols' headers.
-    find . -name "*.[ch]" -or -name "*.cc" -or -name "*.S" | xargs $sed -i -e 's+include <openssl/+include <CCryptoBoringSSL_+' -e 's+include <boringssl_prefix_symbols+include <CCryptoBoringSSL_boringssl_prefix_symbols+'
+    find . -name "*.[ch]" -or -name "*.cc" -or -name "*.S" | xargs $sed -i -e 's+include <openssl/+include <CCryptoBoringSSL_+' -e 's+include <boringssl_prefix_symbols+include <CCryptoBoringSSL_boringssl_prefix_symbols+' -e 's+include "openssl/+include "CCryptoBoringSSL_+'
 
     # Okay now we need to rename the headers adding the prefix "CCryptoBoringSSL_".
     pushd include


### PR DESCRIPTION
This patch also cleans up an include issue. The actual code change is in
`scripts/vendor_boringssl.sh`, the rest is just the update.
