### PR TITLE
Make BoringSSL wrapper match CryptoKit behaviour when working with x9.63

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.4
+// swift-tools-version:5.7
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftCrypto open source project
@@ -56,7 +56,7 @@ if development {
 let package = Package(
     name: "swift-crypto",
     platforms: [
-        .macOS(.v10_15),
+        .macOS(.v13),
         .iOS(.v13),
         .watchOS(.v6),
         .tvOS(.v13),

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.7
+// swift-tools-version:5.4
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftCrypto open source project
@@ -56,7 +56,7 @@ if development {
 let package = Package(
     name: "swift-crypto",
     platforms: [
-        .macOS(.v13),
+        .macOS(.v10_15),
         .iOS(.v13),
         .watchOS(.v6),
         .tvOS(.v13),

--- a/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
@@ -370,6 +370,16 @@ class BoringSSLECPublicKeyWrapper<Curve: OpenSSLSupportedNISTCurve> {
             self.key = try group.makeUnsafeOwnedECKey()
             try self.setPublicKey(x: &x, y: &y)
 
+        default:
+            throw CryptoKitError.incorrectParameterSize
+        }
+    }
+
+    init<Bytes: ContiguousBytes>(compressedRepresentation bytes: Bytes) throws {
+        let group = Curve.group
+        let length = bytes.withUnsafeBytes { $0.count }
+
+        switch length {
         case group.coordinateByteCount + 1:
             var (x, yBit) = try bytes.readx963CompressedPublicNumbers()
             self.key = try group.makeUnsafeOwnedECKey()
@@ -378,12 +388,6 @@ class BoringSSLECPublicKeyWrapper<Curve: OpenSSLSupportedNISTCurve> {
         default:
             throw CryptoKitError.incorrectParameterSize
         }
-    }
-
-    convenience init<Bytes: ContiguousBytes>(compressedRepresentation bytes: Bytes) throws {
-        // CryptoKit accepts the exact same data through init(x963Representation:) as it does through
-        // init(compressedRepresentation:), so we do the same.
-        try self.init(x963Representation: bytes)
     }
 
     init<Bytes: ContiguousBytes>(rawRepresentation bytes: Bytes) throws {

--- a/Tests/CryptoTests/ECDH/X25519-Runner.swift
+++ b/Tests/CryptoTests/ECDH/X25519-Runner.swift
@@ -150,6 +150,23 @@ class X25519Tests: XCTestCase {
             p521NegativeKey.compressedRepresentation,
             p521Negative
         )
+
+        // Check that the uncompressed key gets rejected
+        let uncompressedX963 = Data(base64Encoded: "BOQHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7LE6xvfFkB4Y3VXoOpB/Kp6ngpf3Lce9hDMl7fqaDUfYE=")!
+
+        XCTAssertThrowsError(try P256.KeyAgreement.PublicKey(compressedRepresentation: uncompressedX963))
+    }
+
+    func testUncompressedKeys() throws {
+        let uncompressedX963 = Data(base64Encoded: "BOQHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7LE6xvfFkB4Y3VXoOpB/Kp6ngpf3Lce9hDMl7fqaDUfYE=")!
+        let key = try P256.KeyAgreement.PublicKey(x963Representation: uncompressedX963)
+        XCTAssertEqual(
+            key.x963Representation.base64EncodedString(),
+            "BOQHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7LE6xvfFkB4Y3VXoOpB/Kp6ngpf3Lce9hDMl7fqaDUfYE="
+        )
+
+        let compressedX963Positive = Data(base64Encoded: "A+QHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7L")!
+        XCTAssertThrowsError(try P256.KeyAgreement.PublicKey(x963Representation: compressedX963Positive))
     }
     
     func testWycheproof() throws {

--- a/Tests/CryptoTests/ECDH/X25519-Runner.swift
+++ b/Tests/CryptoTests/ECDH/X25519-Runner.swift
@@ -66,42 +66,42 @@ class X25519Tests: XCTestCase {
 
     func testCompressedKeys() throws {
         let x963Positive = Data(base64Encoded: "A+QHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7L")!
-        let key = try P256.KeyAgreement.PublicKey(x963Representation: x963Positive)
+        let key = try P256.KeyAgreement.PublicKey(compressedRepresentation: x963Positive)
         XCTAssertEqual(
             key.x963Representation.base64EncodedString(),
             "BOQHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7LE6xvfFkB4Y3VXoOpB/Kp6ngpf3Lce9hDMl7fqaDUfYE="
         )
 
         let x963Negative = Data(base64Encoded: "AuQHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7L")!
-        let negativeKey = try P256.KeyAgreement.PublicKey(x963Representation: x963Negative)
+        let negativeKey = try P256.KeyAgreement.PublicKey(compressedRepresentation: x963Negative)
         XCTAssertEqual(
             negativeKey.x963Representation.base64EncodedString(),
             "BOQHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7L7FOQgqb+HnMqoXxW+A1WFYfWgI4jhCe8zaEgVl8rgn4="
         )
 
         let p384Positive = Data(base64Encoded: "AyEfGE5ySReJyfSruLRdsjvCB5RNWGLk8JYrzIrans3MprXf5Q4nh69bQ2rI4+DNpw==")!
-        let p384Key = try P384.KeyAgreement.PublicKey(x963Representation: p384Positive)
+        let p384Key = try P384.KeyAgreement.PublicKey(compressedRepresentation: p384Positive)
         XCTAssertEqual(
             p384Key.x963Representation.base64EncodedString(),
             "BCEfGE5ySReJyfSruLRdsjvCB5RNWGLk8JYrzIrans3MprXf5Q4nh69bQ2rI4+DNp22k0ZcxSL1Ljf19pe25Y6UgedrZf1sOLBVVDZxO36mxwUgPUqFp5/0nNmGMDdQeTQ=="
         )
 
         let p384Negative = Data(base64Encoded: "AiEfGE5ySReJyfSruLRdsjvCB5RNWGLk8JYrzIrans3MprXf5Q4nh69bQ2rI4+DNpw==")!
-        let p384NegativeKey = try P384.KeyAgreement.PublicKey(x963Representation: p384Negative)
+        let p384NegativeKey = try P384.KeyAgreement.PublicKey(compressedRepresentation: p384Negative)
         XCTAssertEqual(
             p384NegativeKey.x963Representation.base64EncodedString(),
             "BCEfGE5ySReJyfSruLRdsjvCB5RNWGLk8JYrzIrans3MprXf5Q4nh69bQ2rI4+DNp5JbLmjOt0K0cgKCWhJGnFrfhiUmgKTx0+qq8mOxIFZNPrfwrF6WGALYyZ508ivhsg=="
         )
 
         let p521Positive = Data(base64Encoded: "AwGUsatNKbCi6jeO1oFHpvhxesJnRxeZ45/sqCvaEZgwnpyj+/SsXjgBViEjvlJUdqentCaUFCwjuYZJM9HpdVq4Iw==")!
-        let p521Key = try P521.KeyAgreement.PublicKey(x963Representation: p521Positive)
+        let p521Key = try P521.KeyAgreement.PublicKey(compressedRepresentation: p521Positive)
         XCTAssertEqual(
             p521Key.x963Representation.base64EncodedString(),
             "BAGUsatNKbCi6jeO1oFHpvhxesJnRxeZ45/sqCvaEZgwnpyj+/SsXjgBViEjvlJUdqentCaUFCwjuYZJM9HpdVq4IwE8xEGqskayEkbPkQCGqSKfVYPZTkBdEs1ham1IXcqT4HSfoGGw98UwjQRiDPfIv0+vU6ocPbxURTdvwUSWPm72WQ=="
         )
 
         let p521Negative = Data(base64Encoded: "AgGUsatNKbCi6jeO1oFHpvhxesJnRxeZ45/sqCvaEZgwnpyj+/SsXjgBViEjvlJUdqentCaUFCwjuYZJM9HpdVq4Iw==")!
-        let p521NegativeKey = try P521.KeyAgreement.PublicKey(x963Representation: p521Negative)
+        let p521NegativeKey = try P521.KeyAgreement.PublicKey(compressedRepresentation: p521Negative)
         XCTAssertEqual(
             p521NegativeKey.x963Representation.base64EncodedString(),
             "BAGUsatNKbCi6jeO1oFHpvhxesJnRxeZ45/sqCvaEZgwnpyj+/SsXjgBViEjvlJUdqentCaUFCwjuYZJM9HpdVq4IwDDO75VTblN7bkwbv95Vt1gqnwmsb+i7TKelZK3ojVsH4tgX55PCDrPcvud8wg3QLBQrFXjwkOrusiQPrtpwZEJpg=="

--- a/Tests/CryptoTests/Signatures/ECDSA/ECDSASignatureTests.swift
+++ b/Tests/CryptoTests/Signatures/ECDSA/ECDSASignatureTests.swift
@@ -344,46 +344,64 @@ class SignatureTests: XCTestCase {
 
     func testCompressedKeys() throws {
         let x963Positive = Data(base64Encoded: "A+QHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7L")!
-        let key = try P256.Signing.PublicKey(x963Representation: x963Positive)
+        let key = try P256.Signing.PublicKey(compressedRepresentation: x963Positive)
         XCTAssertEqual(
             key.x963Representation.base64EncodedString(),
             "BOQHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7LE6xvfFkB4Y3VXoOpB/Kp6ngpf3Lce9hDMl7fqaDUfYE="
         )
 
         let x963Negative = Data(base64Encoded: "AuQHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7L")!
-        let negativeKey = try P256.Signing.PublicKey(x963Representation: x963Negative)
+        let negativeKey = try P256.Signing.PublicKey(compressedRepresentation: x963Negative)
         XCTAssertEqual(
             negativeKey.x963Representation.base64EncodedString(),
             "BOQHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7L7FOQgqb+HnMqoXxW+A1WFYfWgI4jhCe8zaEgVl8rgn4="
         )
 
         let p384Positive = Data(base64Encoded: "AyEfGE5ySReJyfSruLRdsjvCB5RNWGLk8JYrzIrans3MprXf5Q4nh69bQ2rI4+DNpw==")!
-        let p384Key = try P384.Signing.PublicKey(x963Representation: p384Positive)
+        let p384Key = try P384.Signing.PublicKey(compressedRepresentation: p384Positive)
         XCTAssertEqual(
             p384Key.x963Representation.base64EncodedString(),
             "BCEfGE5ySReJyfSruLRdsjvCB5RNWGLk8JYrzIrans3MprXf5Q4nh69bQ2rI4+DNp22k0ZcxSL1Ljf19pe25Y6UgedrZf1sOLBVVDZxO36mxwUgPUqFp5/0nNmGMDdQeTQ=="
         )
 
         let p384Negative = Data(base64Encoded: "AiEfGE5ySReJyfSruLRdsjvCB5RNWGLk8JYrzIrans3MprXf5Q4nh69bQ2rI4+DNpw==")!
-        let p384NegativeKey = try P384.Signing.PublicKey(x963Representation: p384Negative)
+        let p384NegativeKey = try P384.Signing.PublicKey(compressedRepresentation: p384Negative)
         XCTAssertEqual(
             p384NegativeKey.x963Representation.base64EncodedString(),
             "BCEfGE5ySReJyfSruLRdsjvCB5RNWGLk8JYrzIrans3MprXf5Q4nh69bQ2rI4+DNp5JbLmjOt0K0cgKCWhJGnFrfhiUmgKTx0+qq8mOxIFZNPrfwrF6WGALYyZ508ivhsg=="
         )
 
         let p521Positive = Data(base64Encoded: "AwGUsatNKbCi6jeO1oFHpvhxesJnRxeZ45/sqCvaEZgwnpyj+/SsXjgBViEjvlJUdqentCaUFCwjuYZJM9HpdVq4Iw==")!
-        let p521Key = try P521.Signing.PublicKey(x963Representation: p521Positive)
+        let p521Key = try P521.Signing.PublicKey(compressedRepresentation: p521Positive)
         XCTAssertEqual(
             p521Key.x963Representation.base64EncodedString(),
             "BAGUsatNKbCi6jeO1oFHpvhxesJnRxeZ45/sqCvaEZgwnpyj+/SsXjgBViEjvlJUdqentCaUFCwjuYZJM9HpdVq4IwE8xEGqskayEkbPkQCGqSKfVYPZTkBdEs1ham1IXcqT4HSfoGGw98UwjQRiDPfIv0+vU6ocPbxURTdvwUSWPm72WQ=="
         )
 
         let p521Negative = Data(base64Encoded: "AgGUsatNKbCi6jeO1oFHpvhxesJnRxeZ45/sqCvaEZgwnpyj+/SsXjgBViEjvlJUdqentCaUFCwjuYZJM9HpdVq4Iw==")!
-        let p521NegativeKey = try P521.Signing.PublicKey(x963Representation: p521Negative)
+        let p521NegativeKey = try P521.Signing.PublicKey(compressedRepresentation: p521Negative)
         XCTAssertEqual(
             p521NegativeKey.x963Representation.base64EncodedString(),
             "BAGUsatNKbCi6jeO1oFHpvhxesJnRxeZ45/sqCvaEZgwnpyj+/SsXjgBViEjvlJUdqentCaUFCwjuYZJM9HpdVq4IwDDO75VTblN7bkwbv95Vt1gqnwmsb+i7TKelZK3ojVsH4tgX55PCDrPcvud8wg3QLBQrFXjwkOrusiQPrtpwZEJpg=="
         )
+
+        // Check that the uncompressed key gets rejected
+        let uncompressedX963 = Data(base64Encoded: "BOQHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7LE6xvfFkB4Y3VXoOpB/Kp6ngpf3Lce9hDMl7fqaDUfYE=")!
+
+        XCTAssertThrowsError(try P256.Signing.PublicKey(compressedRepresentation: uncompressedX963))
     }
+
+    func testUncompressedKeys() throws {
+        let uncompressedX963 = Data(base64Encoded: "BOQHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7LE6xvfFkB4Y3VXoOpB/Kp6ngpf3Lce9hDMl7fqaDUfYE=")!
+        let key = try P256.Signing.PublicKey(x963Representation: uncompressedX963)
+        XCTAssertEqual(
+            key.x963Representation.base64EncodedString(),
+            "BOQHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7LE6xvfFkB4Y3VXoOpB/Kp6ngpf3Lce9hDMl7fqaDUfYE="
+        )
+
+        let compressedX963Positive = Data(base64Encoded: "A+QHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7L")!
+        XCTAssertThrowsError(try P256.Signing.PublicKey(x963Representation: compressedX963Positive))
+    }
+    
 }
 #endif // (os(macOS) || os(iOS) || os(watchOS) || os(tvOS)) && CRYPTO_IN_SWIFTPM


### PR DESCRIPTION
…63 representation

Make BoringSSL wrapper match CryptoKit behaviour when working with x9.63

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

### Motivation:

Recent versions of CryptoKit have changed how key initialization for EC x9.63 representation works. `P256.KeyAgreement.PublicKey(compressedRepresentation: Bytes)` now only accepts uncompressed form, while `P256.KeyAgreement.PublicKey(x963Representation: Bytes)` only accepts the compressed form. We'd like to bring that behavior in line with our BoringSSL wrappers.

### Modifications:

* Modified the `x963Representation`/`compressedRepresentation` wrappers to only accept compressed/uncompressed key length size
* Modified the unit tests to call `compressedRepresentation` when passing in compressed representation keys

### Result:

The BoringSSL wrapper behaviour now matches CryptoKit, and the unit tests now work with CryptoKit's latest version.