### PR TITLE
Fix over-iterating buffer in hex string utility.

### DIFF
--- a/Sources/Crypto/Util/PrettyBytes.swift
+++ b/Sources/Crypto/Util/PrettyBytes.swift
@@ -42,12 +42,10 @@ extension DataProtocol {
         var hexChars = [UInt8](repeating: 0, count: hexLen)
         var offset = 0
         
-        self.regions.forEach { (_) in
-            for i in self {
-                hexChars[Int(offset * 2)] = itoh((i >> 4) & 0xF)
-                hexChars[Int(offset * 2 + 1)] = itoh(i & 0xF)
-                offset += 1
-            }
+        for i in self {
+            hexChars[Int(offset * 2)] = itoh((i >> 4) & 0xF)
+            hexChars[Int(offset * 2 + 1)] = itoh(i & 0xF)
+            offset += 1
         }
         
         return String(bytes: hexChars, encoding: .utf8)!

--- a/Tests/CryptoTests/Utils/PrettyBytes.swift
+++ b/Tests/CryptoTests/Utils/PrettyBytes.swift
@@ -42,12 +42,10 @@ extension DataProtocol {
         var hexChars = [UInt8](repeating: 0, count: hexLen)
         var offset = 0
         
-        self.regions.forEach { (_) in
-            for i in self {
-                hexChars[Int(offset * 2)] = itoh((i >> 4) & 0xF)
-                hexChars[Int(offset * 2 + 1)] = itoh(i & 0xF)
-                offset += 1
-            }
+        for i in self {
+            hexChars[Int(offset * 2)] = itoh((i >> 4) & 0xF)
+            hexChars[Int(offset * 2 + 1)] = itoh(i & 0xF)
+            offset += 1
         }
         
         return String(bytes: hexChars, encoding: .utf8)!

--- a/Tests/CryptoTests/Utils/PrettyBytesTests.swift
+++ b/Tests/CryptoTests/Utils/PrettyBytesTests.swift
@@ -1,0 +1,33 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2019-2020 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+import XCTest
+
+// Not sure if NSString-bridged "String.init(format:_:)" is available on Linux/Windows.
+#if (os(macOS) || os(iOS) || os(tvOS) || os(watchOS)) && CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
+
+@testable import Crypto
+
+class PrettyBytesTests: XCTestCase {
+    func testHexString() {
+        let random = Data((1...64).map { _ in UInt8.random(in: UInt8.min...UInt8.max)})
+
+        let hexString = random.hexString
+        let target = random.map { String(format: "%02x", $0) }.joined()
+
+        XCTAssertEqual(hexString, target)
+    }
+}
+
+#endif

--- a/Tests/_CryptoExtrasTests/Utils/BytesUtil.swift
+++ b/Tests/_CryptoExtrasTests/Utils/BytesUtil.swift
@@ -63,12 +63,10 @@ extension DataProtocol {
             let ptr = UnsafeMutablePointer<UInt8>.allocate(capacity: hexLen)
             var offset = 0
 
-            self.regions.forEach { (_) in
-                for i in self {
-                    ptr[Int(offset * 2)] = itoh((i >> 4) & 0xF)
-                    ptr[Int(offset * 2 + 1)] = itoh(i & 0xF)
-                    offset += 1
-                }
+            for i in self {
+                ptr[Int(offset * 2)] = itoh((i >> 4) & 0xF)
+                ptr[Int(offset * 2 + 1)] = itoh(i & 0xF)
+                offset += 1
             }
 
             return String(bytesNoCopy: ptr, length: hexLen, encoding: .utf8, freeWhenDone: true)!


### PR DESCRIPTION
Fixes https://github.com/apple/swift-crypto/issues/139: over-iteration in hex string.

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [x] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

Upon discussing it in https://github.com/apple/swift-crypto/issues/139, an issue was identified that could cause unexpected hex output for a data buffer whose memory spans multiple non-contiguous regions.

### Modifications:

Removed memory region specific logic. Fix applied to 3 copies of the same function.

Also added unit test on Apple platforms to compare with `NSString`'s hex output.

### Result:

With multi-region `DataProtocol`s, `hexString` should return correct hex.