### PR TITLE
build: adjust linking for Crypto

### DIFF
--- a/Sources/CryptoBoringWrapper/CMakeLists.txt
+++ b/Sources/CryptoBoringWrapper/CMakeLists.txt
@@ -12,7 +12,7 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-add_library(CryptoBoringWrapper
+add_library(CryptoBoringWrapper STATIC
   "AEAD/BoringSSLAEAD.swift"
   "CryptoKitErrors_boring.swift")
 


### PR DESCRIPTION
The package DLL `Crypto.dll` was building the BoringSSL wrapper (`CryptoBoringWrapper`) in the style that the user requested (static or shared).  However, there is a single user of the library and is not directly included by the SPM client.  Furthermore, the library was not setup for installation which makes redistribution of it impossible. Always build the library in a static mode to allow compaction into the `Crypto` target.