### PR TITLE
Fix ASN.1 serialization when content greater than or equal to 128 bytes

### DIFF
--- a/Sources/Crypto/ASN1/ASN1.swift
+++ b/Sources/Crypto/ASN1/ASN1.swift
@@ -438,7 +438,7 @@ extension ASN1 {
             for shift in (0..<(lengthBytesNeeded - 1)).reversed() {
                 // Shift and mask the integer.
                 self.serializedBytes.formIndex(after: &writeIndex)
-                self.serializedBytes[writeIndex] = UInt8(truncatingIfNeeded: (contentLength >> (shift * 8)) | 0x80 )
+                self.serializedBytes[writeIndex] = UInt8(truncatingIfNeeded: contentLength >> (shift * 8))
             }
 
             assert(writeIndex == self.serializedBytes.index(lengthIndex, offsetBy: lengthBytesNeeded - 1))

--- a/Tests/CryptoTests/ASN1/ASN1Tests.swift
+++ b/Tests/CryptoTests/ASN1/ASN1Tests.swift
@@ -1689,7 +1689,7 @@ A5UvlNrk6ioTg2tumXD3Co06r1Hn+7lkkcjfT5mZO4jy7vP9ItvprJrIa6ySzVQ8
     func testWeirdBigIntSerialization() throws {
         // This is a bigint we can hook to get the test function to do weird things.
         // We just take and accept arbitrary bytes.
-        struct BigIntOfBytes: ASN1IntegerRepresentable {
+        struct BigIntOfBytes: ASN1IntegerRepresentable, Equatable {
             var bytes: [UInt8]
 
             static let isSigned: Bool = false
@@ -1729,6 +1729,13 @@ A5UvlNrk6ioTg2tumXD3Co06r1Hn+7lkkcjfT5mZO4jy7vP9ItvprJrIa6ySzVQ8
         // And a leading zero is removed for unsigned bigints.
         let leadingZeroFromWire = try oneShotDecode([0x02, 0x02, 0x00, 0x80])
         XCTAssertEqual(leadingZeroFromWire.bytes, [0x80])
+
+        // Check encoding and decoding results should be same
+        let smallBytes = BigIntOfBytes(bytes: [1, 1, 1])
+        XCTAssertEqual(smallBytes, try oneShotDecode(oneShotSerialize(smallBytes)))
+
+        let largeBytes = BigIntOfBytes(bytes: .init(repeating: 1, count: 1024))
+        XCTAssertEqual(largeBytes, try oneShotDecode(oneShotSerialize(largeBytes)))
     }
 }
 


### PR DESCRIPTION
When serialize content greater than or equal to 128 bytes, incorrect length being written. 

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [x] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

_[Explain here the context, and why you're making that change. What is the problem you're trying to solve.]_

### Modifications:

_[Describe the modifications you've done.]_

### Result:

_[After your change, what will change.]_