### PR TITLE
Fixup CryptoExtras RSA public key formats

### DIFF
--- a/Sources/_CryptoExtras/RSA/RSA.swift
+++ b/Sources/_CryptoExtras/RSA/RSA.swift
@@ -65,6 +65,14 @@ extension _RSA.Signing {
             }
         }
 
+        public var pkcs1DERRepresentation: Data {
+            self.backing.pkcs1DERRepresentation
+        }
+
+        public var pkcs1PEMRepresentation: String {
+            self.backing.pkcs1PEMRepresentation
+        }
+
         public var derRepresentation: Data {
             self.backing.derRepresentation
         }
@@ -308,4 +316,14 @@ extension _RSA.Signing {
             self.bitCount = bitCount
         }
     }
+}
+
+extension _RSA {
+    static let PKCS1KeyType = "RSA PRIVATE KEY"
+
+    static let PKCS8KeyType = "PRIVATE KEY"
+
+    static let PKCS1PublicKeyType = "RSA PUBLIC KEY"
+
+    static let SPKIPublicKeyType = "PUBLIC KEY"
 }

--- a/Tests/_CryptoExtrasTests/TestRSASigning.swift
+++ b/Tests/_CryptoExtrasTests/TestRSASigning.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 import XCTest
-import Crypto
+@testable import Crypto
 import _CryptoExtras
 
 final class TestRSASigning: XCTestCase {
@@ -569,7 +569,7 @@ final class TestRSASigning: XCTestCase {
         XCTAssertThrowsError(try _RSA.Signing.PrivateKey(keySize: .init(bitCount: 1016)))
     }
 
-    func testParsingPKCS1PublicKeyKeyDER() throws {
+    func testParsingPKCS1PublicKeyDER() throws {
         let pkcs1Key = Data(base64Encoded:
             "MIICCgKCAgEAkehUktIKVrGsDSTdxc9EZ3SZKzejfSNwAHG8U9/E+ioSj0t" +
             "/EFa9n3Byt2F/yUsPF6c947AEYe7/EZfH9IY+Cvo+XPmT5jR62RRr55yzha" +
@@ -584,10 +584,11 @@ final class TestRSASigning: XCTestCase {
             "aG4Nj/QN370EKIf6MzOi5cHkERgWPOGHFrK+ymircxXDpqR+DDeVnWIBqv8" +
             "mqYqnK8V0rSS527EPywTEHl7R09XiidnMy/s1Hap0flhFMCAwEAAQ=="
         )!
-        XCTAssertNoThrow(try _RSA.Signing.PublicKey(derRepresentation: pkcs1Key))
+        let key = try _RSA.Signing.PublicKey(derRepresentation: pkcs1Key)
+        XCTAssertEqual(pkcs1Key, key.pkcs1DERRepresentation)
     }
 
-    func testParsingPKCS1PublicKeyKeyPEM() throws {
+    func testParsingPKCS1PublicKeyPEM() throws {
         let pemKey = """
         -----BEGIN RSA PUBLIC KEY-----
         MIICCgKCAgEAkehUktIKVrGsDSTdxc9EZ3SZKzejfSNwAHG8U9/E+ioSj0t/EFa9
@@ -603,7 +604,38 @@ final class TestRSASigning: XCTestCase {
         eVnWIBqv8mqYqnK8V0rSS527EPywTEHl7R09XiidnMy/s1Hap0flhFMCAwEAAQ==
         -----END RSA PUBLIC KEY-----
         """
-        XCTAssertNoThrow(try _RSA.Signing.PublicKey(pemRepresentation: pemKey))
+        let key = try _RSA.Signing.PublicKey(pemRepresentation: pemKey)
+        XCTAssertEqual(pemKey, key.pkcs1PEMRepresentation)
+    }
+
+    func testParsingSPKIPublicKeyDER() throws {
+        let derKey = Data(base64Encoded:
+        "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA509zjqylvktpuN3zMpdw" +
+        "YwsZ2dp9/cJZ2Krp2EqK+UvMJcp4T3O9rWPMZk1RocQWLpfSwF8jtfyy1OHDQEZh" +
+        "7UkpnlHmCwlNzzCj+/eaC+JP2Dy6p62nCMonjebPCZ5lhramaO4csrL4bmKdCw5i" +
+        "XEEaQdwaA8k7Pvv2pkT+X50ZJKBQAaiHo2yRILI5n15UZ4y0fB+HCvA5qebZtkM0" +
+        "gFqLPxNy1f8oYXuG9KE6sRn/pRwuYuBYD3eAqP6GquO0DkJKmq8RXeewx8ijUBd7" +
+        "2xiZlbnBZxwvu5eEH5XD9iqf+liS+yA1wORQtQhSwuWApk9acaIP9IjyW2zojAtS" +
+        "hwIDAQAB"
+        )!
+        let key = try _RSA.Signing.PublicKey(derRepresentation: derKey)
+        XCTAssertEqual(derKey, key.derRepresentation)
+    }
+
+    func testParsingSPKIPublicKeyPEM() throws {
+        let pemKey = """
+        -----BEGIN PUBLIC KEY-----
+        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA509zjqylvktpuN3zMpdw
+        YwsZ2dp9/cJZ2Krp2EqK+UvMJcp4T3O9rWPMZk1RocQWLpfSwF8jtfyy1OHDQEZh
+        7UkpnlHmCwlNzzCj+/eaC+JP2Dy6p62nCMonjebPCZ5lhramaO4csrL4bmKdCw5i
+        XEEaQdwaA8k7Pvv2pkT+X50ZJKBQAaiHo2yRILI5n15UZ4y0fB+HCvA5qebZtkM0
+        gFqLPxNy1f8oYXuG9KE6sRn/pRwuYuBYD3eAqP6GquO0DkJKmq8RXeewx8ijUBd7
+        2xiZlbnBZxwvu5eEH5XD9iqf+liS+yA1wORQtQhSwuWApk9acaIP9IjyW2zojAtS
+        hwIDAQAB
+        -----END PUBLIC KEY-----
+        """
+        let key = try _RSA.Signing.PublicKey(pemRepresentation: pemKey)
+        XCTAssertEqual(pemKey, key.pemRepresentation)
     }
 
     private func testPKCS1Group(_ group: RSAPKCS1TestGroup) throws {


### PR DESCRIPTION
Motivation

CryptoExtras RSA public keys support being exported in DER and PEM form. These exports work great, but it turns out they are inconsistent between the Darwin and non-Darwin implementations. Darwin platforms would export the public keys in PKCS1 format, while non-Darwin was exporting them as SPKI. This isn't great!

Modifications

- Make the two consistent. `.derRepresentation` should export SPKI formatted public keys, because that's what it does for all the EC keys.
- Add `.pkcs1DERRepresentation` and `.pkcs1PEMRepresentation` for those users that require the PKCS1 formatted key.

Result

Key export types are now consistent on all platforms.
