### PR TITLE
Add AES block function to CryptoExtras

### DIFF
--- a/Sources/_CryptoExtras/AES/Block Function.swift
+++ b/Sources/_CryptoExtras/AES/Block Function.swift
@@ -21,10 +21,28 @@ import Foundation
 extension AES {
     private static let blockSize = 128 / 8
 
+    /// Apply the AES permutation operation in the encryption direction.
+    ///
+    /// This function applies the core AES block operation to `payload` in the encryption direction. Note that this is
+    /// not performing any kind of block cipher mode, and does not authenticate the payload. This is a dangerous primitive
+    /// that should only be used to compose higher-level primitives, and should not be used directly.
+    ///
+    /// - parameter payload: The payload to encrypt. Must be exactly 16 bytes long.
+    /// - parameter key: The encryption key to use.
+    /// - throws: On invalid parameter sizes.
     public static func _permute<Payload: MutableCollection>(_ payload: inout Payload, key: SymmetricKey) throws where Payload.Element == UInt8 {
         return try Self.permuteBlock(&payload, key: key, permutation: .forward)
     }
 
+    /// Apply the AES permutation operation in the decryption direction.
+    ///
+    /// This function applies the core AES block operation to `payload` in the decryption direction. Note that this is
+    /// not performing any kind of block cipher mode, and does not authenticate the payload. This is a dangerous primitive
+    /// that should only be used to compose higher-level primitives, and should not be used directly.
+    ///
+    /// - parameter payload: The payload to decrypt. Must be exactly 16 bytes long.
+    /// - parameter key: The decryption key to use.
+    /// - throws: On invalid parameter sizes.
     public static func _inversePermute<Payload: MutableCollection>(_ payload: inout Payload, key: SymmetricKey) throws where Payload.Element == UInt8 {
         return try Self.permuteBlock(&payload, key: key, permutation: .backward)
     }

--- a/Sources/_CryptoExtras/AES/Block Function.swift
+++ b/Sources/_CryptoExtras/AES/Block Function.swift
@@ -30,7 +30,7 @@ extension AES {
     /// - parameter payload: The payload to encrypt. Must be exactly 16 bytes long.
     /// - parameter key: The encryption key to use.
     /// - throws: On invalid parameter sizes.
-    public static func _permute<Payload: MutableCollection>(_ payload: inout Payload, key: SymmetricKey) throws where Payload.Element == UInt8 {
+    public static func permute<Payload: MutableCollection>(_ payload: inout Payload, key: SymmetricKey) throws where Payload.Element == UInt8 {
         return try Self.permuteBlock(&payload, key: key, permutation: .forward)
     }
 
@@ -43,7 +43,7 @@ extension AES {
     /// - parameter payload: The payload to decrypt. Must be exactly 16 bytes long.
     /// - parameter key: The decryption key to use.
     /// - throws: On invalid parameter sizes.
-    public static func _inversePermute<Payload: MutableCollection>(_ payload: inout Payload, key: SymmetricKey) throws where Payload.Element == UInt8 {
+    public static func inversePermute<Payload: MutableCollection>(_ payload: inout Payload, key: SymmetricKey) throws where Payload.Element == UInt8 {
         return try Self.permuteBlock(&payload, key: key, permutation: .backward)
     }
 

--- a/Sources/_CryptoExtras/AES/Block Function.swift
+++ b/Sources/_CryptoExtras/AES/Block Function.swift
@@ -1,0 +1,125 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
+@_implementationOnly import CryptoBoringWrapper
+import Foundation
+
+extension AES {
+    private static let blockSize = 128 / 8
+
+    public static func _permute<Payload: MutableCollection>(_ payload: inout Payload, key: SymmetricKey) throws where Payload.Element == UInt8 {
+        return try Self.permuteBlock(&payload, key: key, permutation: .forward)
+    }
+
+    public static func _inversePermute<Payload: MutableCollection>(_ payload: inout Payload, key: SymmetricKey) throws where Payload.Element == UInt8 {
+        return try Self.permuteBlock(&payload, key: key, permutation: .backward)
+    }
+
+    private static func permuteBlock<Payload: MutableCollection>(_ payload: inout Payload, key: SymmetricKey, permutation: Permutation) throws where Payload.Element == UInt8 {
+        if payload.count != Int(Self.blockSize) {
+            throw CryptoKitError.incorrectParameterSize
+        }
+
+        if !AES.isValidKey(key) {
+            throw CryptoKitError.incorrectKeySize
+        }
+
+        let requiresSlowPath: Bool = try payload.withContiguousMutableStorageIfAvailable { storage in
+            try Self.permute(UnsafeMutableRawBufferPointer(storage), key: key, permutation: permutation)
+            return false
+        } ?? true
+
+        if requiresSlowPath {
+            try AES.Block.withStackStorage { blockBytes in
+                precondition(blockBytes.count == payload.count)
+
+                blockBytes.copyBytes(from: payload)
+                try Self.permute(blockBytes, key: key, permutation: permutation)
+
+                var index = payload.startIndex
+                for byte in blockBytes {
+                    payload[index] = byte
+                    payload.formIndex(after: &index)
+                }
+            }
+        }
+    }
+
+    enum Permutation {
+        case forward
+        case backward
+    }
+
+    private static func permute(_ payload: UnsafeMutableRawBufferPointer, key: SymmetricKey, permutation: Permutation) throws {
+        precondition(AES.isValidKey(key))
+        precondition(payload.count == Int(Self.blockSize))
+
+        key.withUnsafeBytes { keyPtr in
+            // We bind both pointers here. These binds are not technically safe, but because we
+            // know the pointers don't persist they can't violate the aliasing rules. We really
+            // want a "with memory rebound" function but we don't have it yet.
+            let keyBytes = keyPtr.bindMemory(to: UInt8.self)
+            let blockBytes = payload.bindMemory(to: UInt8.self)
+
+            var key = AES_KEY()
+
+            if permutation == .forward {
+                let rc = CCryptoBoringSSL_AES_set_encrypt_key(keyBytes.baseAddress, UInt32(keyBytes.count * 8), &key)
+                precondition(rc == 0)
+
+                CCryptoBoringSSL_AES_encrypt(blockBytes.baseAddress, blockBytes.baseAddress, &key)
+            } else {
+                let rc = CCryptoBoringSSL_AES_set_decrypt_key(keyBytes.baseAddress, UInt32(keyBytes.count * 8), &key)
+                precondition(rc == 0)
+
+                CCryptoBoringSSL_AES_decrypt(blockBytes.baseAddress, blockBytes.baseAddress, &key)
+            }
+        }
+    }
+
+    private struct Block {
+        private var storage: (UInt64, UInt64)
+
+        private init() {
+            assert(MemoryLayout<Self>.size == Int(AES.blockSize))
+            self.storage = (0, 0)
+        }
+
+        private mutating func withUnsafeMutableBytes<ReturnType>(
+            _ body: (UnsafeMutableRawBufferPointer) throws -> ReturnType
+        ) rethrows -> ReturnType {
+            return try Swift.withUnsafeMutableBytes(of: &self.storage, body)
+        }
+
+        static func withStackStorage<ReturnType>(
+            _ body: (UnsafeMutableRawBufferPointer) throws -> ReturnType
+        ) rethrows -> ReturnType {
+            var storage = Self()
+            return try storage.withUnsafeMutableBytes(body)
+        }
+    }
+
+    private static func isValidKey(_ key: SymmetricKey) -> Bool {
+        switch key.bitCount {
+        case 128, 192, 256:
+            return true
+        default:
+            return false
+        }
+    }
+}
+

--- a/Tests/_CryptoExtrasTests/AES Block Function Tests.swift
+++ b/Tests/_CryptoExtrasTests/AES Block Function Tests.swift
@@ -1,0 +1,263 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+import XCTest
+import Crypto
+import _CryptoExtras
+
+final class AESBlockFunctionTests: XCTestCase {
+    static let nistPlaintextChunks: [[UInt8]] = [
+        try! Array(hexString: "6bc1bee22e409f96e93d7e117393172a"),
+        try! Array(hexString: "ae2d8a571e03ac9c9eb76fac45af8e51"),
+        try! Array(hexString: "30c81c46a35ce411e5fbc1191a0a52ef"),
+        try! Array(hexString: "f69f2445df4f9b17ad2b417be66c3710")
+    ]
+
+    func test128BitEncrypt() throws {
+        let key = SymmetricKey(
+            data: try! Array(hexString: "2b7e151628aed2a6abf7158809cf4f3c")
+        )
+
+        let encryptedChunks = [
+            try! Array(hexString: "3ad77bb40d7a3660a89ecaf32466ef97"),
+            try! Array(hexString: "f5d3d58503b9699de785895a96fdbaaf"),
+            try! Array(hexString: "43b1cd7f598ece23881b00e3ed030688"),
+            try! Array(hexString: "7b0c785e27e8ad3f8223207104725dd4")
+        ]
+
+        // Fast-path
+        for (chunk, expected) in zip(Self.nistPlaintextChunks, encryptedChunks) {
+            var chunk = chunk
+            try AES._permute(&chunk, key: key)
+            XCTAssertEqual(chunk, expected)
+        }
+
+        // Slow-path
+        for (chunk, expected) in zip(Self.nistPlaintextChunks, encryptedChunks) {
+            var block = Block(wrapped: chunk)
+            try AES._permute(&block, key: key)
+            XCTAssertEqual(Array(block.wrapped), expected)
+        }
+    }
+
+    func test128BitDecrypt() throws {
+        let key = SymmetricKey(
+            data: try! Array(hexString: "2b7e151628aed2a6abf7158809cf4f3c")
+        )
+
+        let encryptedChunks = [
+            try! Array(hexString: "3ad77bb40d7a3660a89ecaf32466ef97"),
+            try! Array(hexString: "f5d3d58503b9699de785895a96fdbaaf"),
+            try! Array(hexString: "43b1cd7f598ece23881b00e3ed030688"),
+            try! Array(hexString: "7b0c785e27e8ad3f8223207104725dd4")
+        ]
+
+        // Fast-path
+        for (chunk, expected) in zip(encryptedChunks, Self.nistPlaintextChunks) {
+            var chunk = chunk
+            try AES._inversePermute(&chunk, key: key)
+            XCTAssertEqual(chunk, expected)
+        }
+
+        // Slow-path
+        for (chunk, expected) in zip(encryptedChunks, Self.nistPlaintextChunks) {
+            var block = Block(wrapped: chunk)
+            try AES._inversePermute(&block, key: key)
+            XCTAssertEqual(Array(block.wrapped), expected)
+        }
+    }
+
+    func test192BitEncrypt() throws {
+        let key = SymmetricKey(
+            data: try! Array(hexString: "8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b")
+        )
+
+        let encryptedChunks = [
+            try! Array(hexString: "bd334f1d6e45f25ff712a214571fa5cc"),
+            try! Array(hexString: "974104846d0ad3ad7734ecb3ecee4eef"),
+            try! Array(hexString: "ef7afd2270e2e60adce0ba2face6444e"),
+            try! Array(hexString: "9a4b41ba738d6c72fb16691603c18e0e")
+        ]
+
+        // Fast-path
+        for (chunk, expected) in zip(Self.nistPlaintextChunks, encryptedChunks) {
+            var chunk = chunk
+            try AES._permute(&chunk, key: key)
+            XCTAssertEqual(chunk, expected)
+        }
+
+        // Slow-path
+        for (chunk, expected) in zip(Self.nistPlaintextChunks, encryptedChunks) {
+            var block = Block(wrapped: chunk)
+            try AES._permute(&block, key: key)
+            XCTAssertEqual(Array(block.wrapped), expected)
+        }
+    }
+
+    func test192BitDecrypt() throws {
+        let key = SymmetricKey(
+            data: try! Array(hexString: "8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b")
+        )
+
+        let encryptedChunks = [
+            try! Array(hexString: "bd334f1d6e45f25ff712a214571fa5cc"),
+            try! Array(hexString: "974104846d0ad3ad7734ecb3ecee4eef"),
+            try! Array(hexString: "ef7afd2270e2e60adce0ba2face6444e"),
+            try! Array(hexString: "9a4b41ba738d6c72fb16691603c18e0e")
+        ]
+
+        // Fast-path
+        for (chunk, expected) in zip(encryptedChunks, Self.nistPlaintextChunks) {
+            var chunk = chunk
+            try AES._inversePermute(&chunk, key: key)
+            XCTAssertEqual(chunk, expected)
+        }
+
+        // Slow-path
+        for (chunk, expected) in zip(encryptedChunks, Self.nistPlaintextChunks) {
+            var block = Block(wrapped: chunk)
+            try AES._inversePermute(&block, key: key)
+            XCTAssertEqual(Array(block.wrapped), expected)
+        }
+    }
+
+    func test256BitEncrypt() throws {
+        let key = SymmetricKey(
+            data: try! Array(
+                hexString: "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"
+            )
+        )
+
+        let encryptedChunks = [
+            try! Array(hexString: "f3eed1bdb5d2a03c064b5a7e3db181f8"),
+            try! Array(hexString: "591ccb10d410ed26dc5ba74a31362870"),
+            try! Array(hexString: "b6ed21b99ca6f4f9f153e7b1beafed1d"),
+            try! Array(hexString: "23304b7a39f9f3ff067d8d8f9e24ecc7")
+        ]
+
+        // Fast-path
+        for (chunk, expected) in zip(Self.nistPlaintextChunks, encryptedChunks) {
+            var chunk = chunk
+            try AES._permute(&chunk, key: key)
+            XCTAssertEqual(chunk, expected)
+        }
+
+        // Slow-path
+        for (chunk, expected) in zip(Self.nistPlaintextChunks, encryptedChunks) {
+            var block = Block(wrapped: chunk)
+            try AES._permute(&block, key: key)
+            XCTAssertEqual(Array(block.wrapped), expected)
+        }
+    }
+
+    func test256BitDecrypt() throws {
+        let key = SymmetricKey(
+            data: try! Array(
+                hexString: "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"
+            )
+        )
+
+        let encryptedChunks = [
+            try! Array(hexString: "f3eed1bdb5d2a03c064b5a7e3db181f8"),
+            try! Array(hexString: "591ccb10d410ed26dc5ba74a31362870"),
+            try! Array(hexString: "b6ed21b99ca6f4f9f153e7b1beafed1d"),
+            try! Array(hexString: "23304b7a39f9f3ff067d8d8f9e24ecc7")
+        ]
+
+        // Fast-path
+        for (chunk, expected) in zip(encryptedChunks, Self.nistPlaintextChunks) {
+            var chunk = chunk
+            try AES._inversePermute(&chunk, key: key)
+            XCTAssertEqual(chunk, expected)
+        }
+
+        // Slow-path
+        for (chunk, expected) in zip(encryptedChunks, Self.nistPlaintextChunks) {
+            var block = Block(wrapped: chunk)
+            try AES._inversePermute(&block, key: key)
+            XCTAssertEqual(Array(block.wrapped), expected)
+        }
+    }
+
+    func testRejectInvalidBlockSizes() throws {
+        let key = SymmetricKey(size: .bits128)
+
+        for blockSize in 0..<32 {
+            if blockSize == 16 { continue }
+
+            var chunk = Array(repeating: UInt8(0), count: blockSize)
+
+            // Fast-path
+            XCTAssertThrowsError(try AES._permute(&chunk, key: key))
+            XCTAssertThrowsError(try AES._inversePermute(&chunk, key: key))
+
+            // Slow-path
+            var block = Block(wrapped: chunk)
+            XCTAssertThrowsError(try AES._permute(&block, key: key))
+            XCTAssertThrowsError(try AES._inversePermute(&block, key: key))
+        }
+    }
+
+    func testRejectsInvalidKeySizes() throws {
+        var chunk = Array(repeating: UInt8(0), count: 16)
+
+        for keySizeInBits in stride(from: 128, through: 256, by: 8) {
+            if [128, 192, 256].contains(keySizeInBits) { continue }
+
+            let key = SymmetricKey(size: .init(bitCount: keySizeInBits))
+
+            // Fast-path
+            XCTAssertThrowsError(try AES._permute(&chunk, key: key))
+            XCTAssertThrowsError(try AES._inversePermute(&chunk, key: key))
+
+            // Slow-path
+            var block = Block(wrapped: chunk)
+            XCTAssertThrowsError(try AES._permute(&block, key: key))
+            XCTAssertThrowsError(try AES._inversePermute(&block, key: key))
+        }
+    }
+}
+
+// We use this for testing. Specifically, there's a slow path in the code
+// which ArraySlice and Data will not hit (for Collections that don't implement
+// withContiguousMutableStorageIfAvailable). This is a simple Collection that wraps
+// an ArraySlice but does not expose that method, so hits the slow path.
+struct Block: MutableCollection {
+    var wrapped: ArraySlice<UInt8>
+
+    init(wrapped: ArraySlice<UInt8>) {
+        self.wrapped = wrapped
+    }
+
+    init(wrapped: [UInt8]) {
+        self.wrapped = wrapped[...]
+    }
+
+    var startIndex: Int { wrapped.startIndex }
+
+    var endIndex: Int { wrapped.endIndex }
+
+    func index(after index: Int) -> Int {
+        return index + 1
+    }
+
+    subscript(position: Int) -> UInt8 {
+        get {
+            self.wrapped[position]
+        }
+        set {
+            self.wrapped[position] = newValue
+        }
+    }
+}

--- a/Tests/_CryptoExtrasTests/AES Block Function Tests.swift
+++ b/Tests/_CryptoExtrasTests/AES Block Function Tests.swift
@@ -39,14 +39,14 @@ final class AESBlockFunctionTests: XCTestCase {
         // Fast-path
         for (chunk, expected) in zip(Self.nistPlaintextChunks, encryptedChunks) {
             var chunk = chunk
-            try AES._permute(&chunk, key: key)
+            try AES.permute(&chunk, key: key)
             XCTAssertEqual(chunk, expected)
         }
 
         // Slow-path
         for (chunk, expected) in zip(Self.nistPlaintextChunks, encryptedChunks) {
             var block = Block(wrapped: chunk)
-            try AES._permute(&block, key: key)
+            try AES.permute(&block, key: key)
             XCTAssertEqual(Array(block.wrapped), expected)
         }
     }
@@ -66,14 +66,14 @@ final class AESBlockFunctionTests: XCTestCase {
         // Fast-path
         for (chunk, expected) in zip(encryptedChunks, Self.nistPlaintextChunks) {
             var chunk = chunk
-            try AES._inversePermute(&chunk, key: key)
+            try AES.inversePermute(&chunk, key: key)
             XCTAssertEqual(chunk, expected)
         }
 
         // Slow-path
         for (chunk, expected) in zip(encryptedChunks, Self.nistPlaintextChunks) {
             var block = Block(wrapped: chunk)
-            try AES._inversePermute(&block, key: key)
+            try AES.inversePermute(&block, key: key)
             XCTAssertEqual(Array(block.wrapped), expected)
         }
     }
@@ -93,14 +93,14 @@ final class AESBlockFunctionTests: XCTestCase {
         // Fast-path
         for (chunk, expected) in zip(Self.nistPlaintextChunks, encryptedChunks) {
             var chunk = chunk
-            try AES._permute(&chunk, key: key)
+            try AES.permute(&chunk, key: key)
             XCTAssertEqual(chunk, expected)
         }
 
         // Slow-path
         for (chunk, expected) in zip(Self.nistPlaintextChunks, encryptedChunks) {
             var block = Block(wrapped: chunk)
-            try AES._permute(&block, key: key)
+            try AES.permute(&block, key: key)
             XCTAssertEqual(Array(block.wrapped), expected)
         }
     }
@@ -120,14 +120,14 @@ final class AESBlockFunctionTests: XCTestCase {
         // Fast-path
         for (chunk, expected) in zip(encryptedChunks, Self.nistPlaintextChunks) {
             var chunk = chunk
-            try AES._inversePermute(&chunk, key: key)
+            try AES.inversePermute(&chunk, key: key)
             XCTAssertEqual(chunk, expected)
         }
 
         // Slow-path
         for (chunk, expected) in zip(encryptedChunks, Self.nistPlaintextChunks) {
             var block = Block(wrapped: chunk)
-            try AES._inversePermute(&block, key: key)
+            try AES.inversePermute(&block, key: key)
             XCTAssertEqual(Array(block.wrapped), expected)
         }
     }
@@ -149,14 +149,14 @@ final class AESBlockFunctionTests: XCTestCase {
         // Fast-path
         for (chunk, expected) in zip(Self.nistPlaintextChunks, encryptedChunks) {
             var chunk = chunk
-            try AES._permute(&chunk, key: key)
+            try AES.permute(&chunk, key: key)
             XCTAssertEqual(chunk, expected)
         }
 
         // Slow-path
         for (chunk, expected) in zip(Self.nistPlaintextChunks, encryptedChunks) {
             var block = Block(wrapped: chunk)
-            try AES._permute(&block, key: key)
+            try AES.permute(&block, key: key)
             XCTAssertEqual(Array(block.wrapped), expected)
         }
     }
@@ -178,14 +178,14 @@ final class AESBlockFunctionTests: XCTestCase {
         // Fast-path
         for (chunk, expected) in zip(encryptedChunks, Self.nistPlaintextChunks) {
             var chunk = chunk
-            try AES._inversePermute(&chunk, key: key)
+            try AES.inversePermute(&chunk, key: key)
             XCTAssertEqual(chunk, expected)
         }
 
         // Slow-path
         for (chunk, expected) in zip(encryptedChunks, Self.nistPlaintextChunks) {
             var block = Block(wrapped: chunk)
-            try AES._inversePermute(&block, key: key)
+            try AES.inversePermute(&block, key: key)
             XCTAssertEqual(Array(block.wrapped), expected)
         }
     }
@@ -199,13 +199,13 @@ final class AESBlockFunctionTests: XCTestCase {
             var chunk = Array(repeating: UInt8(0), count: blockSize)
 
             // Fast-path
-            XCTAssertThrowsError(try AES._permute(&chunk, key: key))
-            XCTAssertThrowsError(try AES._inversePermute(&chunk, key: key))
+            XCTAssertThrowsError(try AES.permute(&chunk, key: key))
+            XCTAssertThrowsError(try AES.inversePermute(&chunk, key: key))
 
             // Slow-path
             var block = Block(wrapped: chunk)
-            XCTAssertThrowsError(try AES._permute(&block, key: key))
-            XCTAssertThrowsError(try AES._inversePermute(&block, key: key))
+            XCTAssertThrowsError(try AES.permute(&block, key: key))
+            XCTAssertThrowsError(try AES.inversePermute(&block, key: key))
         }
     }
 
@@ -218,13 +218,13 @@ final class AESBlockFunctionTests: XCTestCase {
             let key = SymmetricKey(size: .init(bitCount: keySizeInBits))
 
             // Fast-path
-            XCTAssertThrowsError(try AES._permute(&chunk, key: key))
-            XCTAssertThrowsError(try AES._inversePermute(&chunk, key: key))
+            XCTAssertThrowsError(try AES.permute(&chunk, key: key))
+            XCTAssertThrowsError(try AES.inversePermute(&chunk, key: key))
 
             // Slow-path
             var block = Block(wrapped: chunk)
-            XCTAssertThrowsError(try AES._permute(&block, key: key))
-            XCTAssertThrowsError(try AES._inversePermute(&block, key: key))
+            XCTAssertThrowsError(try AES.permute(&block, key: key))
+            XCTAssertThrowsError(try AES.inversePermute(&block, key: key))
         }
     }
 }

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -17,7 +17,7 @@ set -eu
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][890]-20[12][1290]/YEARS/' -e 's/2019/YEARS/' -e 's/2020/YEARS/' -e 's/2021/YEARS/' -e 's/2022/YEARS/'
+    sed -e 's/20[12][890]-20[12][1290]/YEARS/' -e 's/20[12][90123]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language... "


### PR DESCRIPTION
In some cases developers have need of AES modes other than what we support today, or need the ability to implement algorithms that require access to the core AES permutation function. As a starting point, we can provide access to the AES block function in CryptoExtras.