### PR TITLE
truncating for big `contentLength`

### DIFF
--- a/Sources/Crypto/ASN1/ASN1.swift
+++ b/Sources/Crypto/ASN1/ASN1.swift
@@ -438,7 +438,7 @@ extension ASN1 {
             for shift in (0..<(lengthBytesNeeded - 1)).reversed() {
                 // Shift and mask the integer.
                 self.serializedBytes.formIndex(after: &writeIndex)
-                self.serializedBytes[writeIndex] = UInt8((contentLength >> (shift * 8)) | 0x80 )
+                self.serializedBytes[writeIndex] = UInt8(truncatingIfNeeded: (contentLength >> (shift * 8)) | 0x80 )
             }
 
             assert(writeIndex == self.serializedBytes.index(lengthIndex, offsetBy: lengthBytesNeeded - 1))


### PR DESCRIPTION
When contentLength is greater than 8 bits, i.e., greater than UInt8.max, the original implementation crashes.
To work around this, use `UInt8.init(truncatingIfNeeded:)` to truncate only the lower 8 bits.

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [x] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_