### PR TITLE
Link Foundation in CryptoBoringWrapper

### DIFF
--- a/Sources/CryptoBoringWrapper/CMakeLists.txt
+++ b/Sources/CryptoBoringWrapper/CMakeLists.txt
@@ -21,6 +21,7 @@ target_include_directories(CryptoBoringWrapper PUBLIC
   $<TARGET_PROPERTY:CCryptoBoringSSLShims,INCLUDE_DIRECTORIES>)
 
 target_link_libraries(CryptoBoringWrapper PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
   CCryptoBoringSSL
   CCryptoBoringSSLShims)
 


### PR DESCRIPTION
To address error seen in https://ci-external.swift.org/job/swiftpm-PR-windows/581/console:

```
FAILED: bin/CryptoBoringWrapper.dll Sources/CryptoBoringWrapper/CMakeFiles/CryptoBoringWrapper.dir/AEAD/BoringSSLAEAD.swift.obj Sources/CryptoBoringWrapper/CMakeFiles/CryptoBoringWrapper.dir/CryptoKitErrors_boring.swift.obj swift/CryptoBoringWrapper.swiftmodule lib/CryptoBoringWrapper.lib 
cmd.exe /C "cd . && T:\1\bin\swiftc.exe -output-file-map Sources\CryptoBoringWrapper\CMakeFiles\CryptoBoringWrapper.dir\Release\output-file-map.json -incremental -j 36 -emit-library -o bin\CryptoBoringWrapper.dll -module-name CryptoBoringWrapper -module-link-name CryptoBoringWrapper -emit-module -emit-module-path swift\CryptoBoringWrapper.swiftmodule -emit-dependencies -DCryptoBoringWrapper_EXPORTS -O -libc MD -I C:\Users\swift-ci\jenkins\workspace\swiftpm-PR-windows\swift-crypto\Sources\CCryptoBoringSSL\include -I C:\Users\swift-ci\jenkins\workspace\swiftpm-PR-windows\swift-crypto\Sources\CCryptoBoringSSLShims\include -I swift C:\Users\swift-ci\jenkins\workspace\swiftpm-PR-windows\swift-crypto\Sources\CryptoBoringWrapper\AEAD\BoringSSLAEAD.swift C:\Users\swift-ci\jenkins\workspace\swiftpm-PR-windows\swift-crypto\Sources\CryptoBoringWrapper\CryptoKitErrors_boring.swift    -Xlinker -implib:lib\CryptoBoringWrapper.lib -L T:\12\lib  -L T:\12\lib  -L T:\12\lib lib\CCryptoBoringSSL.lib  lib\CCryptoBoringSSLShims.lib  lib\CCryptoBoringSSL.lib && cd ."
C:\Users\swift-ci\jenkins\workspace\swiftpm-PR-windows\swift-crypto\Sources\CryptoBoringWrapper\AEAD\BoringSSLAEAD.swift:17:8: error: no such module 'Foundation'

import Foundation
```
