### PR TITLE
[1.1.x] build: use cctols ranlib on Darwin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,6 +40,7 @@ endif()
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin AND NOT CMAKE_CROSSCOMPILING)
   set(CMAKE_AR "/usr/bin/ar")
   set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> crs <TARGET> <LINK_FLAGS> <OBJECTS>")
+  set(CMAKE_RANLIB "/usr/bin/ranlib")
 endif()
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)


### PR DESCRIPTION
This complements the change in #105 and allows to build with a CMake
newer than 3.19.6.

Addresses rdar://99435188

(cherry picked from commit 7ba978bbd451e2f831f84a805c73393b331e0aa8)

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [ ] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [x] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

Attempting to use CMake 3.22 to build this project as part of the swift toolchain in CI

### Modifications:

Adjust the path to ranlib on Darwin

### Result:

We should be able to build swift-crypto on Darwin using a CMake newer than 3.19.6