### PR TITLE
Update Wycheproof ecdh_secp256r1_test.json to v1

### DIFF
--- a/Tests/CryptoTests/ECDH/BoringSSL/ASN1.swift
+++ b/Tests/CryptoTests/ECDH/BoringSSL/ASN1.swift
@@ -293,7 +293,11 @@ extension ArraySlice where Element == UInt8 {
         self = self[self.index(after: subidentifierEndIndex)...]
 
         // We need to compact the bits. These are 7-bit integers, which is really awkward.
-        return UInt(sevenBitBigEndianBytes: oidSlice)
+        guard let int = UInt(sevenBitBigEndianBytes: oidSlice) else {
+            // too big to parse, happens for Wycheproof vectors with comment "large integer in oid"
+            throw ECDHTestErrors.ParseSPKIFailure
+        }
+        return int
     }
 }
 
@@ -313,10 +317,13 @@ extension UInt {
         }
     }
 
-    init<Bytes: Collection>(sevenBitBigEndianBytes bytes: Bytes) where Bytes.Element == UInt8 {
+    init?<Bytes: Collection>(sevenBitBigEndianBytes bytes: Bytes) where Bytes.Element == UInt8 {
         // We need to know how many bytes we _need_ to store this "int".
         guard ((bytes.count * 7) + 7) / 8 <= MemoryLayout<UInt>.size else {
-            fatalError("Too big to parse")
+            // Too big to parse, this happens for e.g. Wycheproof in testvector 'ecdh_secp256r1_test' for
+            // tests with comment "large integer in oid", thus we let this
+            // initializer be failable.
+            return nil
         }
 
         self = 0

--- a/Tests/Test Vectors/ecdh_secp256r1_test.json
+++ b/Tests/Test Vectors/ecdh_secp256r1_test.json
@@ -1,3584 +1,6911 @@
 {
   "algorithm" : "ECDH",
-  "generatorVersion" : "0.4.12",
+  "schema" : "ecdh_test_schema.json",
+  "generatorVersion" : "0.9rc5",
+  "numberOfTests" : 612,
+  "header" : [
+    "Test vectors of type EcdhTest are intended for",
+    "testing an ECDH implementations using X509 encoded",
+    "public keys and integers for private keys.",
+    "Test vectors of this format are useful for testing",
+    "Java providers."
+  ],
   "notes" : {
-    "AddSubChain" : "The private key has a special value. Implementations using addition subtraction chains for the point multiplication may get the point at infinity as an intermediate result. See CVE_2017_10176",
-    "CompressedPoint" : "The point in the public key is compressed. Not every library supports points in compressed format.",
-    "InvalidAsn" : "The public key in this test uses an invalid ASN encoding. Some cases where the ASN parser is not strictly checking the ASN format are benign as long as the ECDH computation still returns the correct shared value.",
-    "InvalidPublic" : "The public key has been modified and is invalid. An implementation should always check whether the public key is valid and on the same curve as the private key. The test vector includes the shared secret computed with the original public key if the public point is on the curve of the private key. Generating a shared secret other than the one with the original key likely indicates that the bug is exploitable.",
-    "ModifiedPrime" : "The modulus of the public key has been modified. The public point of the public key has been chosen so that it is both a point on both the curve of the modified public key and the private key.",
-    "UnnamedCurve" : "The public key does not use a named curve. RFC 3279 allows to encode such curves by explicitly encoding, the parameters of the curve equation, modulus, generator, order and cofactor. However, many crypto libraries only support named curves. Modifying some of the EC parameters and encoding the corresponding public key as an unnamed curve is a potential attack vector.",
-    "UnusedParam" : "A parameter that is typically not used for ECDH has been modified. Sometimes libraries ignore small differences between public and private key. For example, a library might ignore an incorrect cofactor in the public key. We consider ignoring such changes as acceptable as long as these differences do not change the outcome of the ECDH computation, i.e. as long as the computation is done on the curve from the private key.",
-    "WeakPublicKey" : "The vector contains a weak public key. The curve is not a named curve, the public key point has order 3 and has been chosen to be on the same curve as the private key. This test vector is used to check ECC implementations for missing steps in the verification of the public key.",
-    "WrongOrder" : "The order of the public key has been modified. If this order is used in a cryptographic primitive instead of the correct order then private keys may leak. E.g. ECDHC in BC 1.52 suffered from this."
+    "AdditionChain" : {
+      "bugType" : "KNOWN_BUG",
+      "description" : "The private key has an unusual bit pattern, such as high or low Hamming weight. The goal is to test edge cases for addition chain implementations."
+    },
+    "CVE-2017-8932" : {
+      "bugType" : "KNOWN_BUG",
+      "description" : "A bug in the standard library ScalarMult implementation of curve P-256 for amd64 architectures in Go before 1.7.6 and 1.8.x before 1.8.2 causes incorrect results to be generated for specific input points.",
+      "effect" : "An adaptive attack can be mounted to progressively extract the scalar input to ScalarMult by submitting crafted points and observing failures to the derive correct output.",
+      "cves" : [
+        "CVE-2017-8932"
+      ]
+    },
+    "CompressedPoint" : {
+      "bugType" : "UNKNOWN",
+      "description" : "The point in the public key is compressed. Not every library supports points in compressed format."
+    },
+    "CompressedPublic" : {
+      "bugType" : "FUNCTIONALITY",
+      "description" : "The public key in the test vector is compressed. Some implementations do not support compressed points."
+    },
+    "EdgeCaseDoubling" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vector contains an EC point that hits an edge case (e.g. a coordinate 0) when doubled. The goal of the test vector is to check for arithmetic errors in these test cases.",
+      "effect" : "The effect of such arithmetic errors is unclear and requires further analysis."
+    },
+    "EdgeCaseEphemeralKey" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vector contains an ephemeral public key that is an edge case."
+    },
+    "EdgeCaseSharedSecret" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vector contains a public key and private key such that the shared ECDH secret is a special case. The goal of this test vector is to detect arithmetic errors.",
+      "effect" : "The seriousness of an arithmetic error is unclear. It requires further analysis to determine if the bug is exploitable."
+    },
+    "InvalidAsn" : {
+      "bugType" : "UNKNOWN",
+      "description" : "The public key in this test uses an invalid ASN encoding. Some cases where the ASN parser is not strictly checking the ASN format are benign as long as the ECDH computation still returns the correct shared value."
+    },
+    "InvalidCompressedPublic" : {
+      "bugType" : "MODIFIED_PARAMETER",
+      "description" : "The test vector contains a compressed public key that does not exist. I.e., it contains an x-coordinate that does not correspond to any points on the curve. Such keys should be rejected "
+    },
+    "InvalidCurveAttack" : {
+      "bugType" : "CONFIDENTIALITY",
+      "description" : "The point of the public key is not on the curve. ",
+      "effect" : "If an implementation does not check whether a point is on the curve then it is likely that the implementation is susceptible to an invalid curve attack. Many implementations compute the shared ECDH secret over a curve defined by the point on the public key. This curve can be weak and hence leak information about the private key."
+    },
+    "InvalidEncoding" : {
+      "bugType" : "MODIFIED_PARAMETER",
+      "description" : "The test vector contains a public key with an invalid encoding."
+    },
+    "InvalidPublic" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The public key has been modified and is invalid. An implementation should always check whether the public key is valid and on the same curve as the private key. The test vector includes the shared secret computed with the original public key if the public point is on the curve of the private key.",
+      "effect" : "Generating a shared secret other than the one with the original key likely indicates that the bug is exploitable."
+    },
+    "LargeCofactor" : {
+      "bugType" : "MODIFIED_PARAMETER",
+      "description" : "The cofactor is larger than the limits specified in FIPS-PUB 186-4 table 1, p.36."
+    },
+    "Modified curve parameter" : {
+      "bugType" : "MODIFIED_PARAMETER",
+      "description" : "The parameters a and b of the curve have been modified. The parameters haven been chosen so that public key or generator still are also valid points on the new curve."
+    },
+    "ModifiedCofactor" : {
+      "bugType" : "MODIFIED_PARAMETER",
+      "description" : "The cofactor has been modified. ",
+      "effect" : "The seriousness of accepting a key with modified cofactor depends on whether the primitive using the key actually uses the cofactor."
+    },
+    "ModifiedGenerator" : {
+      "bugType" : "MODIFIED_PARAMETER",
+      "description" : "The generator of the EC group has been modified.",
+      "effect" : "The seriousness of the modification depends on whether the cryptographic primitive uses the generator. In the worst case such a modification allows an invalid curve attack."
+    },
+    "ModifiedGroup" : {
+      "bugType" : "MODIFIED_PARAMETER",
+      "description" : "The EC curve of the public key has been modified. EC curve primitives should always check that the keys are on the expected curve."
+    },
+    "ModifiedPrime" : {
+      "bugType" : "MODIFIED_PARAMETER",
+      "description" : "The modulus of the public key has been modified. The public point of the public key has been chosen so that it is both a point on both the curve of the modified public key and the private key."
+    },
+    "ModifiedPublicPoint" : {
+      "bugType" : "MODIFIED_PARAMETER",
+      "description" : "The public point of the key has been modified and is not on the curve.",
+      "effect" : "Not checking that a public point is on the curve may allow an invalid curve attack."
+    },
+    "NegativeCofactor" : {
+      "bugType" : "MODIFIED_PARAMETER",
+      "description" : "The cofactor of the curve is negative."
+    },
+    "Normal" : {
+      "bugType" : "BASIC",
+      "description" : "The test vector contains a pseudorandomly generated, valid test case. Implementations are expected to pass this test."
+    },
+    "UnnamedCurve" : {
+      "bugType" : "UNKNOWN",
+      "description" : "The public key does not use a named curve. RFC 3279 allows to encode such curves by explicitly encoding, the parameters of the curve equation, modulus, generator, order and cofactor. However, many crypto libraries only support named curves. Modifying some of the EC parameters and encoding the corresponding public key as an unnamed curve is a potential attack vector."
+    },
+    "UnusedParam" : {
+      "bugType" : "MALLEABILITY",
+      "description" : "A parameter that is typically not used for ECDH has been modified. Sometimes libraries ignore small differences between public and private key. For example, a library might ignore an incorrect cofactor in the public key. We consider ignoring such changes as acceptable as long as these differences do not change the outcome of the ECDH computation, i.e. as long as the computation is done on the curve from the private key."
+    },
+    "WeakPublicKey" : {
+      "bugType" : "MODIFIED_PARAMETER",
+      "description" : "The vector contains a weak public key. The curve is not a named curve, the public key point has order 3 and has been chosen to be on the same curve as the private key. This test vector is used to check ECC implementations for missing steps in the verification of the public key."
+    },
+    "WrongCurve" : {
+      "bugType" : "CONFIDENTIALITY",
+      "description" : "The public key and private key use distinct curves. Implementations are expected to reject such parameters.",
+      "effect" : "Computing an ECDH key exchange with public and private keys can in the worst case lead to an invalid curve attack. Hence, it is important that ECDH implementations check the input parameters. The severity of such bugs is typically smaller if an implementation ensures that the point is on the curve and that the ECDH computation is performed on the curve of the private key. Some of the test vectors with modified public key contain shared ECDH secrets, that were computed over the curve of the private key."
+    },
+    "WrongOrder" : {
+      "bugType" : "MODIFIED_PARAMETER",
+      "description" : "The order of the public key has been modified.",
+      "effect" : "If this order is used in a cryptographic primitive instead of the correct order then an invalid curve attack is possible and the private keys may leak. E.g. ECDHC in BC 1.52 suffered from this."
+    }
   },
-  "numberOfTests" : 340,
-  "header" : [],
   "testGroups" : [
     {
+      "type" : "EcdhTest",
       "curve" : "secp256r1",
       "encoding" : "asn",
-      "type" : "ECHDComp",
       "tests" : [
         {
           "tcId" : 1,
           "comment" : "normal case",
+          "flags" : [
+            "Normal"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000462d5bd3372af75fe85a040715d0f502428e07046868b0bfdfa61d731afe44f26ac333a93a9e70a81cd5a95b5bf8d13990eb741c8c38872b4a07d275a014e30cf",
-          "private" : "612465c89a023ab17855b0a6bcebfd3febb53aef84138647b5352e02c10c346",
+          "private" : "0612465c89a023ab17855b0a6bcebfd3febb53aef84138647b5352e02c10c346",
           "shared" : "53020d908b0219328b658b525f26780e3ae12bcd952bb25a93bc0895e1714285",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
           "tcId" : 2,
           "comment" : "compressed public key",
-          "public" : "3039301306072a8648ce3d020106082a8648ce3d0301070322000362d5bd3372af75fe85a040715d0f502428e07046868b0bfdfa61d731afe44f26",
-          "private" : "612465c89a023ab17855b0a6bcebfd3febb53aef84138647b5352e02c10c346",
-          "shared" : "53020d908b0219328b658b525f26780e3ae12bcd952bb25a93bc0895e1714285",
-          "result" : "acceptable",
           "flags" : [
+            "CompressedPublic",
             "CompressedPoint"
-          ]
+          ],
+          "public" : "3039301306072a8648ce3d020106082a8648ce3d0301070322000362d5bd3372af75fe85a040715d0f502428e07046868b0bfdfa61d731afe44f26",
+          "private" : "0612465c89a023ab17855b0a6bcebfd3febb53aef84138647b5352e02c10c346",
+          "shared" : "53020d908b0219328b658b525f26780e3ae12bcd952bb25a93bc0895e1714285",
+          "result" : "acceptable"
         },
         {
           "tcId" : 3,
-          "comment" : "edge case for shared secret",
+          "comment" : "shared secret has x-coordinate that satisfies x**2 = 0",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000458fd4168a87795603e2b04390285bdca6e57de6027fe211dd9d25e2212d29e62080d36bd224d7405509295eed02a17150e03b314f96da37445b0d1d29377d12c",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
           "shared" : "0000000000000000000000000000000000000000000000000000000000000000",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
           "tcId" : 4,
-          "comment" : "edge case for shared secret",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040f6d20c04261ecc3e92846acad48dc8ec5ee35ae0883f0d2ea71216906ee1c47c042689a996dd12830ae459382e94aac56b717af2e2080215f9e41949b1f52be",
+          "comment" : "shared secret has x-coordinate p-3",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a1ecc24bf0d0053d23f5fd80ddf1735a1925039dc1176c581a7e795163c8b9ba2cb5a4e4d5109f4527575e3137b83d79a9bcb3faeff90d2aca2bed71bb523e7e",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "00000000000000000000000000000000ffffffffffffffffffffffffffffffff",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "ffffffff00000001000000000000000000000000fffffffffffffffffffffffc",
+          "result" : "valid"
         },
         {
           "tcId" : 5,
-          "comment" : "edge case for shared secret",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400c7defeb1a16236738e9a1123ba621bc8e9a3f2485b3f8ffde7f9ce98f5a8a1cb338c3912b1792f60c2b06ec5231e2d84b0e596e9b76d419ce105ece3791dbc",
+          "comment" : "shared secret has x-coordinate 2**16 + 0",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041b0e7437c33d379929430d3ec10df59bed7fe2a1d950c5791e1e9ddeef1f4d70fbdb0e3bbce63a27f27838c685207f2ccaf689d25eb622744db1168ac92619e8",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "0000000000000000ffffffffffffffff00000000000000010000000000000001",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "0000000000000000000000000000000000000000000000000000000000010000",
+          "result" : "valid"
         },
         {
           "tcId" : 6,
-          "comment" : "edge case for shared secret",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e9b98fb2c0ac045f8c76125ffd99eb8a5157be1d7db3e85d655ec1d8210288cf218df24fd2c2746be59df41262ef3a97d986744b2836748a7486230a319ffec0",
+          "comment" : "shared secret has x-coordinate 2**32 + 0",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000408d6148d0244d243b3d0d1777de6375fa7ebeab477f19915d05994db04df219727737d4f8ce0a7f390becce92b2bcd5c054f18ecb58e5dd59baf88b4ed6abea8",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "00000000ffffffff00000000ffffffff00000000ffffffff0000000100000000",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "0000000000000000000000000000000000000000000000000000000100000000",
+          "result" : "valid"
         },
         {
           "tcId" : 7,
-          "comment" : "edge case for shared secret",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e9484e58f3331b66ffed6d90cb1c78065fa28cfba5c7dd4352013d3252ee4277bd7503b045a38b4b247b32c59593580f39e6abfa376c3dca20cf7f9cfb659e13",
+          "comment" : "shared secret has x-coordinate 2**64 + 0",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042424f9d7ba0a89ce3c7c1e8f15dfd83004d86680967a82cbf9bb6b11dae5fd72e05c3687187b1cf28438a17a7469fa3b094b7d6f36cccc3492c0b0a61fab2a38",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "000003ffffff0000003ffffff0000003ffffff0000003ffffff0000003ffffff",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "0000000000000000000000000000000000000000000000010000000000000000",
+          "result" : "valid"
         },
         {
           "tcId" : 8,
-          "comment" : "edge case for shared secret",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004767d7fbb84aa6a4db1079372644e42ecb2fec200c178822392cb8b950ffdd0c91c86853cafd09b52ba2f287f0ebaa26415a3cfabaf92c6a617a19988563d9dea",
+          "comment" : "shared secret has x-coordinate 2**96 + 0",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044c9695b7668434fc85769acb10f0edcf87a96b7d5dc347b46bb304b0b1d3267fcf5d993bff2a8c774808231a34f41b33667d8ebeafd00689fa3a9bfa05a40c1c",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff00010001",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "0000000000000000000000000000000000000001000000000000000000000000",
+          "result" : "valid"
         },
         {
           "tcId" : 9,
-          "comment" : "edge case for shared secret",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c74d546f2fcc6dd392f85e5be167e358de908756b0c0bb01cb69d864ca083e1c93f959eece6e10ee11bd3934207d65ae28af68b092585a1509260eceb39b92ef",
+          "comment" : "shared secret has x-coordinate that satisfies x**2 = -3",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a492fe4b4908b6d675d687551f99c617e4e5c97aa266958953129eb381f0153b111b95c94fa1d1ecd1d41d2785c1db5195875ae98051732a59ba7720f9089af6",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "085ec5a4af40176b63189069aeffcb229c96d3e046e0283ed2f9dac21b15ad3c",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "6522aed9ea48f2623b8eeae3e213b99da32e74c9421835804d374ce28fcca662",
+          "result" : "valid"
         },
         {
           "tcId" : 10,
-          "comment" : "edge case for shared secret",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000434fc9f1e7a094cd29598d1841fa9613dbe82313d633a51d63fb6eff074cc9b9a4ecfd9f258c5c4d4210b49751213a24c596982bd1d54e0445443f21ef15492a5",
-          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "190c25f88ad9ae3a098e6cffe6fd0b1bea42114eb0cedd5868a45c5fe277dff3",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 11,
-          "comment" : "edge case for shared secret",
+          "comment" : "shared secret has x-coordinate that satisfies x**2 = 2",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d5c96efd1907fd48de2ad715acf82eae5c6690fe3efe16a78d61c68d3bfd10df03eac816b9e7b776192a3f5075887c0e225617505833ca997cda32fd0f673c5e",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
           "shared" : "507442007322aa895340cba4abc2d730bfd0b16c2c79a46815f8780d2c55a2dd",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
+        },
+        {
+          "tcId" : 11,
+          "comment" : "shared secret has x-coordinate that satisfies x**2 = 5",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c74d546f2fcc6dd392f85e5be167e358de908756b0c0bb01cb69d864ca083e1c93f959eece6e10ee11bd3934207d65ae28af68b092585a1509260eceb39b92ef",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "085ec5a4af40176b63189069aeffcb229c96d3e046e0283ed2f9dac21b15ad3c",
+          "result" : "valid"
         },
         {
           "tcId" : 12,
-          "comment" : "edge case for shared secret",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f475f503a770df72c45aedfe42c008f59aa57e72b232f26600bdd0353957cb20bdb8f6405b4918050a3549f44c07a8eba820cdce4ece699888c638df66f54f7c",
+          "comment" : "shared secret has x-coordinate that satisfies x**2 = 7",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000434fc9f1e7a094cd29598d1841fa9613dbe82313d633a51d63fb6eff074cc9b9a4ecfd9f258c5c4d4210b49751213a24c596982bd1d54e0445443f21ef15492a5",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "5f177bfe19baaaee597e68b6a87a519e805e9d28a70cb72fd40f0fe5a754ba45",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "190c25f88ad9ae3a098e6cffe6fd0b1bea42114eb0cedd5868a45c5fe277dff3",
+          "result" : "valid"
         },
         {
           "tcId" : 13,
-          "comment" : "edge case for shared secret",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f3cb6754b7e2a86d064dfb9f903185aaa4c92b481c2c1a1ff276303bbc4183e49c318599b0984c3563df339311fe143a7d921ee75b755a52c6f804f897b809f7",
+          "comment" : "shared secret has x-coordinate that satisfies x**2 = 8",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f475f503a770df72c45aedfe42c008f59aa57e72b232f26600bdd0353957cb20bdb8f6405b4918050a3549f44c07a8eba820cdce4ece699888c638df66f54f7c",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "7fff0001fffc0007fff0001fffc0007fff0001fffc0007fff0001fffc0007fff",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "5f177bfe19baaaee597e68b6a87a519e805e9d28a70cb72fd40f0fe5a754ba45",
+          "result" : "valid"
         },
         {
           "tcId" : 14,
-          "comment" : "edge case for shared secret",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cce13fbdc96a946dfb8c6d9ed762dbd1731630455689f57a437fee124dd54cecaef78026c653030cf2f314a67064236b0a354defebc5e90c94124e9bf5c4fc24",
+          "comment" : "shared secret has x-coordinate that satisfies x**2 = 2**96 + 2",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004949304889050834006ecf11eba0e73f0dd2a5e77a5ea642a34a3f9989eda2d57384509cd42763c87cf460d1ad75664402986bb8cca0acdfc3685d2c9c7d32933",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "8000000000000000000000000000000000000000000000000000000000000004",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "3476a8fa9c7448124aa945a2e1103eb91f95c7b4d91aaa1c35b8965191fc0fe0",
+          "result" : "valid"
         },
         {
           "tcId" : 15,
-          "comment" : "edge case for shared secret",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047633dfd0ad06765097bc11bd5022b200df31f28c4ff0625421221ac7eeb6e6f4cb9c67693609ddd6f92343a5a1c635408240f4f8e27120c12554c7ff8c76e2fe",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 2",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e25ead8342888d1fbd2bd211e9db5bc761da9cfa1e805078b53606df9e5444403d3421fa70f940dba104d842034d2efec9332161ccfb654a8e9f2ec42fc1a837",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "8000003ffffff0000007fffffe000000ffffffc000001ffffff8000004000000",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "5555555555555555555555555555555555555555555555555555555555555554",
+          "result" : "valid"
         },
         {
           "tcId" : 16,
-          "comment" : "edge case for shared secret",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a386ace573f87558a68ead2a20088e3fe928bdae9e109446f93a078c15741f0421261e6db2bf12106e4c6bf85b9581b4c0302a526222f90abc5a549206b11011",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 2",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cb32ab951d7581e7602c89320d91d7043e9dc56a10348d586a08d1870753152bf96bd53e7cfc2434dc61a09f8f4853e4c6dd49e786194ec0a988d0e8d29378b8",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "ff00000001fffffffc00000007fffffff00000001fffffffc00000007fffffff",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9",
+          "result" : "valid"
         },
         {
           "tcId" : 17,
-          "comment" : "edge case for shared secret",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048e7b50f7d8c44d5d3496c43141a502f4a43f153d03ad43eda8e39597f1d477b8647f3da67969b7f989ff4addc393515af40c82085ce1f2ee195412c6f583774f",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 4",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040b9d56422ed9c2082dd9d46d231fd0141f92e79f5a12da4c77c488c87363f944e6e3c2ec9779615f242bc30d1c28c1f984b8c252243f5f1eaa3d855e1cc2d8a6",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "ffff00000003fffffff00000003fffffff00000003fffffff00000003fffffff",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "3333333333333333333333333333333333333333333333333333333333333333",
+          "result" : "valid"
         },
         {
           "tcId" : 18,
-          "comment" : "edge case for shared secret",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c827fb930fd51d926086191b502af83abb5f717debc8de29897a3934b2571ca05990c0597b0b7a2e42febd56b13235d1d408d76ed2c93b3facf514d902f6910a",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 4",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040507fabb16755f4885ae45b3d497822388f4e6a531de512c200480b4e56b892ab70746c1d8a20637eff17948e557a2b4da2562ba6b62991b426b7b3787a19693",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "ffffffff00000000000000ffffffffffffff00000000000000ffffffffffffff",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+          "result" : "valid"
         },
         {
           "tcId" : 19,
-          "comment" : "y-coordinate of the public key is small",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043cbc1b31b43f17dc200dd70c2944c04c6cb1b082820c234a300b05b7763844c74fde0a4ef93887469793270eb2ff148287da9265b0334f9e2609aac16e8ad503",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 8",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043b18caef2cd982c3b58f258cb76daa029383f42c8f3f083493f42c915935243a260830b7d25b66378c5d25fb0cf23d32527a2cdb7f7d7e6c89ebea8277738ed8",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "7fffffffffffffffffffffffeecf2230ffffffffffffffffffffffffffffffff",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f",
+          "result" : "valid"
         },
         {
           "tcId" : 20,
-          "comment" : "y-coordinate of the public key is small",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042830d96489ae24b79cad425056e82746f9e3f419ab9aa21ca1fbb11c7325e7d318abe66f575ee8a2f1c4a80e35260ae82ad7d6f661d15f06967930a585097ef7",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 8",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004123b1921231bee315e1ea66cb95318d6392f85695bbec03c334740ce7add768efec9a108770ff0eb448eee9f06367416d74b22a2f38157bb00d8c0be44ebf152",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "000000000000000000000000111124f400000000000000000000000000000000",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0",
+          "result" : "valid"
         },
         {
           "tcId" : 21,
-          "comment" : "y-coordinate of the public key is small",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004450b6b6e2097178e9d2850109518d28eb3b6ded2922a5452003bc2e4a4ec775c894e90f0df1b0e6cadb03b9de24f6a22d1bd0a4a58cd645c273cae1c619bfd61",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 16",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004924fb33985c8a687fc04c9dd05e531ca0e0223aa58d58351e922ef482043d30cf504745e769b6dcbefe404da37f717b3109d2af23450fcfe2f075c2dabbe7194",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "000000000000000000000001ea77d449ffffffffffffffffffffffffffffffff",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00f9",
+          "result" : "valid"
         },
         {
           "tcId" : 22,
-          "comment" : "y-coordinate of the public key is large",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043cbc1b31b43f17dc200dd70c2944c04c6cb1b082820c234a300b05b7763844c7b021f5b006c778ba686cd8f14d00eb7d78256d9b4fccb061d9f6553e91752afc",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 16",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000422495c6884937a1bc05871e9ee1a2c43f8f14db19ee60bd2d89c4293042f5a9452cea27e6fe574a00e5f15fe11aa54f54ebd8bde3aa41c80bf9d5f7b1dc6efec",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "7fffffffffffffffffffffffeecf2230ffffffffffffffffffffffffffffffff",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00feff",
+          "result" : "valid"
         },
         {
           "tcId" : 23,
-          "comment" : "y-coordinate of the public key is large",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042830d96489ae24b79cad425056e82746f9e3f419ab9aa21ca1fbb11c7325e7d3e754198fa8a1175e0e3b57f1cad9f517d528290a9e2ea0f96986cf5a7af68108",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 30",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f3cb6754b7e2a86d064dfb9f903185aaa4c92b481c2c1a1ff276303bbc4183e49c318599b0984c3563df339311fe143a7d921ee75b755a52c6f804f897b809f7",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "000000000000000000000000111124f400000000000000000000000000000000",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "7fff0001fffc0007fff0001fffc0007fff0001fffc0007fff0001fffc0007fff",
+          "result" : "valid"
         },
         {
           "tcId" : 24,
-          "comment" : "y-coordinate of the public key is large",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004450b6b6e2097178e9d2850109518d28eb3b6ded2922a5452003bc2e4a4ec775c76b16f0e20e4f194524fc4621db095dd2e42f5b6a7329ba3d8c351e39e64029e",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 30",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a8d93bebbaf25fa9a1f98c44b54dbf28634a5fd08402dba5d9e4873f8123da1db972d91a0eabadb630b271e6551b757d969301beddd11f82decdfbe4f9657f50",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "000000000000000000000001ea77d449ffffffffffffffffffffffffffffffff",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "8000fffe0003fff8000fffe0003fff8000fffe0003fff8000fffe0003fff7ffe",
+          "result" : "valid"
         },
         {
           "tcId" : 25,
-          "comment" : "y-coordinate of the public key has many trailing 1's",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049a0f0e3dd31417bbd9e298bc068ab6d5c36733af26ed67676f410c804b8b2ca1b02c82f3a61a376db795626e9400557112273a36cddb08caaa43953965454730",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 32",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048d0086e678a0fe7b4ad7bd4f94a38267b9f9f1d2b82452db4cfb335595c26c55f78476a00a0153941da0b0b81c834682edc9fcc8bc21a7b5bacb460dbb566c19",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "7fffffffffffffffffffffffca089011ffffffffffffffffffffffffffffffff",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000fffe",
+          "result" : "valid"
         },
         {
           "tcId" : 26,
-          "comment" : "y-coordinate of the public key has many trailing 1's",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048e5d22d5e53ec797c55ecd68a08a7c3361cd99ca7fad1a68ea802a6a4cb58a918ea7a07023ef67677024bd3841e187c64b30a30a3750eb2ee873fbe58fa1357b",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 32",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000402a96834fe3b54d440003521f2355aea48d0bbc576473fecc6975100c589865263255764891ffc108cfe754af52a4362953955ddfadcf752637c11edeaa6a807",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "0000000000000000000000001f6bd1e500000000000000000000000000000000",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000fffefffd",
+          "result" : "valid"
         },
         {
           "tcId" : 27,
-          "comment" : "y-coordinate of the public key has many trailing 1's",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004293aa349b934ab2c839cf54b8a737df2304ef9b20fa494e31ad62b315dd6a53c118182b85ef466eb9a8e87f9661f7d017984c15ea82043f536d1ee6a6d95b509",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 51",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048721294f9eb3ba69a13ae7d933fa51c48393fe1b9b9b17a08cecff2ee6ad434d2c23cd11d26694c472dda8cea4133bbc68e1f234bc7e8bffcea9446091855491",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "000000000000000000000002099f55d5ffffffffffffffffffffffffffffffff",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "8000003ffffff0000007fffffe000000ffffffc000001ffffff8000003fffffc",
+          "result" : "valid"
         },
         {
           "tcId" : 28,
-          "comment" : "y-coordinate of the public key has many trailing 0's",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049a0f0e3dd31417bbd9e298bc068ab6d5c36733af26ed67676f410c804b8b2ca14fd37d0b59e5c893486a9d916bffaa8eedd8c5ca3224f73555bc6ac69abab8cf",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 51",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043e99ec3c58ac3898936e4a61182b198823c9992209f67bf5291aa354fceb2f1312952518636add666320c8b7fa631541d0ca50796dbff0c1e72f94718776bd60",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "7fffffffffffffffffffffffca089011ffffffffffffffffffffffffffffffff",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "7fffffe000000ffffffc000001ffffff8000003ffffff0000007fffffdfffffe",
+          "result" : "valid"
         },
         {
           "tcId" : 29,
-          "comment" : "y-coordinate of the public key has many trailing 0's",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048e5d22d5e53ec797c55ecd68a08a7c3361cd99ca7fad1a68ea802a6a4cb58a9171585f8edc1098998fdb42c7be1e7839b4cf5cf6c8af14d1178c041a705eca84",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 52",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e9484e58f3331b66ffed6d90cb1c78065fa28cfba5c7dd4352013d3252ee4277bd7503b045a38b4b247b32c59593580f39e6abfa376c3dca20cf7f9cfb659e13",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "0000000000000000000000001f6bd1e500000000000000000000000000000000",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "000003ffffff0000003ffffff0000003ffffff0000003ffffff0000003ffffff",
+          "result" : "valid"
         },
         {
           "tcId" : 30,
-          "comment" : "y-coordinate of the public key has many trailing 0's",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004293aa349b934ab2c839cf54b8a737df2304ef9b20fa494e31ad62b315dd6a53cee7e7d46a10b99156571780699e082fe867b3ea257dfbc0ac92e1195926a4af6",
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 52",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004eb6eb532fe4af2a5a275ab4e9f728ae64e9dbc08e9359091d75e5334a6e08db64c146339c05d1d5782ebeeb86d3eb5c63e9f99f17187c039666c5237b736e9cd",
           "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
-          "shared" : "000000000000000000000002099f55d5ffffffffffffffffffffffffffffffff",
-          "result" : "valid",
-          "flags" : []
+          "shared" : "fffffc000000ffffffc000000ffffffc000000ffffffc000000ffffffbffffff",
+          "result" : "valid"
         },
         {
           "tcId" : 31,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000000000000000000000000000000000000000000000000000000000000000066485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "cfe4077c8730b1c9384581d36bff5542bc417c9eff5c2afcb98cc8829b2ce848",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 60",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048e7b50f7d8c44d5d3496c43141a502f4a43f153d03ad43eda8e39597f1d477b8647f3da67969b7f989ff4addc393515af40c82085ce1f2ee195412c6f583774f",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "ffff00000003fffffff00000003fffffff00000003fffffff00000003fffffff",
+          "result" : "valid"
         },
         {
           "tcId" : 32,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000000000000000000000000000ffffffffffffffffffffffffffffffff4f2b92b4c596a5a47f8b041d2dea6043021ac77b9a80b1343ac9d778f4f8f733",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "49ae50fe096a6cd26698b78356b2c8adf1f6a3490f14e364629f7a0639442509",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 60",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000440d4f4f6d9a41ab6ea90d46610b924ab15ed4f259fd09ddd41a707782fa9e203a5080a7e118a50c4b3d2c43dcbbf35c39e276a0a50b33a9ffbe7c9095055fc25",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "0000fffffffc0000000fffffffc0000000fffffffc0000000fffffffbfffffff",
+          "result" : "valid"
         },
         {
           "tcId" : 33,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000ffffffffffffffff0000000000000001000000000000000138120be6ab31edfa34768c4387d2f84fb4b0be8a9a985864a1575f4436bb37b0",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "5a1334572b2a711ead8b4653eb310cd8d9fd114399379a8f6b872e3b8fdda2d9",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 62",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a386ace573f87558a68ead2a20088e3fe928bdae9e109446f93a078c15741f0421261e6db2bf12106e4c6bf85b9581b4c0302a526222f90abc5a549206b11011",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "ff00000001fffffffc00000007fffffff00000001fffffffc00000007fffffff",
+          "result" : "valid"
         },
         {
           "tcId" : 34,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000ffffffff00000000ffffffff00000000ffffffff0000000100000000462c0466e41802238d6c925ecbefc747cfe505ea196af9a2d11b62850fce946e",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "c73755133b6b9b4b2a00631cbc7940ecbe6ec08f20448071422e3362f2556888",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 62",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004739b5c2189729b577ba1a467a1a0851c556b860f6b2016bcd50beb22ee9c0d7961ea43cf1ea7aad1a2360b0f37a74ca532dc8d1af26cdf89a87d93dcaa0c9564",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "00fffffffe00000003fffffff80000000fffffffe00000003fffffff80000000",
+          "result" : "valid"
         },
         {
           "tcId" : 35,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000003ffffff0000003ffffff0000003ffffff0000003ffffff0000003ffffff1582fa32e2d4a89dfcfb3d0b149f667dba3329490f4d64ee2ad586c0c9e8c508",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "06fa1059935e47a9fd667e13f469614eb257cc9a7e3fc599bfb92780d59b146d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 64",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046c03f055f710aea89341f0ef7a1c6d5c45a50923ce8adb33c2520f7881547748691f4dafcf6d5df8d9e6afda66ca81718bea8171abc87036a9c370385b60d969",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "00000000ffffffff00000000ffffffff00000000ffffffff00000000fffffffc",
+          "result" : "valid"
         },
         {
           "tcId" : 36,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff00010001684c8a9586ed6f9cbe447058a7da2108bab1e5e0a60d1f73e4e2e713f0a3dfe0",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "f237df4c10bd3e357971bb2b16b293566b7e355bdc8141d6c92cabc682983c45",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 64",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048a3f60cfec64745bf625696f2fe4b6e4ce8208954f4fc4da21f87f9f7a2c3275b54d90851b39707586dc6cceccc5e50a1e4a955463107d1d87c8252df2110d6d",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000",
+          "result" : "valid"
         },
         {
           "tcId" : 37,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004085ec5a4af40176b63189069aeffcb229c96d3e046e0283ed2f9dac21b15ad3c7859f97cb6e203f46bf3438f61282325e94e681b60b5669788aeb0655bf19d38",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "d874b55678d0a04d216c31b02f3ad1f30c92caaf168f34e3a743356d9276e993",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 112",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c827fb930fd51d926086191b502af83abb5f717debc8de29897a3934b2571ca05990c0597b0b7a2e42febd56b13235d1d408d76ed2c93b3facf514d902f6910a",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "ffffffff00000000000000ffffffffffffff00000000000000ffffffffffffff",
+          "result" : "valid"
         },
         {
           "tcId" : 38,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004190c25f88ad9ae3a098e6cffe6fd0b1bea42114eb0cedd5868a45c5fe277dff321b8342ef077bc6724112403eaee5a15b4c31a71589f02ded09cd99cc5db9c83",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "11a8582057463fc76fda3ab8087eb0a420b0d601bb3134165a369646931e52a6",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 112",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fc85bfee056478a1717582accd11ed49009891cbda5fe40b9f4c1742e127db2c97033f5f6405acfa57553f1e375a13e8d6e3a1151958c709be508e0bac7804d6",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "00000000ffffffffffffff00000000000000ffffffffffffff00000000000000",
+          "result" : "valid"
         },
         {
           "tcId" : 39,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004507442007322aa895340cba4abc2d730bfd0b16c2c79a46815f8780d2c55a2dd4619d69f9940f51663aa12381bc7cf678bd1a72a49fbc11b0b69cb22d1af9f2d",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "4e173a80907f361fe5a5d335ba7685d5eba93e9dfc8d8fcdb1dcd2d2bde27507",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 128",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000438bf171cdbd4e2e7128528db43d80655b789e69e6ba1d36b62e4e59d8ecf4c51bbe3244e4fbf79f24512f30c4a605314749e2f20d858ec961060a2cab467013f",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "0000000000000000ffffffffffffffff0000000000000000fffffffffffffffd",
+          "result" : "valid"
         },
         {
           "tcId" : 40,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045f177bfe19baaaee597e68b6a87a519e805e9d28a70cb72fd40f0fe5a754ba4562ca1103f70a2006cd1f67f5f6a3580b29dc446abc90e0e910c1e05a9aa788cd",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "73220471ec8bad99a297db488a34a259f9bc891ffaf09922e6b5001f5df67018",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "shared secret has x-coordinate with repeating bit-pattern of size 128",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004249f4f517d7788d4622d762c4312101fba71fe2657f1f2c33c0613d2e21890b778f32da1b61ed9385cd52f5e7103f77b01b403fb6537a0c0e866195d0a448f34",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "7fffffffffffffff0000000000000000ffffffffffffffff0000000000000000",
+          "result" : "valid"
         },
         {
           "tcId" : 41,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047fff0001fffc0007fff0001fffc0007fff0001fffc0007fff0001fffc0007fff2e2213caf03033e0fd0f7951154f6e6c3a9244a72faca65e9ce9eeb5c8e1cea9",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "55d0a203e22ffb523c8d2705060cee9d28308b51f184beefc518cff690bad346",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "shared secret has an x-coordinate of approx p//3",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e9c0af0bf6dadd8fbe04c5cf3fce80683a9c267b0dc9850cbc1bcdfeb744c3516efe878223dd9dd924e83e3ab22c9bf304129ab59c1f3d30fb58b8770bf9d9bf",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "5555555500000000555555555555555555555555aaaaaaaaaaaaaaaaaaaaaaab",
+          "result" : "valid"
         },
         {
           "tcId" : 42,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000480000000000000000000000000000000000000000000000000000000000000042be8789db81bb4870a9e60c5c18c80c83de464277281f1af1e640843a1a3148e",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "2518d846e577d95e9e7bc766cde7997cb887fb266d3a6cb598a839fd54aa2f4f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "shared secret has an x-coordinate of approx p//5",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042b29f482bc43559f70447584919df1e03706ee63c987b6f7499ae29ab01ca828a4bd05d61f596e01623a8e2076c013889fbb0f9937e475a00ddd75e6a992e776",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "3333333300000000333333333333333333333333666666666666666666666666",
+          "result" : "valid"
         },
         {
           "tcId" : 43,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048000003ffffff0000007fffffe000000ffffffc000001ffffff8000004000000722540f8a471c379083c600b58fde4d95c7dcad5095f4219fc5e9bdde3c5cd39",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "bdb49f4bdf42ac64504e9ce677b3ec5c0a03828c5b3efad726005692d35c0f26",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "shared secret has an x-coordinate of approx p//7",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042766dc8e289fd27625d4765eb014aa54a44a7d5724050b9446e363071c260913aff9f1dc5e71b666501b24d70805cb8e1a01ee90ca84cb0c6f7ea453df85f520",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "249249246db6db6ddb6db6db6db6db6db6db6db7000000000000000000000000",
+          "result" : "valid"
         },
         {
           "tcId" : 44,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ff00000001fffffffc00000007fffffff00000001fffffffc00000007fffffff5df80fc6cae26b6c1952fbd00ed174ee1209d069335f5b48588e29e80b9191ad",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "f503ac65637e0f17cb4408961cb882c875e4c6ef7a548d2d52d8c2f681838c55",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "shared secret has an x-coordinate of approx p//9",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d33314f13a7fe8357bfd7a11799498e55bc782c6f434856d733b668e1d05448348dc5aae3f6431dd20c018f54b1d65fd1864ddfeea04ad7533971237c60ac0c7",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "1c71c71c5555555571c71c71c71c71c71c71c71c8e38e38e38e38e38e38e38e4",
+          "result" : "valid"
         },
         {
           "tcId" : 45,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffff00000003fffffff00000003fffffff00000003fffffff00000003fffffff2c63650e6a5d332e2987dd09a79008e8faabbd37e49cb016bfb92c8cd0f5da77",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "e3c18e7d7377dc540bc45c08d389bdbe255fa80ca8faf1ef6b94d52049987d21",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043cbc1b31b43f17dc200dd70c2944c04c6cb1b082820c234a300b05b7763844c74fde0a4ef93887469793270eb2ff148287da9265b0334f9e2609aac16e8ad503",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "7fffffffffffffffffffffffeecf2230ffffffffffffffffffffffffffffffff",
+          "result" : "valid"
         },
         {
           "tcId" : 46,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000000000000ffffffffffffff00000000000000ffffffffffffff7a116c964a4cd60668bf89cffe157714a3ce21b93b3ca607c8a5b93ac54ffc0a",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "516d6d329b095a7c7e93b4023d4d05020c1445ef1ddcb3347b3a27d7d7f57265",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042830d96489ae24b79cad425056e82746f9e3f419ab9aa21ca1fbb11c7325e7d318abe66f575ee8a2f1c4a80e35260ae82ad7d6f661d15f06967930a585097ef7",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "000000000000000000000000111124f400000000000000000000000000000000",
+          "result" : "valid"
         },
         {
           "tcId" : 47,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047fffffffffffffffffffffffeecf2230ffffffffffffffffffffffffffffffff00000001c7c30643abed0af0a49fe352cb483ff9b97dccdf427c658e8793240d",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "6fd26661851a8de3c6d06f834ef3acb8f2a5f9c136a985ffe10d5eeb51edcfa3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004450b6b6e2097178e9d2850109518d28eb3b6ded2922a5452003bc2e4a4ec775c894e90f0df1b0e6cadb03b9de24f6a22d1bd0a4a58cd645c273cae1c619bfd61",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "000000000000000000000001ea77d449ffffffffffffffffffffffffffffffff",
+          "result" : "valid"
         },
         {
           "tcId" : 48,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047fffffffffffffffffffffffeecf2230fffffffffffffffffffffffffffffffffffffffd383cf9bd5412f50f5b601cad34b7c00746823320bd839a71786cdbf2",
+          "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047fffffffffffffffffffffffeecf2230ffffffffffffffffffffffffffffffff00000001c7c30643abed0af0a49fe352cb483ff9b97dccdf427c658e8793240d",
           "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
           "shared" : "6fd26661851a8de3c6d06f834ef3acb8f2a5f9c136a985ffe10d5eeb51edcfa3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
           "tcId" : 49,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047fffffffffffffffffffffffca089011ffffffffffffffffffffffffffffffff267bfdf8a61148decd80283732dd4c1095e4bb40b9658408208dc1147fffffff",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "44236c8b9505a19d48774a3903c0292759b0f826e6ac092ff898d87e53d353fc",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 50,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047fffffffffffffffffffffffca089011ffffffffffffffffffffffffffffffffd984020659eeb722327fd7c8cd22b3ef6a1b44c0469a7bf7df723eeb80000000",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "44236c8b9505a19d48774a3903c0292759b0f826e6ac092ff898d87e53d353fc",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 51,
-          "comment" : "edge cases for ephemeral key",
+          "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000000000000000000000000111124f4000000000000000000000000000000000000000d12d381b0760b1c50be8acf859385052c7f53cde67ce13759de3123a0",
           "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
           "shared" : "f1f0e43b374feb7e7f96d4ffe7519fa8bb6c3cfd25f6f87dab2623d2a2d33851",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 52,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000000000000000000000000111124f400000000000000000000000000000000fffffff1ed2c7e5089f4e3af4175307a6c7afad480ac3219831ec8a621cedc5f",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "f1f0e43b374feb7e7f96d4ffe7519fa8bb6c3cfd25f6f87dab2623d2a2d33851",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 53,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000000000001f6bd1e5000000000000000000000000000000004096edd6871c320cb8a9f4531751105c97b4c257811bbc32963eaf39ffffffff",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "3ebbace1098a81949d5605dd94a7aa88dc396c2c23e01a9c8cca5bb07bfbb6a1",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 54,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000000000001f6bd1e500000000000000000000000000000000bf69122878e3cdf447560bace8aeefa3684b3da97ee443cd69c150c600000000",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "3ebbace1098a81949d5605dd94a7aa88dc396c2c23e01a9c8cca5bb07bfbb6a1",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 55,
-          "comment" : "edge cases for ephemeral key",
+          "tcId" : 50,
+          "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000000000000000000000001ea77d449ffffffffffffffffffffffffffffffff000000007afbc0b325e820646dec622fb558a51c342aa257f4b6a8ec5ddf144f",
           "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
           "shared" : "1b085213a9c89d353e1111af078c38c502b7b4771efba51f589b5be243417bdc",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
+        },
+        {
+          "tcId" : 51,
+          "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043cbc1b31b43f17dc200dd70c2944c04c6cb1b082820c234a300b05b7763844c7b021f5b006c778ba686cd8f14d00eb7d78256d9b4fccb061d9f6553e91752afc",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "7fffffffffffffffffffffffeecf2230ffffffffffffffffffffffffffffffff",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 52,
+          "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042830d96489ae24b79cad425056e82746f9e3f419ab9aa21ca1fbb11c7325e7d3e754198fa8a1175e0e3b57f1cad9f517d528290a9e2ea0f96986cf5a7af68108",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "000000000000000000000000111124f400000000000000000000000000000000",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 53,
+          "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004450b6b6e2097178e9d2850109518d28eb3b6ded2922a5452003bc2e4a4ec775c76b16f0e20e4f194524fc4621db095dd2e42f5b6a7329ba3d8c351e39e64029e",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "000000000000000000000001ea77d449ffffffffffffffffffffffffffffffff",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 54,
+          "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047fffffffffffffffffffffffeecf2230fffffffffffffffffffffffffffffffffffffffd383cf9bd5412f50f5b601cad34b7c00746823320bd839a71786cdbf2",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "6fd26661851a8de3c6d06f834ef3acb8f2a5f9c136a985ffe10d5eeb51edcfa3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 55,
+          "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000000000000000000000000111124f400000000000000000000000000000000fffffff1ed2c7e5089f4e3af4175307a6c7afad480ac3219831ec8a621cedc5f",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "f1f0e43b374feb7e7f96d4ffe7519fa8bb6c3cfd25f6f87dab2623d2a2d33851",
+          "result" : "valid"
         },
         {
           "tcId" : 56,
-          "comment" : "edge cases for ephemeral key",
+          "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000000000000000000000001ea77d449fffffffffffffffffffffffffffffffffffffffe85043f4dda17df9b92139dd04aa75ae4cbd55da80b495713a220ebb0",
           "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
           "shared" : "1b085213a9c89d353e1111af078c38c502b7b4771efba51f589b5be243417bdc",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
           "tcId" : 57,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000000000000000000000002099f55d5ffffffffffffffffffffffffffffffff152c1a22d823a27855ed03f8e2ab5038bb1df4d87e43865f2daf6948ffffffff",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "67cb63566c7ceb12fdd85ce9d2f77c359242bbaa0ea1bf3cf510a4a26591d1f1",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049a0f0e3dd31417bbd9e298bc068ab6d5c36733af26ed67676f410c804b8b2ca1b02c82f3a61a376db795626e9400557112273a36cddb08caaa43953965454730",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "7fffffffffffffffffffffffca089011ffffffffffffffffffffffffffffffff",
+          "result" : "valid"
         },
         {
           "tcId" : 58,
-          "comment" : "edge cases for ephemeral key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000000000000000000000002099f55d5ffffffffffffffffffffffffffffffffead3e5dc27dc5d88aa12fc071d54afc744e20b2881bc79a0d25096b700000000",
-          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
-          "shared" : "67cb63566c7ceb12fdd85ce9d2f77c359242bbaa0ea1bf3cf510a4a26591d1f1",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048e5d22d5e53ec797c55ecd68a08a7c3361cd99ca7fad1a68ea802a6a4cb58a918ea7a07023ef67677024bd3841e187c64b30a30a3750eb2ee873fbe58fa1357b",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "0000000000000000000000001f6bd1e500000000000000000000000000000000",
+          "result" : "valid"
         },
         {
           "tcId" : 59,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "3",
-          "shared" : "85a0b58519b28e70a694ec5198f72c4bfdabaa30a70f7143b5b1cd7536f716ca",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004293aa349b934ab2c839cf54b8a737df2304ef9b20fa494e31ad62b315dd6a53c118182b85ef466eb9a8e87f9661f7d017984c15ea82043f536d1ee6a6d95b509",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "000000000000000000000002099f55d5ffffffffffffffffffffffffffffffff",
+          "result" : "valid"
         },
         {
           "tcId" : 60,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "0ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-          "shared" : "a329a7d80424ea2d6c904393808e510dfbb28155092f1bac284dceda1f13afe5",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047fffffffffffffffffffffffca089011ffffffffffffffffffffffffffffffff267bfdf8a61148decd80283732dd4c1095e4bb40b9658408208dc1147fffffff",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "44236c8b9505a19d48774a3903c0292759b0f826e6ac092ff898d87e53d353fc",
+          "result" : "valid"
         },
         {
           "tcId" : 61,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "100000000000000000000000000000000000000000000000000000000000000",
-          "shared" : "bd26d0293e8851c51ebe0d426345683ae94026aca545282a4759faa85fde6687",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000000000001f6bd1e5000000000000000000000000000000004096edd6871c320cb8a9f4531751105c97b4c257811bbc32963eaf39ffffffff",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "3ebbace1098a81949d5605dd94a7aa88dc396c2c23e01a9c8cca5bb07bfbb6a1",
+          "result" : "valid"
         },
         {
           "tcId" : 62,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-          "shared" : "ea9350b2490a2010c7abf43fb1a38be729a2de375ea7a6ac34ff58cc87e51b6c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000000000000000000000002099f55d5ffffffffffffffffffffffffffffffff152c1a22d823a27855ed03f8e2ab5038bb1df4d87e43865f2daf6948ffffffff",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "67cb63566c7ceb12fdd85ce9d2f77c359242bbaa0ea1bf3cf510a4a26591d1f1",
+          "result" : "valid"
         },
         {
           "tcId" : 63,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "08000000000000000000000000000000000000000000000000000000000000000",
-          "shared" : "34eed3f6673d340b6f716913f6dfa36b5ac85fa667791e2d6a217b0c0b7ba807",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049a0f0e3dd31417bbd9e298bc068ab6d5c36733af26ed67676f410c804b8b2ca14fd37d0b59e5c893486a9d916bffaa8eedd8c5ca3224f73555bc6ac69abab8cf",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "7fffffffffffffffffffffffca089011ffffffffffffffffffffffffffffffff",
+          "result" : "valid"
         },
         {
           "tcId" : 64,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "0ffffffff00000000ffffffffffffffffbce6faada7179e83f3b9cac2fc632551",
-          "shared" : "1354ce6692c9df7b6fc3119d47c56338afbedccb62faa546c0fe6ed4959e41c3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048e5d22d5e53ec797c55ecd68a08a7c3361cd99ca7fad1a68ea802a6a4cb58a9171585f8edc1098998fdb42c7be1e7839b4cf5cf6c8af14d1178c041a705eca84",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "0000000000000000000000001f6bd1e500000000000000000000000000000000",
+          "result" : "valid"
         },
         {
           "tcId" : 65,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "0ffffffff00000000ffffffffffffffffbce6faada7179e84f3a9cac2fc632551",
-          "shared" : "fe7496c30d534995f0bf428b5471c21585aaafc81733916f0165597a55d12cb4",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCaseSharedSecret"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004293aa349b934ab2c839cf54b8a737df2304ef9b20fa494e31ad62b315dd6a53cee7e7d46a10b99156571780699e082fe867b3ea257dfbc0ac92e1195926a4af6",
+          "private" : "0a0d622a47e48f6bc1038ace438c6f528aa00ad2bd1da5f13ee46bf5f633d71a",
+          "shared" : "000000000000000000000002099f55d5ffffffffffffffffffffffffffffffff",
+          "result" : "valid"
         },
         {
           "tcId" : 66,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "0ffffffff00000000ffffffffffffffffbce6faada7179e84f3b1cac2fc632551",
-          "shared" : "348bf8042e4edf1d03c8b36ab815156e77c201b764ed4562cfe2ee90638ffef5",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047fffffffffffffffffffffffca089011ffffffffffffffffffffffffffffffffd984020659eeb722327fd7c8cd22b3ef6a1b44c0469a7bf7df723eeb80000000",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "44236c8b9505a19d48774a3903c0292759b0f826e6ac092ff898d87e53d353fc",
+          "result" : "valid"
         },
         {
           "tcId" : 67,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "0ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac1fc632551",
-          "shared" : "6e4ec5479a7c20a537501700484f6f433a8a8fe53c288f7a25c8e8c92d39e8dc",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000000000001f6bd1e500000000000000000000000000000000bf69122878e3cdf447560bace8aeefa3684b3da97ee443cd69c150c600000000",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "3ebbace1098a81949d5605dd94a7aa88dc396c2c23e01a9c8cca5bb07bfbb6a1",
+          "result" : "valid"
         },
         {
           "tcId" : 68,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "0ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6324f3",
-          "shared" : "f7407d61fdf581be4f564621d590ca9b7ba37f31396150f9922f1501da8c83ef",
-          "result" : "valid",
+          "comment" : "y-coordinate of the public key has many trailing 0's",
           "flags" : [
-            "AddSubChain"
-          ]
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000000000000000000000002099f55d5ffffffffffffffffffffffffffffffffead3e5dc27dc5d88aa12fc071d54afc744e20b2881bc79a0d25096b700000000",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "67cb63566c7ceb12fdd85ce9d2f77c359242bbaa0ea1bf3cf510a4a26591d1f1",
+          "result" : "valid"
         },
         {
           "tcId" : 69,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "0ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632533",
-          "shared" : "82236fd272208693e0574555ca465c6cc512163486084fa57f5e1bd2e2ccc0b3",
-          "result" : "valid",
+          "comment" : "ephemeral key has x-coordinate that satisfies x**2 = 0",
           "flags" : [
-            "AddSubChain"
-          ]
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000000000000000000000000000000000000000000000000000000000000000066485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "cfe4077c8730b1c9384581d36bff5542bc417c9eff5c2afcb98cc8829b2ce848",
+          "result" : "valid"
         },
         {
           "tcId" : 70,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "0ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632543",
-          "shared" : "06537149664dba1a9924654cb7f787ed224851b0df25ef53fcf54f8f26cd5f3f",
-          "result" : "valid",
+          "comment" : "ephemeral key has x-coordinate p-3",
           "flags" : [
-            "AddSubChain"
-          ]
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000fffffffffffffffffffffffc19719bebf6aea13f25c96dfd7c71f5225d4c8fc09eb5a0ab9f39e9178e55c121",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "4c25702d10cd12ec7e77c4f1979237976d6aa809c645d75a59d399a52377eb7b",
+          "result" : "valid"
         },
         {
           "tcId" : 71,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "0ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254b",
-          "shared" : "f2b38539bce995d443c7bfeeefadc9e42cc2c89c60bf4e86eac95d51987bd112",
-          "result" : "valid",
+          "comment" : "ephemeral key has x-coordinate 2**16 + 0",
           "flags" : [
-            "AddSubChain"
-          ]
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000000000000000000000000000000000000000000000000000000000001000073ca30641acabe581170b4d5253f7a342b039a87ab2447badad08ece2cf19f52",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "4cfd639fd80c84b935c33cfaacceeb256b2f7e273c3ae5f0ff92b74957376f22",
+          "result" : "valid"
         },
         {
           "tcId" : 72,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "0ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
-          "shared" : "85a0b58519b28e70a694ec5198f72c4bfdabaa30a70f7143b5b1cd7536f716ca",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate 2**32 + 0",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000000000000000000000000000000000000000000100000000328bbc85099acc7685cf4bb5e18d72c57271615ccd46377bfacb0e8501aa76fb",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "581bb2ea633af1e59b15c1342d5e14adb58f613a231149f7df7a69c0eca95b2c",
+          "result" : "valid"
         },
         {
           "tcId" : 73,
-          "comment" : "edge case private key",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
-          "private" : "0ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254f",
-          "shared" : "027b013a6f166db655d69d643c127ef8ace175311e667dff2520f5b5c75b7659",
-          "result" : "valid",
+          "comment" : "ephemeral key has x-coordinate 2**64 + 0",
           "flags" : [
-            "AddSubChain"
-          ]
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000000000000000000000000000000000000000000000001000000000000000010048b687675af9815297d73a7f25b1a3c42d33c64b466991a7573b4954aa0b0",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "9920473de58a319ebd87d57f4f6c09093c5e0072c01bc8df0dc60b8a7a684c6f",
+          "result" : "valid"
         },
         {
           "tcId" : 74,
-          "comment" : "CVE-2017-8932",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004023819813ac969847059028ea88a1f30dfbcde03fc791d3a252c6b41211882eaf93e4ae433cc12cf2a43fc0ef26400c0e125508224cdb649380f25479148a4ad",
-          "private" : "2a265f8bcbdcaf94d58519141e578124cb40d64a501fba9c11847b28965bc737",
-          "shared" : "4d4de80f1534850d261075997e3049321a0864082d24a917863366c0724f5ae3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate 2**96 + 0",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000000000000000000000000000000000010000000000000000000000007d12de58d54423eb85ae8d157ae416fb004a7eb522ac1b67047ef3cdf9acdc3f",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "d9cd0d10ed4d3dc01f4216d229e21c6a447227a5bc2592c359b2d689a2dee3a8",
+          "result" : "valid"
         },
         {
           "tcId" : 75,
-          "comment" : "CVE-2017-8932",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cc11887b2d66cbae8f4d306627192522932146b42f01d3c6f92bd5c8ba739b06a2f08a029cd06b46183085bae9248b0ed15b70280c7ef13a457f5af382426031",
-          "private" : "313f72ff9fe811bf573176231b286a3bdb6f1b14e05c40146590727a71c3bccd",
-          "shared" : "831c3f6b5f762d2f461901577af41354ac5f228c2591f84f8a6e51e2e3f17991",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate that satisfies x**2 = -3",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046522aed9ea48f2623b8eeae3e213b99da32e74c9421835804d374ce28fcca6622c7fda3c84b704f27ffc0b2ab350d8cbc33a34df0c811155ed4389d2710e3fa9",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "af8bc612853197a6ee8b4af7300c0bc623f0cf4e4b301f47d66c27e8ecce9268",
+          "result" : "valid"
         },
         {
           "tcId" : 76,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate that satisfies x**2 = 2",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004507442007322aa895340cba4abc2d730bfd0b16c2c79a46815f8780d2c55a2dd4619d69f9940f51663aa12381bc7cf678bd1a72a49fbc11b0b69cb22d1af9f2d",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "4e173a80907f361fe5a5d335ba7685d5eba93e9dfc8d8fcdb1dcd2d2bde27507",
+          "result" : "valid"
         },
         {
           "tcId" : 77,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate that satisfies x**2 = 5",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004085ec5a4af40176b63189069aeffcb229c96d3e046e0283ed2f9dac21b15ad3c7859f97cb6e203f46bf3438f61282325e94e681b60b5669788aeb0655bf19d38",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "d874b55678d0a04d216c31b02f3ad1f30c92caaf168f34e3a743356d9276e993",
+          "result" : "valid"
         },
         {
           "tcId" : 78,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000000000000000000000000000000000000000000000000000ffffffff00000001000000000000000000000000fffffffffffffffffffffffe",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate that satisfies x**2 = 7",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004190c25f88ad9ae3a098e6cffe6fd0b1bea42114eb0cedd5868a45c5fe277dff321b8342ef077bc6724112403eaee5a15b4c31a71589f02ded09cd99cc5db9c83",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "11a8582057463fc76fda3ab8087eb0a420b0d601bb3134165a369646931e52a6",
+          "result" : "valid"
         },
         {
           "tcId" : 79,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000000000000000000000000000000000000000000000000000ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate that satisfies x**2 = 8",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045f177bfe19baaaee597e68b6a87a519e805e9d28a70cb72fd40f0fe5a754ba4562ca1103f70a2006cd1f67f5f6a3580b29dc446abc90e0e910c1e05a9aa788cd",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "73220471ec8bad99a297db488a34a259f9bc891ffaf09922e6b5001f5df67018",
+          "result" : "valid"
         },
         {
           "tcId" : 80,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate that satisfies x**2 = 2**96 + 2",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043476a8fa9c7448124aa945a2e1103eb91f95c7b4d91aaa1c35b8965191fc0fe04ddac138688df5123fa5760d670247893f9ad5cad5e88895a0ae7fdf97b8f412",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "f4e5f1757c8a03a3aec57b598b66a93bb356a6917e26b60489c0d06236ac6a37",
+          "result" : "valid"
         },
         {
           "tcId" : 81,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 2",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000455555555555555555555555555555555555555555555555555555555555555540a46712790e63f981f0103b2a609fa691c5291a17974eb0c3b518faac21535d6",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "be033e3db6216d3b3f9d66c96ca3b24475813ba8eb7820d7d6ff29c72fd39c64",
+          "result" : "valid"
         },
         {
           "tcId" : 82,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000000000000000000000000000000000000000000000000001ffffffff00000001000000000000000000000000fffffffffffffffffffffffe",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 2",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa9389142d4676cee2332eb8909fa13f95f20cdb3acc831a231802a4858a973ca63",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "a0da0b184f59ab0fdc0a6b03157c1b75269b284608b74a6e826f77104c42a9bd",
+          "result" : "valid"
         },
         {
           "tcId" : 83,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000000000000000000000000000000000000000000000000001ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 4",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004333333333333333333333333333333333333333333333333333333333333333311489212aff79cbed5b6440161d57c98a34e6b80ec3854c3b2855af35f0d17e1",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "ac03527f79d801081da4c0adcbba92e983ed46254354fd98e23ab659ee02a6cd",
+          "result" : "valid"
         },
         {
           "tcId" : 84,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000fffffffffffffffffffffffe0000000000000000000000000000000000000000000000000000000000000000",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 4",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc75552486fd8e6bc424492204207fece59d93fb124390497f841d9c808c8cc3ec",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "0d2759dae57c906a8cca8541a56f429a6ffedf028212f7f0ad06b696ee655caf",
+          "result" : "valid"
         },
         {
           "tcId" : 85,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000fffffffffffffffffffffffe0000000000000000000000000000000000000000000000000000000000000001",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 8",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f03425ba0d8a018b42861e816c79a17d3b47df8f5f7107c181168e9edc62cb3cf",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "ff6e930d08290769ef982bc568b0b45f88b7d5219b00667820793b3e824c1615",
+          "result" : "valid"
         },
         {
           "tcId" : 86,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000fffffffffffffffffffffffeffffffff00000001000000000000000000000000fffffffffffffffffffffffe",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 8",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f017b41bf72c9f5ec204dba0deb5dfaa43b793a83b243060d0375b969e0416bd56",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "bd106c43e45272091553f476e015fbb0982764c018d5f0666834ae0dc5dca131",
+          "result" : "valid"
         },
         {
           "tcId" : 87,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000fffffffffffffffffffffffeffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 16",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00f918461138bca461c00fc474da0e4e35309be520e2e109e17a1cecb892b96598f6",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "b661d2bf35efdd264f32a3bb254cd6443e8115a297aba1d31610495d7c560dd5",
+          "result" : "valid"
         },
         {
           "tcId" : 88,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000000",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 16",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00ff00feff2d6c62a47883c5899cac06b1367c21948689d522674a60f43f4b808adf618b0b",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "e818ea3c65c24330b7b8894680fe349b17f450e9d878292f1390ead78085ed1f",
+          "result" : "valid"
         },
         {
           "tcId" : 89,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000001",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 30",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047fff0001fffc0007fff0001fffc0007fff0001fffc0007fff0001fffc0007fff2e2213caf03033e0fd0f7951154f6e6c3a9244a72faca65e9ce9eeb5c8e1cea9",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "55d0a203e22ffb523c8d2705060cee9d28308b51f184beefc518cff690bad346",
+          "result" : "valid"
         },
         {
           "tcId" : 90,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000ffffffffffffffffffffffffffffffff00000001000000000000000000000000fffffffffffffffffffffffe",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 30",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048000fffe0003fff8000fffe0003fff8000fffe0003fff8000fffe0003fff7ffe1d3b684a87958143f250bf5a2f7859fd036620b4dc18dacd1d0c8c42eeb2e54a",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "50af11f10d130df5f9adcdd0103ff3d42808582487330932c2546022bf7c6a18",
+          "result" : "valid"
         },
         {
           "tcId" : 91,
-          "comment" : "point is not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000ffffffffffffffffffffffffffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 32",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000fffe7ccb5c10c028f331230dd0a005e9faf37864c198c5bf7d91bdd71624520d4b04",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "ec90224ee61b2ed7cb6b9716e248aa099dbf1eae41d1ca477e8e5ba4a512913e",
+          "result" : "valid"
         },
         {
           "tcId" : 92,
-          "comment" : "",
-          "public" : "3018301306072a8648ce3d020106082a8648ce3d030107030100",
-          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
-          "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 32",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000ffff0000fffefffd620bbe0a621748ea2b0e0dfa463169e7c805412f4374dc9755c4db93989a7529",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "cf1acfa0595265623fbfee5d8498e609b6590760d1b04f31f3470cd1af3ba9dd",
+          "result" : "valid"
         },
         {
           "tcId" : 93,
-          "comment" : "public point not on curve",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764c",
-          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
-          "shared" : "",
-          "result" : "invalid",
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 51",
           "flags" : [
-            "InvalidPublic"
-          ]
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048000003ffffff0000007fffffe000000ffffffc000001ffffff8000003fffffc0c3527bd081c1c07b313bc1a0c3f845fb2fe22557699ccc8f1354e61a27b7f88",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "967e55f853dad60f678bd35a46bd3c7dc6cf7d18526ac0890af80ade84461005",
+          "result" : "valid"
         },
         {
           "tcId" : 94,
-          "comment" : "public point = (0,0)",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
-          "shared" : "",
-          "result" : "invalid",
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 51",
           "flags" : [
-            "InvalidPublic"
-          ]
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047fffffe000000ffffffc000001ffffff8000003ffffff0000007fffffdfffffe232aa1c67f77cfb00e73898cf431831073c6b2a4bfa1135881a0595720759ece",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "f21a20024d8315ae877f90af5b0c68b6a50214fea797942870c35f4ca127e591",
+          "result" : "valid"
         },
         {
           "tcId" : 95,
-          "comment" : "order = -115792089210356248762697446949407573529996955224135760342422259061068512044369",
-          "public" : "308201333081ec06072a8648ce3d02013081e0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f50221ff00000000ffffffff00000000000000004319055258e8617b0c46353d039cdaaf020101034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
-          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
-          "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
-          "result" : "invalid",
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 52",
           "flags" : [
-            "WrongOrder",
-            "InvalidPublic",
-            "UnnamedCurve"
-          ]
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000003ffffff0000003ffffff0000003ffffff0000003ffffff0000003ffffff1582fa32e2d4a89dfcfb3d0b149f667dba3329490f4d64ee2ad586c0c9e8c508",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "06fa1059935e47a9fd667e13f469614eb257cc9a7e3fc599bfb92780d59b146d",
+          "result" : "valid"
         },
         {
           "tcId" : 96,
-          "comment" : "order = 0",
-          "public" : "308201133081cc06072a8648ce3d02013081c0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5020100020101034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
-          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
-          "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
-          "result" : "invalid",
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 52",
           "flags" : [
-            "WrongOrder",
-            "InvalidPublic",
-            "UnnamedCurve"
-          ]
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fffffc000000ffffffc000000ffffffc000000ffffffc000000ffffffbffffff73f471909cfde3db2c13523bcf372877c28d23ed1ff6a3326df6bbc4b756723e",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "2e83d496538e7bd16b530d93b960317394b5f8b9da5128a03d08b3c8fbb46561",
+          "result" : "valid"
         },
         {
           "tcId" : 97,
-          "comment" : "order = 1",
-          "public" : "308201133081cc06072a8648ce3d02013081c0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5020101020101034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
-          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
-          "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
-          "result" : "acceptable",
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 60",
           "flags" : [
-            "WrongOrder",
-            "UnusedParam",
-            "UnnamedCurve"
-          ]
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffff00000003fffffff00000003fffffff00000003fffffff00000003fffffff2c63650e6a5d332e2987dd09a79008e8faabbd37e49cb016bfb92c8cd0f5da77",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "e3c18e7d7377dc540bc45c08d389bdbe255fa80ca8faf1ef6b94d52049987d21",
+          "result" : "valid"
         },
         {
           "tcId" : 98,
-          "comment" : "order = 26959946660873538060741835960514744168612397095220107664918121663170",
-          "public" : "3082012f3081e806072a8648ce3d02013081dc020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5021d00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2020101034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 60",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000fffffffc0000000fffffffc0000000fffffffc0000000fffffffbfffffff71664ef90d87525ddf7815e676ae3b96c25ed9e7bdaa05da96227a1fe38c3d11",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "bc0a152832a8972bbeceb522e661e5249cc7455bf93cba324e810ab62a2e58c1",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 99,
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 62",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ff00000001fffffffc00000007fffffff00000001fffffffc00000007fffffff5df80fc6cae26b6c1952fbd00ed174ee1209d069335f5b48588e29e80b9191ad",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "f503ac65637e0f17cb4408961cb882c875e4c6ef7a548d2d52d8c2f681838c55",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 100,
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 62",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400fffffffe00000003fffffff80000000fffffffe00000003fffffff8000000007bc25fb4d2b4cd12a16515725d64cdbd5bc86b7f84ef005c9e51d0700a3a4b8",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "68e8765c71a63f3458e8edb2e52f499a1de13ae1ff1c95f18c4adad9d898667a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 101,
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 64",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000ffffffff00000000ffffffff00000000ffffffff00000000fffffffc4de9de6942e770033f5f1defbb36249e6bdf45a33e2ef4ec75a7ad880b5432c8",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "4060db7a9bf8ca17a5ffa614a85f9a25ed6f1854dc0f2396b9e8439ea8807a55",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 102,
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 64",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000000ffffffff00000000ffffffff00000000ffffffff00000000462e0f7377a81a3a47a28e62dd8105687e457496c61fdce49ba1aaeefcf10b44",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "9e6b02ef374c5b7c8d1021d1e0520ef5f6e3cb7e454d6630bd270decc0343f1e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 103,
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 112",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000000000000ffffffffffffff00000000000000ffffffffffffff7a116c964a4cd60668bf89cffe157714a3ce21b93b3ca607c8a5b93ac54ffc0a",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "516d6d329b095a7c7e93b4023d4d05020c1445ef1ddcb3347b3a27d7d7f57265",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 104,
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 112",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000ffffffffffffff00000000000000ffffffffffffff0000000000000012a69aaa5d3ac4cee07592ea0989dd9f426a0e4d16807b6c6d04baa628a659c0",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "e7e84fa13b2c443d0a5c3ea60cf87e772c7faf9f18ef5a0d77113dd6c92c8d17",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 105,
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 128",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000ffffffffffffffff0000000000000000fffffffffffffffd137bd006820a8be23475ea25d8fa05c8ed47fca1236cd5d1f07667db6fcd2979",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "6c7b3006dccdb0b021f00307200793374419358b1367800ace76d988b10ff699",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 106,
+          "comment" : "ephemeral key has x-coordinate with repeating bit-pattern of size 128",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047fffffffffffffff0000000000000000ffffffffffffffff0000000000000000322a5313a994312a3f047d5a9c6cdeda173f1d3b35143b3b1a594f7dbe544d0e",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "b522e81a22720c57040f2e02781728577cb5603ea280be7a1c84750e33d7c963",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 107,
+          "comment" : "ephemeral key has an x-coordinate of approx p//3",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045555555500000000555555555555555555555555aaaaaaaaaaaaaaaaaaaaaaab79dfbfa5e66fbea30e75ecc703e65db43e027416c01f6e20fe129be0e43457d8",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "f9ee8b2b668e2a76ed66dfc57006b6403ef8e388c066a0b0493ee0425f8dbe3e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 108,
+          "comment" : "ephemeral key has an x-coordinate of approx p//5",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004333333330000000033333333333333333333333366666666666666666666666610a4ea9bc365e1b224b173e9fd688a5234932ec90a5cb9ecc0a22a109927e73b",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "1b78098993807e9df54800e2c0f836ea1c4604f7b3c9401311784f69ac4657bb",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 109,
+          "comment" : "ephemeral key has an x-coordinate of approx p//7",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004249249246db6db6ddb6db6db6db6db6db6db6db70000000000000000000000005ebbe906d14cfa3e7e90d397973f093a6c678a23bcb2896189ffece5a1ca398e",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "7ee2972f263079a49b5bfc664bcf42c2573af3514340e8e726e08881aa2d33b1",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 110,
+          "comment" : "ephemeral key has an x-coordinate of approx p//9",
+          "flags" : [
+            "EdgeCaseEphemeralKey"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041c71c71c5555555571c71c71c71c71c71c71c71c8e38e38e38e38e38e38e38e46ef488581fbbd6b4ef78d03cdd161272243fdcc10979fd8e8fd199b98a63d378",
+          "private" : "55d55f11bb8da1ea318bca7266f0376662441ea87270aa2077f1b770c4854a48",
+          "shared" : "7b5020080ce9bd76083ff132dc28ea996314be1a4ac21f987fbbe859f902fab1",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 111,
+          "comment" : "edge case for computation of x with projective coordinates",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004851eb1b8699d1cc01c6b6048139797dab3981c924f9ef81bd1f464c3182c870901285b2ae7cbcabfd5bccb9441eb3376b491595f60a1ec21dbe9f972bc32abbe",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "6d03fef6b354840f4642fba1c8fce9f7d1cda8ae27b6ca01510fb44573fdaffb",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 112,
+          "comment" : "edge case for computation of x with projective coordinates",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f576e22747f6c77a8f685a7a7b527363e0fe7d351a9e3f5923fff2bf97e91af41e575d400331cfc9f97180d8a48c418c5a982609fab88937d2590bfdaf37d6a4",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "98009cee0e8ea4fb42dfb70a5ada46ece32e2885a4f9c3a6afba13e82f87e113",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 113,
+          "comment" : "edge case for computation of x with projective coordinates",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004310785fa42c37bd200781d70e3859b39b2fa1d286a3b6c4f605a41e045634b81b8d32564a7a232c5d47407a7795c01eda819f23a5a190149eb8c9abf94ed7c49",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "e8f0e427cc30ae50197d2bbf3a451667a470797d5abe55ff1b1d6de88e41372c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 114,
+          "comment" : "edge case for computation of x with projective coordinates",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000481bfb55b010b1bdf08b8d9d8590087aa278e28febff3b05632eeff09011c5579732d0e65267ea28b7af8cfcb148936c2af8664cbb4f04e188148a1457400c2a7",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "b485f3364354b738dc5402729b880c90c502d9ab52ccf81e3d21602c7b9bd909",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 115,
+          "comment" : "edge case for computation of x with projective coordinates",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000402495ac9f43e45aae30d3366e351cc08828cf3e11cc3b7209fbd1730c4a14f4e4aaa98dbe0d94caa44538fcf7949eb44debb7bcd228a54d9cd9b3c2eddf94611",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "e5781ddaf18dcfc33f4879a2660b7a32a599fc32ea5a1beb28a48caa3e6ec7b7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 116,
+          "comment" : "edge case for computation of x with projective coordinates",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004efe7754ed4c0b3c1dd301bc1ed69800aa2ff5d51fb85937715e60d2e7bcada8e4ea7e547a04c3869106b56245c27da9737b9e8160c05fb0d86040276708fb9fb",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "b5a0ec92aecc3010d27d2263d3da66e3d2f3395d23947024a3f4744454622027",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 117,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000466aeda76d73983caf2de921af389268ceffd278fb9eccf928702b1f4271b43f1d646d6cf8bc11a0ef97cd64c08a11f72f94af4e6b3c9870b8eb3a5b036c04fb8",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "8462e9df7960ece33089e5a98d61da4faaf3660f93d75f7cc5e397b64cd1591d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 118,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f483602787972cf7b7582d8e2f2c7998e537ca57eba69718b68d96240f035b1b55dcb4f7be7b79c469ba8a0b104900d7053ffcac04f394be925fe0cff2e969c3",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "d44d05d246e61892c1056e28865f60574dbeb6be62680776a537b0b2c3e6b4dc",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 119,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004579be77fa6698c4baf0132d2f7993ed76dfd36d78b584605e1be024595e3ad51c069473e1b25fd94a42b68ccb3004a851593a3af78f922d90920d8a877c365f3",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "0550ab2f9500b8580dad07073506da9b2db71bd974a85f81dfd148e260bc8ec1",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 120,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047f8128d883be31873efedab699206f889b776be270e163df43035409fa5215f1f36c3581f8f8d569a4323f8700ca09792150421521e2ef0a96ae9a4caed0e02c",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "1312f05b3e5cae60f27c9485cfd00584cce3f961fee2fdf103c32a79ba17ffbb",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 121,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ee5d94bfb5db9cfe511a3aa70bafc93db93107383c12f5bebffd90c621a2051db4fce13261d54ab29c3c699b77358edb54c71801f3fe2a0d5cdf2ee3f184b4d6",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "be4792922519717e235366d64709c51b027d440c6fb8c216fbd92498aaf71277",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 122,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040ec4f8845226e864c088505d721a2155190d4caa9a1f5a3f0afdf2ff49cf6d8bad01fd3808aa03442cf5396e10e13efd24cbd5a52862822eb62dfd27b5040600",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "05a2ed58207e0d6a99f37a6da640f8b3b1acaf0c16826bc4fd1eb1e2a6a1534c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 123,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043107892f3427842c8d6aa60afb1d3b1441e28a67f10e1198a07265125bbda7e2ca9d6df758904f2207cddb862806af0b8cb66ad72b161b4dc959acf614fc2f90",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "def48de01d86d7260e5c2a6439068542437a20b140dcd45623dd1ec0d1394742",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 124,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000409e5c414b7f5073858553b8b8b4295488e3f3ab966581f240a6124251512270f8fc12563fb9bd6f97b445417cfb14cf9944bac1a26c176b532b698ea8c1bed6f",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "c06f7373e67ee8c64dd86127fff8b2d23d284420d30e571a79fbb9b54aa70dfe",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 125,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f93b07969211cafc1a30c5c578c8bf35be63a04daa2ba434da8b5e4b83769ef554b022e4f7f406bc93e71a8719ad0ccc392755ceb274e248829a72540e95f169",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "7a966ea1fd7c32b1fe01eb14b50d835d92c31f0a4204517aea66939e7106cc1c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 126,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004513609657f902924e921dab1411685316b41d2bfc0be53d1de49db9c1ca78e55141d36501aac4b47dbf24fad43e47bac111596c05f66ef69258ddf0227e8e7ad",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "27347a05a945862499ce29fa7f6e4b2c496b6984b3936db3da2a5b82c4fe6302",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 127,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000493ebaf5ecc0aa486e7e735130611ab5b165fe395a4f1ea8f82097ce422f44202ae855c1eb4c334f53b87e426801a0376837db2c86137522894ef6d9d69520163",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "4f04382598f2288f95fda3657d5e517b5f8885f2257d12b3efabb624ad5d2626",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 128,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000411fd00b18efc4efa07e87878b5df2e7a596f93b950e50e9adda40d4e6ac854c0cc47edcf533fe03a614c03a709c9d0c0cf8dbfd4e2140b5b2df23848b49548c2",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "3b50f822d5c9311735fdb358e8c6fb2e4aa695656d75f84f151cbbdc40f7f259",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 129,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004501a72044f83c517316628b0bc9d89ab82131bc12df36c7a42b952d5bc23c85182ba2906e104dd0a7eed7b0b1772e12b3b3b7f40a2df049174fab09a02a1a5bf",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "ac45cd4afa8a5e4e4a0e3f60e7bfea0b759875781aa7722750022e02b66e1303",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 130,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041f3d7d05b846eab4dac4db695a441f194c226821f5429f66aba4ae0e6ba5b90400334b91fd4073d1b7c354bd62f6bced7cdbbbd7c2d392b03ac1fe52df084069",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "8682d123138dbb4dc40451478b078596e5b19c8b1b5c68c2a8a3b046873bfe6e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 131,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000411ccde06e8de88d192897fd0f7bb5896553a524df319e4594a55623bc76462e122a170de0b9442314a947fbf5e035880b562ef88e3ac98594f48abc63741337b",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "246a119990f295924b62b290e591f428054c2d34314c54ee50dd3d85ed5516be",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 132,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004594b085272f89fae6813fd3944baddbb9f2b18236273cdabf3e607a73714a252956035b2531b98fdafa63ee7e72752ef03caa9ebbb1697a18e6d31e149485e5d",
+          "private" : "00e461c5b5e63d75b4c8c123bf8b9cd45e712af08f7e2e494a8f255ac9d80e058b",
+          "shared" : "343c4a2c74e9416b07c855c2ec5ab053e11b51c47389d8455d6175e24f513717",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 133,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048238f048c292e08d49bdb5dab1f08da6d39cdbefb1d75e03e76048b903d6baf9c761b25afbf041e0e65eb9e013c336fbfc364134355fd10a86c258de3e19a857",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "81fa8ca50ac155200de410dfdfd8093037674baba7ca102828a5d0026f24f0f5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 134,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042d08cf1230463b7102e8a54185986a62a3f2520c0c151ace12f5d073a40cbb2fecb8c2ed0a722185e987cf7c32acc42133f6ddb7230ea48dc0f7c6b5a43a4c0f",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "151411c3b8e6d25c515186c1d9b9c6e1a05da5a7f09cd4ea8844e0916846ba48",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 135,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bcd1f2a75eee0baf7e0f55bbb1c876966d9d5d21f02a145ac9668491e4ca5e511c5be74b4082596f2c6cdbdb6cc9083895f333cee8075c2650963e7e727906e6",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "f72d64d6b5e38ae223c77ad3467818f8b03b9535011400157a5f426c4a512fa1",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 136,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044700bc548e9d6256ece382112b93f8780fd2e427f690c35bf31f682284119c725ea408d7fc6599bd2b0e754f9de166ea47a4e48b14925fa7bb635ef09642af05",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "108a89a0bc8e1b85981fe4853a86a42648ccbe6855dda1079136db8c59fc2065",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 137,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a0b351864a8c47ba445634bc107fed06451f97391c55921db61e74ca527a6a45fab27b1896d52df4611f627414c48ba7a131766002d5523ff883a499769a422b",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "7d362a6e1f00e525fbf012fcc9da98e09ddc281c143f1e023fac6a6b6303341f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 138,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041350cac374bb076ee89eb8af43d076afc7312021006431fd909d22df064f6637244f236a65e7c1c778f6cac2d9b4ec3bd999ac185797a227cf00552d6aa5163a",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "1de1656d961de1f584a2f7179bd3be3b4a282cbd3248f29e74b73a812cad8d90",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 139,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c185508f464f67aacc24fa859e744fe57c3ecef2fa911c16dd2cbd073b308aaa8fef47dcef6b0fba6205f0b7e23d17758f1df5401cd9a39de42b07b92d153625",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "56ae038f61abb293f43328a5e6e40bdf73f9e7d5868e5bf1af3b03fafa559e86",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 140,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004dccff194a9d307b5900a13f2d7a192f6e82845af1007c951b5b9720bff98d0a028fb8ba9238ad537e0d7f31444086611430abaea547913a0591dd908ecd864b5",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "c75eb0a2cd617f0117f1d9adc1056a0252a0cca0b64b373bb30d5231380415ca",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 141,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040cb05cb7a4b01db1382620ca756285e1a7c6846bbb595cbbac9f89e0a62489cca88829c95f6b2e8187d2e1c3a744f41d3ebc98fa01748b1248462b350256a5e8",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "010385fdf7f4c6402ae432e4b2f11f2f861c75c4dd27b4f35b7f1efa94bbeecf",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 142,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f95894cfe4f14ccc483adf9cdf106709e3eca5ceb20e7c145d3bf18b6aeaa8039c42c0c8c3db57e0bbb2593ebe088771ebd0e2857fc2a877c3748adacd038542",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "af116b172237915370625d3ca7360a6b6d651c573031ac33c0ce4b72a9427a7c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 143,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000416a8b93a6b9529b5920566131a792c554ac421af3a4bfc341408d14ddc8971c5f60ea4663449bf3ec747481d730c4d97a1565b5bb207e27e55aec88969f2023e",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "10c3a41e0a1d0018444bbc3bcf76b2893f66b69cfb046255c82a17ffa3413246",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 144,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047d9c0f7a011de080da8e6e225f7211e729c29425c9dc9a289d5cf8a0f63589aa129b3bfcb433ff084409e32f73741e592913003367123b3e6ec4b7fc398d1b29",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "2695b4e4a5c648ec17905e69286b6d4935a21772f5ded1e55136cf17331de9d5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 145,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fea54580f4096299c17c281a3fcf6738226b636c85e8efd360a4413848b07881fd47181ae8c3ad8948f65d8c845a863b2f86a6ce8aa37a5e5c20d3e96fc9c884",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "a6f648ff3373f9433a21a38829a5667ccc2b1bcd3de13516537d6d9b77c04044",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 146,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000408beacc04ac27e3839ce74d515d238aa98e1aa1b5e580fc5fae0116e520d880cba0585f723c44f243813b07e2d7626605ee5861523d1ac075479da773efe026e",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "e1db68841b6000deba2e9a666ab2cd227fd9f33f69187b611dafec0d6c9b6e7e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 147,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048cc2807089ccab7bdfbf1697f153d4eea63f3043ce63135f6b906f8235f76bf99ebdb2c26b09f49b122d1ac73a8ba37ce9c385c0269c4e40ac3a9c20314a4437",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "36648fd5e125abe08ae21199d08eb78eb7e345a1fb3b26e5fd25d3c1e96e3bb5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 148,
+          "comment" : "edge case for computation of x with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e854fed884e6c76277af9d8dc83df66b81478a8ffff2c313f22abf0f8d4442f50f57244419b2075ce2b282440944213d87c50f58b9e7b71765d45fcad152b333",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "418df7a1a6315f55104b5b9f96da454725f59992c588a531e80a4744b8d7d4b8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 149,
+          "comment" : "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c1f319279a7bae9f3dc527c42308a7a6255763cccd6f24d266e75f88eb4d022f6b3a3cf14ed3b5e6915ff322b705b175da07223cff4e9ad4520dec7028e1e396",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "32dda9876dcac25c58543304a2cf6c1b31fdabf3c89e43d6eee628a02422b19c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 150,
+          "comment" : "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044753ee2e3ac201e9a4bf25e31513a45365b5d0526dcb2e0a88736fc8ae2681c1cc49b1e868d4de224593ec7e00e9f2c209f3b935428d3bfa978f74869af889e2",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "4c54d63b14b8ff10b653f663f3230c1827d682c833ead1f44ad6ae8e7df35e2d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 151,
+          "comment" : "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000429c1e774c9d3a8930df8a663fadc8b9a6092d8054ff37adf598edd78d0a3ffc57173a3594be68b7ad191e0ff27d79eb4e7bb22f1090873cf307cd073b27368fc",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "4df3a98474884b1c3c78b6c81e4f90d53d8bb4daba4227c411a5747e6aac8cb8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 152,
+          "comment" : "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004893cb0c308aaa2092d9af93e0f02cd951ec386e866480eece443cc89e672733ff6c6f43caa1e1d168ba3ead9ea041cf4f227d76b90e9e25f497f2ece8935512b",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "d2aa087051fbdc35051d21ff415f934ab5698629abde5d4b39f2f6a76e3992cf",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 153,
+          "comment" : "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c5a2dc340e0983aad4f895bf54be9d9e176d6ba1ba6c859ca0851889a97b7dc5c90dab79207b861fd996429639cd8f31be0298b63f4934923a483a9e6f7c5ab9",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "ac7c60651653a4f3d4478ebb9aec4381183ffe1b152b6643c07c47c0b2a489cd",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 154,
+          "comment" : "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e9db2cf8037505fd8a8044f4b3f80f67f9688815c69c788ddb26fcb3c84cb8adf02e121e4020424c6d8f1d269c00f2a7f23a59237fb48a5ba17ee57c1c264282",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "509d06dc43813dba9114c13c337bdc0bccc2c7dfa7a7d8960e5593c52849c855",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 155,
+          "comment" : "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004776aef1acb82b628e132cc29440988f0a15d4cc2b4f328aecb063c9b86e5018e91bb2038fbbb05573b1c943de8bae0853d6a934d4d164429aa145d68e9c2e0cb",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "28a88b6b258f233020ba6fa9c00d1d72831f4515b86966a9782f521315e18aa7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 156,
+          "comment" : "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049ec06b0b08662c0e1dd9111696a63a1601cc83cee20695778adf84d43064fc90ea9ffe0e7b32c3e30e5f7809d9acc49a8da7b77742c2a3d3660f1cee1dd4be19",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "c4ff865ff3dc4953ea78d92a02f3345a53bdb6050cfd8f41baa4395ecb6acab8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 157,
+          "comment" : "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fa51d128adc2000f09ff12c6fd8e25aa08556d708bf6b0ffff9e8eaad4783f0d1dd40ad51ae91e0ab471f2f6067052b1afe96a57cf5e4ddf899a6258f81c332f",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "de1069f051637e10166559cef44688afc809341855261215c4f381d9d7da76ca",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 158,
+          "comment" : "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004614dcfbea4789a3f3eb4a8e2f111c887f0248d9316b99d0864c927a045d69417ac5f8c4001f7b6e67faf5b2692f745b86f51e725c1080f15330a631ef6a503ab",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "4207bf4159faa0e50ed238b9c0ff46194a539a1ba03a5a4c8d68f369aecd31a5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 159,
+          "comment" : "edge case for computation of x with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048321763f5533310a4779e83a58ff110480394690f7c2f65fc229c1a58ffbddc86d170141a108fc92f2bb96ddcea0652cb650c5e863af9289d37ae87a29022d9f",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "7c8e29caa01e9f325e1e70d71a59850749239adf4e1b8fa5d6d0abd70c83afb7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 160,
+          "comment" : "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004aa42c977da1ed42e52041c0af2c090f244b22ae354cc9b10781e44c89eebe336f7100a0eac8b55513ce57a8d0c195adcf50d1b05fd35b0576cd92805cbab4c1f",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "98afbf6e00eb004c79657b40b7105f8526b5205942af2218f453bc26337306be",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 161,
+          "comment" : "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040730d77d9114d5610d49a98dc196ca9e1e8fd2abe007da96b574f736bf1939258c8814055a774f7e79f7b4fb9cfb03d839566afc6059311f3d55d49ca4ddab31",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "c537409021ad95646fbccf9232ea47fa764d12db7595f436a65ad5b13cdd19f8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 162,
+          "comment" : "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000485a82fabb60c7664e2500c59d0f24eac1aab0060c07b49828c55009fd27aa49647b85f72b467bfa2fe1b13258feb121aee75a3155b30e8b4b566b610f13b6dc5",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "ad60146b1cf2d9661884b9ef867cbb09e42466563936b03174efd8517ca8c6e0",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 163,
+          "comment" : "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004833f2a6e5c76c3ddd13a106cee4aa8b2a9dc32e0bd7bbe2a6322abe0ab4110a2ab93845403808a7cc8e8b65fa42da414327ec3a19d539fc033ba8d8aae7cb23f",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "f677a03d68570cf6083a1ba415b40b5f7ffdace4eeb804983cbd03b979d939b2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 164,
+          "comment" : "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cf8116ba0901b0b95308bc686fed90ceba0e5d424c8ec206cab8d7cffe93fba2d5e7a62cdeab84a20fce37b5b0ac168ca2a85a1d18cb04ee48deb250b54691aa",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "30c9fb67a3db93a4b3a54135d265171a14a2a0a79cd715e13515510793d8d081",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 165,
+          "comment" : "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e754cdf8e56944d5bd36d025b1c0f5fb2754a2eee0fb5200bd169cdfc83f07c38f2b7881de647c2c66294e1adf767e515adda742d3a863f0cdd6665b964e60a3",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "8451f3414247058c32b53be128cffd2f2887434ab902b67b05fbbe7aeed8cbd1",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 166,
+          "comment" : "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000474f1feb9a641fd87a49e16fbb1be363297ef971213bc7d36b6abbf29d0e88ac34b6c246b313be6c3c9f33defd4ade947af547168f7c22278df8cb7b06a8018c5",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "dd6bf055a9e431479707e64590fc58f97ad3238d063ce8f66d5d37b2e3475638",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 167,
+          "comment" : "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049368066a0748867a7b870244f5c9f82ea8bd51552959dd550bb7394497159a5dbf89b521e51db372c0bcd11fee41682cecf8e702f5956f1274efee4dfcb2f65f",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "4529f4b631c9984ab216a6801281fc4fd8731a58b65ca8d07bff07811116371f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 168,
+          "comment" : "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000464e5d7b0f7fcf4c9c16156cb8745c43995f823e7e10954131e61f9fa09059e2c2f7a39dd0dc6e8a9bb7cc79d821e7c749963dd97c7070129db638c0dd1ba053a",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "12aeb42630e4885a93cac090c66479d011a1fdfaa46c0db33e0fd51e1e573cd8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 169,
+          "comment" : "edge case for computation of x with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043da0655a52e3d6857a39faef864cee42f1816bd8d83af8c657990846821f00228f76d10162e295fd7737d0d22fafbab24d5db0ff432b51354030e1fb09273c51",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "ad8deae400ae52dfc8d5ecd3518d78c789b3ec88cc1ec7719081a066def26c4e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 170,
+          "comment" : "edge case for computation of y with projective coordinates",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000442e831d5dfd2b9f5387263cd686ee03dfa235cbc07f6f3a87a7e8150556362b32be47f8e3011572855ca487ffb594f7722ef9fc3292902a23146c19bbf6da76a",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "e6d3991eecb1a4b78aa700ea56934a38785b3662c59766e2ee5b157f77ecbb7c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 171,
+          "comment" : "edge case for computation of y with projective coordinates",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041321838efd80e1dd8e4d0d95d17895c7dc60303a5c234182b592d9d21ef14752a44eaf3394c63708763f3b97b2d2863fd3b77ebda44862c7c23daaa437d5fe59",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "99bfe73eaba2599e79307488047236de003e9fd26f5ff1dbef62b3fec75fd612",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 172,
+          "comment" : "edge case for computation of y with projective coordinates",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042407bb2cef161472cc799db14e703183676f312c571e9f3df137f55df9442c4077bf00500aa7bece8c1f762ff08a0ec71bfdadfaf13380704e6202de62c5f22f",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "faedeb03f8b5178db58604ab69b10b176e92c5deccf4249a9d60010dcd16a635",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 173,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042477b9ec12029a86f50cd95dda6cead7a34f1c2360f39e3d1159793c8ee663a6bcfed85bd19d4ed3855807267e39156413b41e39a701d8d17a23ac685fe5360c",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "47e5858af99e4e916054897807d685c8cb8b0f1692ba782bec2290a58248c683",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 174,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c829d3a99bb47e4256fcc63210c13282ab59e7aae90877b1797bd699d672a38b8696a03730704204894aa967273c120b57cbb71f9fca62c64f692e7f49598d2b",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "ade4ff3437df254696fb2b19f5154108d88e775e57d345bbf57a02b2abb3f07a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 175,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fd61ec5552fbb24b575ebdc9d4a443e156bfc0d13c9dc611149e21d79c48c444b7b73a8dbb83a5e2267a8bcd398b10af0843474c750265e9d48d04ac4ab60405",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "598922a353fe1add65ac8f66fd225e826fa8ce493470322593735fc6627e6f2f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 176,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049cd9e0f17c11a10f8aaa1f47ea7141f6399f40b079b07b14cd388f3b6b0a47a8efc86998f717a83e53c8e58ad23c71d0ecc8bc841bc16ff232a5e326844cd4c9",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "923cca706deb11de7c17f8dc089dadcee15042d5619732d9ea537f7dd993fc31",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 177,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043846b407782243fdf3b04042990b16e2abdb325ba098532879d14e16e914c274de571bc4ce2edd7d2d37df5593959b5c7ab59ac8fe5e06c44bbae6960b6c2510",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "bf6234cf4de2040548dd0ea2a99310389db48fe6c0eb81395ab2d42484f841ae",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 178,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d3a07a4b6f9b660d92b3fe937e2ebf91dda8005a7ffd0292dad91d0592f1a89ed7209513bde00287b8234e280c00b3c59dc5e333c8c56864bb6cfb364e3f2d85",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "da223bd733d403e2f2f9f59ff712230b0ab7feafc87dc7021644569e3d513795",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 179,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042ad9550728f65b142ed676438bafe80e365cff4eb557526560e4adfd696da778f0f01da8e947628346614ed7fefe24901f9eee79de6dc06d85d563722ec77961",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "fb888df1c34b3ff15620b94a20726954eb7989e6f8a266ee4902f45e7e86e21a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 180,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000419f5f0b4edd6124e340adbcce791b06d14054c7eb1f9914b44245c51d6c1101d82304d117f729ef06d97eb56aeb99a6222dc3de5e30c071956fd73ee8cdbeb81",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "c656a27fc48053f9bcfa3a240f904be76954cc8b8cb3f4790613e618c5069ddb",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 181,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044485dc2fbc68079c357a04daa6d5306cc78827b0fa64935747b98123009b26605258c4a5608315007db08c27ba86c8971bddc529d1c14e66478ef7fd92b33ae0",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "59e168701d9676742fd203e9ff357dfafbbe51eccb2797f7bb416d4ae21bad99",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 182,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042f98fd0dc4b37807d9b1dd015a08a90dc90c088014d1305e49017b60d5b07e0e1e8ec878731277193c54991353d1a424a1153b87bf2cf25309c74032fdc73f95",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "7f19652f3077e73a9677fee21d0cbad29914e3bb0270fe77500c4c0a9da8eeb8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 183,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004df1a499387ece423215b041d19076b61902d31bec5135910b90d8819df3bd2fe9a9bffe9f1b68acab7f57f9a19ca5820389f1d73533dd73f6532d69652336fb7",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "b1c79105ffd4b5f4f92ce3a5f55624fd2aace8eee3b80f5438c8419c55051a7d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 184,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b8c2c47d8c6dd3bdee17a58081cba359e86ef4e19b368d46ed5e43fbe074b08c9b3031b7756e746099d22c985e9fd6213519186acb537fe4bcdb69f5f3a01968",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "e1f33be462ded1d121dd2a15d413fb8b9a105922cb90c550abe7ddf352266c75",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 185,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000421a34eeb4e1e2ed7e4546a8144a8d1c83ed64f3318f72f7a2d786316bdb5e97412a8cfaa2fac8629fa7e20d9229f35662f5d05ea8cd38836537d16c1a64605aa",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "04b295929582f1a5273346623d9d07fa43c654e9b1564244ddf82d61793fecb8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 186,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047e9906202cd1abf7147027c8647b3a5816b363266326804d6d596e875f02e1e686a981ef38871ad59f427815cedc1aead339c90d61da12b0f7275f4084761afb",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "bc33390ac64b082bb0f2ec689f239e5931a54483e7acae90442a9401c3645223",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 187,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bc21004d799ecb473253e3ed07b4aff2d3ca90f12943a76e9ebdcd4931c438eaa9b6e2c6834bfbe56f4c4e5e22b125814d83f2973dcd64dc7f51939574002fac",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "5a0c1a2a33176dcb56645a3548ff709e31c37067e5ef969d230c1b1927d75d62",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 188,
+          "comment" : "edge case for computation of y with projective coordinates in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ca6b6e4eda95cccd6cc8e16c3c6c748e2acbe31b70529bcb69445c1140e63e2583cf3c33723659b2e303051c3c1e9f702f9f27421f6b3457e377356018489b46",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "7c6a5a4a5608ae11acda6292f6d3b05b7153877dd6e1ad914ff5e3550f457661",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 189,
+          "comment" : "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004884cf0d17df4ef5e488d725b47d069cd2b99940b05b26efcd55d0e5ecd205b61e3b191a7f9f920cfab05b0f9cddd02fecf857d0e405ca36f0106aa367d492460",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "d990ca49c9b414818622b9c69197fccb197c94bd1ce13c24110e94c5c321e2c9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 190,
+          "comment" : "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b1e5aec6272dbb856417e7ce6102bace3e0dd7c32386511e065c1a32d5688fc5c078aff94b8eac78bdb54b210bc74676d2336ab7bc7236808291540f65c82982",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "973af53e8a92e7469856265229acbbe0adb5574beb32ea6780be385b28ae8b07",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 191,
+          "comment" : "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ff8d38f61f633c5eb570ef877e61b4466b511ecc3dc3de87e6224a8c78c0893d7153d4f87b7f9d0488b6588df56c9934ae75d1486c1ebdb49444bad832d08017",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "d9fdde34e48cadf6e63c1de84b22da7180ac644c42c055d28625b2bf11cf4951",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 192,
+          "comment" : "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044c381ef0302e1b428f4887f7b4fde4960245920f40c4005669a091644c27482bef739bc3a3d22c6e707557f2469f504aea9e8a07591776b3324beb5c498e6f55",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "9dda17a91ad44d472304c805b350f9ee55de2d94d7327160dbc50e2eaa85e4e8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 193,
+          "comment" : "edge case for computation of y with projective coordinates in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004245a530c56d07978f91177e8d97cb1368546bafefbf8148cef339fe7bb652ba5b27a60edd2f498ca636996a9e5e629d5c9ec203217c1b5402ff99a0d2fa97cad",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "7a69b8de61da48f9901ff440192fc90086c3a2bb56bdb224a55b89cb82c72162",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 194,
+          "comment" : "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043cc566a230b3df272a172cd80fb481cfdb8dd1c27a84dbb7a391f11484f14ef99be9d4cfd33748ee157625f809d0fbc1a6f0317d97dbfeda4999742455fdf78e",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "76a4006db3de3e098936d004cac1f7af41d515f753b9aa4433eb2466da42acfc",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 195,
+          "comment" : "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004455fc13990663bf24cf5908c59e4c3a084fc39ee1a7b14d812c227a8dabd6f94685d00ad604b206d59b2f4d9a75442083b85a316dab78574a3bbaa6259e89a3e",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "3be92a857ffb42c5d5c128925b89aec34cfe649920dfd647f0a03f421fb20f09",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 196,
+          "comment" : "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f933578fd1938e44b271ae431ffd0df5548496945d91cb8d311ebec9dd50d036f3d88fa2aae4236cb08858158d725e1213fdb982503bc910a5b58366cd85ee0e",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "19e0d41257ccbee1c453f834fa5f349cd9bbb98a92e848354a7579dfd2c78e30",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 197,
+          "comment" : "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045606cbf0c5b52f0f464137d0133559fea50af271a9826ff6125746636d981850d7b10dab8e64b2f8df6fafb8d5943e7b37c6500fa95bfd6680d8f2ff74c4407a",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "3a7a54996053b41361b605e73852a5a0b17d85b42b3c4a6f119c6c87ebeb9f03",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 198,
+          "comment" : "edge case for computation of y with projective coordinates in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bf236450ef33bceffbb90e0b86f8e99deaa1337c89826363b3cb4e0a66d541030676703afc892b8059c92e24f653b9cb2a11a5f520c848303c17c2c48600c84c",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "72f042a5b276a980d50a0583483eeda72de8ac796b1d50a843b4552a151e199d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 199,
+          "comment" : "point with coordinate x = 0",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004000000000000000000000000000000000000000000000000000000000000000066485c780e2f83d72433bd5d84a06bb6541c2af31dae871728bf856a174f93f4",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "40eafb850ca7e08f19ee6447f196aeabf292e27397856e106e60a6c8b48cdb27",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 200,
+          "comment" : "point with coordinate x = 0",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000481bfb55b010b1bdf08b8d9d8590087aa278e28febff3b05632eeff09011c55798cd2f199d9815d7585073034eb76c93d50799b354b0fb1e77eb75eba8bff3d58",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "b485f3364354b738dc5402729b880c90c502d9ab52ccf81e3d21602c7b9bd909",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 201,
+          "comment" : "point with coordinate x = 0",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004614dcfbea4789a3f3eb4a8e2f111c887f0248d9316b99d0864c927a045d6941753a073befe08491a8050a4d96d08ba4790ae18db3ef7f0eaccf59ce1095afc54",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "4207bf4159faa0e50ed238b9c0ff46194a539a1ba03a5a4c8d68f369aecd31a5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 202,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004dbfa466f12013255f9d57a6496c158ee7dd202a1ce4a5a53005b3564d509a0bbf2578007e857bdd082751ef2f3b4b9c38a0b87bab413d55ccb26a574f2b4be9d",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "e2d57eeec983756c9124f885a4d118ed5b8de7d2895fd91264cf291496949a12",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 203,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048238f048c292e08d49bdb5dab1f08da6d39cdbefb1d75e03e76048b903d6baf9389e4da4040fbe2019a1461fec3cc90403c9becccaa02ef5793da721c1e657a8",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "81fa8ca50ac155200de410dfdfd8093037674baba7ca102828a5d0026f24f0f5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 204,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042d08cf1230463b7102e8a54185986a62a3f2520c0c151ace12f5d073a40cbb2f13473d11f58dde7b16783083cd533bdecc092249dcf15b723f08394a5bc5b3f0",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "151411c3b8e6d25c515186c1d9b9c6e1a05da5a7f09cd4ea8844e0916846ba48",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 205,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046e8966a6013dde2bb3b2a28c6eb013c481ddb7249ef19d73b92da35cad1d6f14604bf43d798ae27621df2eddc8f5d90ee0289c54bbac82b3c5264c478761d153",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "5460bbc867f4f61b79ed491e41779e2ac8dea27ec1320b558f3cff5b6a94c224",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 206,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044f612e0252b8d484bd2657a9ca1bba22afe978466aae6f12bf1d9171e01683ca48f4f3c986bf941b523889a7583fae695d3d4ea4adfb57d0c82370fd82364c1e",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "a78ac266fc5a85102db78180bd9ae4b77039ec97391a211403322e4d56b59049",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 207,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e8b782dab2dba4db066670ae656c7eca4abc7b1a24c7976de2ce02f25b668413bda2f9991ad7aaf44437bfdd3d91c8f94178cde0f8af9833544ccc9e2d606b8e",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "f481ae23b9192191e8e1c47203f6a807e54e1ff471e6642716f07895b32f4451",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 208,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041350cac374bb076ee89eb8af43d076afc7312021006431fd909d22df064f6637dbb0dc949a183e398709353d264b13c4266653e8a8685dd830ffaad2955ae9c5",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "1de1656d961de1f584a2f7179bd3be3b4a282cbd3248f29e74b73a812cad8d90",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 209,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ec624cda95af6633088f9809e441104322ff529e0952aad4efe3286203e0c700396b89e7168b1da4dab123aa6eb7ed60069d07b241d6fff4ba04647e4fccf1a9",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "50b13920c2368b9a2e8c80a02a6f4e4a2f84af33532eaf5728da161e620a312a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 210,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d80a508b155f0c733936d523201bde339794417858cd4a34b685635138ddcf67b4af7eb47f6a8491c9147b49babcdd6538e0a126547493cdcb7e8c900d48337f",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "e597c39fd42649418bb49eca83589645df32ff1b3f3417087ccb3ee5bf38fbf5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 211,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040cb05cb7a4b01db1382620ca756285e1a7c6846bbb595cbbac9f89e0a62489cc5777d635a094d17f782d1e3c58bb0be2c1436706fe8b74edb7b9d4cafda95a17",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "010385fdf7f4c6402ae432e4b2f11f2f861c75c4dd27b4f35b7f1efa94bbeecf",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 212,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000472aba18bcccea84909fa724888c2d1d007b11c97e02f61e44b125b402a11041a3ca1faea5f02dd5f1327d5028de70e78c81b05338a2b2e3da509f08e2bd9ea3f",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "5696fa199ef1088f88c8979db25721d0a707eb7a51bfd97a1278bcfd43b38304",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 213,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004276e45461a0e00704bee883b3e61016eec41678d8176d37eba25557a740284e05ab0fd1bf9fdac37fa83f83f5156648bb036d6ce46ff1f6ad4c72bc953214f0f",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "eab63813807eec138a696be8b9e0023dd3c6cee35b7378174aac70838866c216",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 214,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ec90e45db57bc01f74d7d01e8783937723f8e27ba99541698e01c57cd2a39da0933bfd2d11d31af9cba4c53aeabe6a3635a0643c114afa109ada02004286aea1",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "c982c6d73a9307038bbed250369aca65a7e392bf15f440227eb9fea43cc4756e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 215,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000428993d7c18770eec4418c16d595987c196412f7b273da44136b19d4b516a2ac7b9ba3574a31169d3f2f7a62758d9d27a2a4fea904b24d42312a9ebfb49ae355a",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "5581a9f0971c60709ebaf53b1febd6e0d174664b82a36692656953507c0f6dc9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 216,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043e4851b2b0d1463b9c90772e10fe8cf29b181463de28e9cf81b4c9604931a4dabde252d07c1061e60f4f8cbae5c2a290c034438a06a8bac67b1ece8ed551a234",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "c7df69b1bc484804a3683449c3a228ff787387d56672588140c980b1fd4765e2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 217,
+          "comment" : "point with coordinate x = 0 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043cedff3609bd11397ed3aca84a0a7bffd009d48beab100719c7607ed28e56124a15f6af627e03f57a98012fba18321b1dff6c24f51d7b6415d102608b772a44e",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "973c078916ecc4c660aa00dd4ec1e1df8793cb7f8670766a5156f8344088002f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 218,
+          "comment" : "point with coordinate x = 0 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000441e9d4cfa8efe80b895a8cbcce2568e251db7ecdfd20a7ad710d4a4bf2addc6b5ec36a8339168a03f15b8c80f2a2a828f151d38791584853ba2ff44a2a0460a1",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "b48e119d29eef7dbb76b64218e728ddbf6ec600505ec7ced6ab6fb8763308da5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 219,
+          "comment" : "point with coordinate x = 0 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004776aef1acb82b628e132cc29440988f0a15d4cc2b4f328aecb063c9b86e5018e6e44dfc60444faa9c4e36bc217451f7ac2956cb3b2e9bbd655eba297163d1f34",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "28a88b6b258f233020ba6fa9c00d1d72831f4515b86966a9782f521315e18aa7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 220,
+          "comment" : "point with coordinate x = 0 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049ec06b0b08662c0e1dd9111696a63a1601cc83cee20695778adf84d43064fc90156001f084cd3c1df1a087f626533b6572584889bd3d5c2c99f0e311e22b41e6",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "c4ff865ff3dc4953ea78d92a02f3345a53bdb6050cfd8f41baa4395ecb6acab8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 221,
+          "comment" : "point with coordinate x = 0 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fa51d128adc2000f09ff12c6fd8e25aa08556d708bf6b0ffff9e8eaad4783f0de22bf529e516e1f64b8e0d09f98fad4e501695a930a1b22076659da707e3ccd0",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "de1069f051637e10166559cef44688afc809341855261215c4f381d9d7da76ca",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 222,
+          "comment" : "point with coordinate x = 0 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004efe7754ed4c0b3c1dd301bc1ed69800aa2ff5d51fb85937715e60d2e7bcada8eb1581ab75fb3c797ef94a9dba3d82568c84617eaf3fa04f279fbfd898f704604",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "b5a0ec92aecc3010d27d2263d3da66e3d2f3395d23947024a3f4744454622027",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 223,
+          "comment" : "point with coordinate x = 0 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d8e13fbd017f1f9a26be35c611d7b2299f5d10de3c8a26362273fffb85238f3ed1426b748c1f87e3afa2c1e7a0224310c980655e07399590d1494d6d6bea0396",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "d2a5bc66498c6036aecdfaad041cef732a893de190a0a5b42ff71e13f09280e7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 224,
+          "comment" : "point with coordinate x = 0 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045a1027666a0e372481fec0b3901e058d60107c07b1115550ceb05789b55a6d35063d4c8ee66ed45ff3e1dfdcfd73ed96a9e83193884adbcaa574b2dd118a692b",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "1f812313ddcf36bc38071d0e51a74100d630c8e20cc414326eefa42ecb1b5f8e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 225,
+          "comment" : "point with coordinate x = 0 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047937b9c40986dd755a0656203089782583da7d8113a44190762ab474a20bcf60efcbc1525aed5b4ad8e687cb02c2ef8887095cadca56c765b41b4a9544ff2fe8",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "f284089bddd5e2e1be3f82640efa0658468fa1f10b281963a3ca190c3982fda6",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 226,
+          "comment" : "point with coordinate x = 0 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049368066a0748867a7b870244f5c9f82ea8bd51552959dd550bb7394497159a5d40764add1ae24c8e3f432ee011be97d3130718fe0a6a90ed8b1011b2034d09a0",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "4529f4b631c9984ab216a6801281fc4fd8731a58b65ca8d07bff07811116371f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 227,
+          "comment" : "point with coordinate x = 0 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004981d7449bdf0013f5eeddbb7e42c442f7ccdd9427bd26d7b388755aa5e26f46a1292b88fa6bf5dffca054dd42ed3594277b593dcc402d80340fb7816e4dcab37",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "64bbc9fdd73643eb2954f4ab640381b938c5e601846a0c6b6954966e0dc73e6f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 228,
+          "comment" : "point with coordinate y = 1",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000409e78d4ef60d05f750f6636209092bc43cbdd6b47e11a9de20a9feb2a50bb96c0000000000000000000000000000000000000000000000000000000000000001",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "28f67757acc28b1684ba76ffd534aed42d45b8b3f10b82a5699416eff7199a74",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 229,
+          "comment" : "point with coordinate y = 1",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045384d6c0def78960db967b8096d35477c5a5ce30ef0c6d8879a5568ca87e979401ee56c4581722610b43f3cbfcf3862c082a6e36baa36fd6f78403c0e399faa5",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "9ee653cda46db67612760ce35bac8450bbf48dbf74451ed93abb6db408a9fe10",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 230,
+          "comment" : "point with coordinate y = 1",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044eca7641a4afd5eab0b214657ff3bdcbfc66f1551a53bb59493bc38ed78ff39614a0cadff14c14736edbdcdab510cba07a8924ffd0490ee514aedfaadb648b01",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "9736ad6b2a2ef17ec3f8c8dc2e35715fb1c06f28d82e4e26876f0214588165f1",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 231,
+          "comment" : "point with coordinate y = 1",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048d0177ebab9c6e9e10db6dd095dbac0d6375e8a97b70f611875d877f0069d2c70000000000000000000000000000000000000000000000000000000000000001",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "748fa4f5a399320382dc920026938694c41a26fe2aaa318c5e710198dd71c793",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 232,
+          "comment" : "point with coordinate y = 1",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045fdb7f0cffb8b5b1142d24698a4bda76bf9827d63b1a6bd85a4e2f9b59c510cfbcb35ba9c987108b6d4337ad5393f9f910ec92410c230869d66528ed88c1b98a",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "7f97db83b4d86f04fe286041ee21e80ec3d59f3ce82cdeeaf362016fc87a3e02",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 233,
+          "comment" : "point with coordinate y = 1",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004530b2293e60c6b6f14c75c90b1ef8b9f9fa6b2151b8d9855792eb2b3dc69f07a0db42440e73fd7d6df04aed5022fbe21ceaec33c5fbade1bd6ad321ef2e10d0b",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "21794cf24f56273fa4463cc7ae4232fa34dbe0f18b73613b8ae9cbfb9c36abf0",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 234,
+          "comment" : "point with coordinate y = 1",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046916fac45e568b6b9e2e2ecd611b282e5fcc40a3067d601057f879ce5a8a73cc0000000000000000000000000000000000000000000000000000000000000001",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "915106d07816e879e7643f00abf6d79fb8f1cb78bf64a6a3827f91a7b0ef0f41",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 235,
+          "comment" : "point with coordinate y = 1",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ed9568c85bc52a6b45733618c3602107c1fdacf23b1a38e486af95978a214e2efa0d71d5e737891c4276e247581ee6139011ca1460db9b1e20b364d9275683e2",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "2fcce552310819dd775ab7ba9ff0f96a1fcadd25a0c709703cef04bb6e1a7bd7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 236,
+          "comment" : "point with coordinate y = 1",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049ff7731c00f2aa88b3fc174aba907ad17595e602e768a5f1e9462a6d4b89b2d23f178a70b9bb3edce289118338a33df30c432c347f12a3de0a2b03b353878d96",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "757d926a2693bc8a3d2d8c0554a13579ef9e559186578911f37edc88b2f5e61a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 237,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048270f8179d57436b34dfc0bdf7d417a5c895116b90cb51aec718614f864a635d174804e0c0e06e3d68d3149e0b956621c6aa2bde83f4d17d03d28ef8aa389fff",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "3db29ec6f978d2269e92e9c7eb5c8b5a8e56c2228a4fb9e483feca50aa3e451f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 238,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c61750e98abaf20225a881dbfd3510532cfc3df971bbbca4a2bd52f91acc9c59d0fe79342097f88ae78fc79a8032245fdd2c30cc64aceaaa9fd57b0825692531",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "72c57c2e10d77318b3a796097bbf768c6366142d80f98c90a93780a841075f32",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 239,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049c5d3bb54650d9550e1ee2efa3ea43c14ab99d18bb049f37b42a6dac48232f0bd3a2760d83d33afe4ce6f1d1245489c509bd26b0251f308f8c996e80f7a3f8eb",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "a96b07944e9eb2b22a9a36575eff1f4f6363b4aa3a53b100b8518a67ba5405dd",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 240,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f1724efd481ad45a55795f06126b1f5ed28e7d9bb4fee910af2ad8c1373b18ff77edbc34da6c787ec73430347f4da86810032d88f7475f6c42f15914079d179e",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "855883316b6d097ae5eab6c67e8411a1397349a09b9d7d8f096b2ba1bd03ea31",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 241,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fc3680af52fa89ffcd193ecc0b0714466fe5db277ee5872846c520bf4e3721d927260a0e225a3d377e6723ecb6bef8d4493c2da78a22a307fcca8f88f4527208",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "5a75bb7a0c96b8340d0842bcccf11974e1a5a2c8f4bc22b333433cce646b6a8a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 242,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004106b6f81e3482db18d74029291821ae448c38844ef783bf1d6999a404401f63f6a5753f0edc68a62cfd6a0b181bb2599e1f3bac5fa8824af160de79ed867c350",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "d96412e31cf4d26195920cac952fb79ea25f6c50abc79b5ed0ef8026a6e83319",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 243,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004093cb5193a4f94cd18edaa20a973b87ff79b0c03684c79487ecfee347e5354eb04fcb5752539170777932be15cd84c97f03815ffee8b60b647c178eebb8e14d4",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "2b0eed9badc92a1068196dfec124fe8f9d3f451e294d322eb881cce02f286026",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 244,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d6c38f448b964e27b5b450cc38d3cf41ef9df83d8a959771eb9c21855cb36445df638aef46a2aeb13199281e1a26d12fe61b029ec7f68b90faa89f88c7a95942",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "ed0b1d8dfd27a61fce91dc6405bfc53b6d48a8c13ba541c96ef3dcf31d7cdb88",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 245,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048a748d61f59c3b6a29b733b0d554b2492e7f76fad7cae1c17f2ac3de9e4a65d2eedbe6c26b6fd22bfc03c1687555d2f0a38e02adee5570686171abfec6681917",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "a796dd144f21ba3318f9e10828ecefc9c0f6ef2c427ae31351c16c2fbfa3cfa6",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 246,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f1052699d87e5677c75e26b2abe719310648d820a96e5b381fff58b392401581b1bb16ae8b68cbb76a3256870bad1ee5a30ff9fd662fd4f8d1fe5b5f1f98ff46",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "1f3a9615b0745046a972bad5d59794a0b60b032b4ac94fe85f77dfb380d1f32b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 247,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041219af5230064ee9778667225f0e009cdb961330e386edb34e4fa9fddd0e5be7e2a12554227f613aaaa78938ddbbc99b923f9d181b8192dc4b816577e8f3b7e9",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "caf9141d1fca4d0f10683b5e86d2b41af5602f017991fe7348d44e8d7014115c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 248,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000460def130f190e6dc44f5eb8a59e12e7efb27db968c7fa6cc6d31785f066b41b1f1bb556ac4cd77033e7aa6c5ba16f47ebafb14975a7fd72dd9b7fe23116bca55",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "6539ec1c98fa75197ba07c678b26300b3da1fe407dd4c68b89457ed669082e06",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 249,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f23f09bdb7d17289eb005975a757a39325b4df9b29e55ba2ca679b5ec0973ae918c881f3c7b6c12bed1ec54b837d08c5908e89bdcedd84b9177720378f789600",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "0b6619827cfa948d63f021e9eddb92f884fb5ce8a404bfe059e993fc23447a69",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 250,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045dbec098c1b7de3e3e2e73d0b62cd49c877e1a0130a1b39eb2fd4dbd4426aa4ccbeee217591a8d76cc8deaf14dde52e3f401e53b30cbb9c1807910d827d0041d",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "2a53a561acf5caec6eb0d8aa40727942881a75d136899dfbff91528236926c39",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 251,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041e70730dc4f39c8970182e1a29cc836b9e9d6cbd6fcaa8c0dc1062fed9a849693e7b9151f9c8a3345366f8221c8fb700e8c3a9aa7f0cc46a48864e1605592094",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "9b377716ff1d056dac8e392249eaec740d2f5aa62303f4baf6bb1b03b2a276c5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 252,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f428c9ae3e23eaf9c2a5b9a7e41efd1cffbf35f881bfc35694d9c05d1e312b10ef6da9023cfd2dd0cb7b9e2a77d644affe62a63fb0f29d45291c6861aa063c5c",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "0c0c6867669743082547aa94451feb362fa29fbaf228dfb3eaf375f1a5ec2fb3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 253,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b9a16d9a5b85a714e2bb2aa22b086a17404c7a3ff62452732347419c99e90bdad578b462f523994304b6afcf6944a9cc5d0ad1afad956475c8f2953c06b06b97",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "d11f9e32587fd3b6f4a2354812618b4b3b4a7539b8a223b388bb7437f8d138a5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 254,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048f659a163a58e9f900c1e9b34fb1cd61ffc9890267be3417c8afe79d57214da05cd5cb68a2b93da0dbe56c1cfc0dce8b6c3260e0c48379c6d2091f16b39221c0",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "4babf6368e0359b78614060241ece46facca3f52f5bbc47ac0b46a075b5dd3a0",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 255,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d257f133f00a079f4e6778ea4a9bf42b9f231290431b5b93d7e8b0e35b48010650d6c6b46574d1efce03510b8db4a0981ce138c5bd8fe0e54c988c40c5fc9200",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "9627cc5c8d8b72278be89c32b52210173e6f4b8e2f48e460c6429f46f9f469ae",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 256,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045ef2ac57c4e93cf78d8f86c35d413b98dc1902dd245affde5c16034afc7ea45547b3e9f77fbc5075bad03c418094f1aec1d03edeafa167fa6af83526552f7034",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "d2b178bc9bb16b5a91a100bb72e15a9639e050c034346061413ec20c4fcc9bbc",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 257,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a7b513f96266414fa6ff439a35d8f09ab615db0bb6a3b1a120c217683f724b2342007a2c9feabcd6249a0d17acecd995e2a217fb5f07bec96938016e297efa52",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "6cdca0a731aff1ccfb1904a769cef79eba965fbab1cc64d2049d0df45dccd276",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 258,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047743ab7248dae5f1a59ac6b0a136e9f1e51aff8bd45795ace5f8187a13edf9adbd9642078378bab5c6d484f9e1ce39675b72170bf39abc9be7942fc01fc435d7",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "bd15e97a7f49aa33e57b54140a75fffce71b788ce0faa334cf8b45623dcc818a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 259,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040e3aa971bacdace350dc0957fa5bde0946324eb139939d7fc1997c701effd04a4e6c3625d9564168d3a752961221a1de8cf5f3d603752a8c2e6277ac3a918c25",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "c8b5e8e7488857a2dde62c5fc21e4525ebaba0e06b5be83ec6e7dd771e15a01a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 260,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040f563e21bf9b24015a7cdbb6f000a692784ac2e4bc2715c76f684264a899c8240cab0d76e6b01cabe4f327429d11be115ed6dc0ca74f02c1b987a082f5af43a8",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "1c63a457509b148272687e6e442bde51982d41b0080d8c0c5eb714257af971e7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 261,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045da49f10249e4df3dbb4e31ece0b0ee9aa073f2588195aaae63e74f6567a774810b5dd61b6bf219e9eab30ef09c13fc184b3d09ff7a4e192bca8f5111c4163c7",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "73a1ac9ece354a930dfd9c77577b4f50acc0a78964ea0d7775631d64c709c4a2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 262,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046f72e6e5c6300679d3f14f0f6e590665643576ae8bbcb7c05b2f4a83e75e6ac3e712cb056ff034da340543c5da6997e65a3ab4cd39e997892bb92ee2c22b8167",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "fcaa406329bb74f995862cea7cecc7425c6bd4148ef1a9f46b5d42da5994556a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 263,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046b544df9168e7787db282e2ae01dd72306d9c9bc80f5ab38ce594766c3d929e967493ff601ca60862b47d3a0785c917e44584044e36023a54424015e58be5040",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "e49ff11d46b6c4b5dde528b04132d15c040e79f9b7151fbc650030988028cb87",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 264,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041c31385b9db9b374e92499939ab0fd7e7eda464561eba89fcd7b4769814a8638a4764cf8ce97b5d143bb8eeb9e1b27287f2b73942ecdbc6359aafb1ee7a152c2",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "fc8f64eac1c7e688c52c467185de21914e8b253056d9e4be010ed0128f92a889",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 265,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004aabcf8b1443d6cbb1de129a0ffe09f60b23fd9d0a44b6bdf25bed7373fdbfd1db716bde7fe9f2f46de0b688e3025e029cff15244429ad4f83484f5dea4af8583",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "6b56d8a01a884319ab5fb9d890cacfc7aabd81ad938cb5eaae207c8c1aa06efb",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 266,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e7cd580bd957915d527056832e37793ab3b082ddfad9372412e1908e5c16bbb6208601a970d5844b780d9246e9583eb35918c42ed695c07d52244037f0e31db5",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "2f64b5c8046d41a4e1d631ff23846bff956a4925a47f8534490a20b4b1918b9c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 267,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042a52db1fe246b71c79c0d0ac49a7d38de67b202995efbbd2a9cc525f6f36010368f494be27e0593e2d612f1fa10a9211437e6aa16e65d97735014072f0dcec94",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "63ac31e718b9a780a85f0670e1d3685bbe306e5f06fee282a8784700b503c124",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 268,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041c50dc49fef708c4cdd62e766f9b60f784d51afee17a8fe9f3701b2fae55b7a5d10f0d9639d83dce8f26a869705a6d6d38e6d328f5685581142aec0dcd1f90e7",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "555c1917b770cebe6a98337a008ae3d8d04f571565327c93debf61ef90ddddd8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 269,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046d0aa1bc1cee6d07d045002c13290d0ca25ca3c8783343a525fac70472b92c62d6fba71174448b472cf172b0ca9e377f1a2603ba7ae1276d153b20c63e7d24bf",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "3a65a9200f8f96635912faa5e7859fa303a76a1c2a41ea97ef61aa39287700a9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 270,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f07e3d8be2ba54c6084141e1fd2b29cfd00d4e6dd6ffb115ed839b10bd8a422f42992cb9a5243897d55408e9bb556043318d87349af35dcc0975ed805c8fa2c9",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "bb7bb52da570ba58e05fd322f82d556c2d65b365db30815879f67f233b089b51",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 271,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000443a9b90274dbd5f36dd29046fc8390008dde74513ce4c3e8892b236efff80c9dc71547152a5897dbe16957bd15d1a87d770496f814fe2921c8f33df04393c7f8",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "e8cae9944233b867eedf5902fc49ecd07e4c81c46279531e89520b74ba5370b5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 272,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e9af8e8c19da9d5c2f3b3c03b8e927c3cbe2d717f98f500972e56d82eb07c2b14e83fcaacadc26f8bb5e7b94741fe54f31275ebd6e1c969d7ec2fecead8a0dae",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "e72ad0cdb25f4307d1d834a5f792e9af64fd1b69a47041ec8fa46d526f419e4d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 273,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000433d9582b567aadbe59606fa6ffc11848e4947b5179597317776317b2b4ff65d0b4d8568dc843319cc04f4bf110496dee7c9229fc68cb0958f3cbd37ecca6990f",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "000197fbc260a84dbcbf88136aeaa79b03bb8949aefd2416bef63929ef789bf3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 274,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e21c0282adb1b2055fda744644c68612cfb0c68a70b9812d007f21a78f1adc4849f3e7644bc6633e2773a2f3cc5214fa7208e30afb3de992f077ee321569dc48",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "cdb18bf62670a853488ca510d8f55bab2918991424925bd9b74a821d2c6e7e3c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 275,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004af27de0da6556e4e64588c9694afee9a84e1cbd0c388972df3a997f760bbcd903c5a02e161551f333d770559ab1af49bf8b68274896590939ce956d9913b676f",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "167303505d22cf9ef78c5b9687a5418fa9fb284f2b0ff68316288ecd7f2e2e09",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 276,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040da41b82550b358ff474915d83104d41a83a12ef70589b9d392f0f30dc32429edc76163c8fe07a3f709cbd92da0bbfc5045f3db82aa5344cf1fd5b27fcd2f7a6",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "85600ff23c3cde26009fea9b6539664bf045056883728ab0d4498ea0a8f4a453",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 277,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000419c844b8c7209026a0996a782983e1bd0f0de9255b86739be9bef08ea5475cc669a779ddf57747cf7d9a22f00ed8efc6e818af5827b750d665fee6d6d58a22e8",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "a3250a2bfb145ce86e706ac3ab2bf503a66486ac0b2f7522601c124b0e0f9c5b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 278,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bd07bd4326cdcabf42905efa4559a30e68cb215d40c9afb60ce02d4fda617579b927b5cba02d24fb9aafe1d429351e48bae9dd92d7bc7be15e5b8a30a86be13d",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "2d70cc8c8af01366051cc8359c2fc8f258757e2601fd8f3e08422a7b23bfeff5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 279,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040089dee27a60d071dabbaf58f3e56614dad3b7f9a8030769fd0463b3e6e0f03a147b4d6e7e7fd939b9b54dab458fd556ad8fdaf4da6c3909588c4e050ca74a67",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "cbe0c571d1080ea34ee20ad1bfd21ea5ecc442ead733fb4eee3c0d7b0cce9935",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 280,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000442ede106cf85aef46df7e5dba8a8b00459317d9e766a7b77c299aa0e17dea142b6e9a86f4fc3e945d4323ba8e459f6b7b14c563a698c757a2d5f7b0bc301ede2",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "33320fc7917fe4e19280bfbfe16f223c037f7c2dc30c0fda98310740f57fe289",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 281,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004974b4316c5e7d1348b28dbc4fd61d8d3470de744c30f5be237f85f29969dea77b5f00b58b83cfc7bc51655465b4a28abe1ed3dbec20c6b4643aec85b95a5bec6",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "35c726ead66c39414fe0c24604df7838e5725d2fc1bd0853261e1de3338ecb4f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 282,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000459873d7523936a121b629e9870f930419f253a5767b9d0dc49716f2c50e17bd0163b71f2bf4318fbde1ceaa585450080eec28474cd18bf7c21d2d1bfde4ff677",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "66ea42fe6fd8741b37599bbdada3ec0e6b08c0b52ea67c29a33172f72742583c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 283,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bd85a79f81c4f9613e64fa347886437856c7358d1b69cf1e923d7742d82f9b6767d26918eaa8acb113a1daadaedc709742457303ebc23cdda5572613dc827703",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "2f8a502e4f440133e84fb625292cbeabe2cb79da73987c76d4fed864d1b1b762",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 284,
+          "comment" : "point with coordinate y = 1 in left to right addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043e6a4effc47c2f5926bb6b4acf2eac48b9524c47d511f816976796778600d6c5bfce593242a5985a977590f8d7485df3f953352957f3c17c13e94583d9c0e7b9",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "06436817d8928b77b73d16c5c3b35e243ad3ef2ab59ad047142c67a6d0923c84",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 285,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049a4487fcfce8396688e7449e095fe803caa253d4bd7c66dbc6261cc9d9f883a50e5251bae29c5a5cdfa31bc61105671a88a018467398158d35b88829237c0bff",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "7e83fd2c3d713bc85d6d85d9078b3a0842824d410e8abde04da0fd71c7d94705",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 286,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fed6ce127290c1291ca5ce64acb4e0f2f8905654d1d25ba57c1f74ab52f21f42963d31671c06b802169929525c4a1fdeff5b1eafab919dc2df6c52be84dfaef3",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "0e3dfdab606ebdc6428282acd443f189c99b3b483aa101fd8d6bed38aec59e02",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 287,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f7cee5b55f1869f137dd707c8f8fb8965a2be5840c3149fb759695a4661b9c0d23c78c4e9647b0d6cb2f2602be73ff25cf3d09c96d892b5745fe5eca814aec91",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "f489f2bd93f76b8e41fc6b9f211bc599d49db1f17a38e95bab1d31b2a2b55829",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 288,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042baaaec3b3e8d54a4e18f0960b947da2535e3cfcca2cfa8b7113aad8e3b6626f72f71e7c9e96042c1d39cc8f1139d5147c6f4fe62e23cf6df364b5f4d899f842",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "cc5738b49d30d5d02cf7e0c54a3de09b5b6f3c4dea91dd0679072a3562444c37",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 289,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a51ab1238bc1bed25247e7d179c83a61ae2d4a9fe2288c363ae0eb7a77de432a3c6d35d82ba8017e6ca9041cc785a30703f7bc4427506e624ac5979d715421dd",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "89a11177d6907a81d47467093bf6a3cc8ba55dee05239b160a31a3000f5d807b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 290,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048b5ae8a0e55f30f509061315abae79ac480f88b44655f7269a385c81526884be262974a31a0e2322126c2d77b26b108abd81f8b952c458ccc95d46fb4924c7c0",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "2cb03c30b20037a5cf4d5b33574f3abac895bfab37867eb2ebed260e0929058d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 291,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045f60c77e474dd66c8135ee3dafc75ba644649824c72737542091ad469adbb685312c09c69b629d0436bf3bd6c6083ff2a87be484a73ef3a5d2c3e06b5d9b21b3",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "e54d487d0c4b12fe522af3e663ce316e632ba9d63a1f02a36fc5a82bf82731a4",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 292,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e06eaa73f6feae45417d859bbad4bc404b2885bcd213ebace594e16f4970e0c411ed3323a3d7afc7076239884307f91849ed5f5e36b6171d309c81344c53e06d",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "ccea969d40fa42933f4fbdc4cabe2185f8a452996254c1f4e0dde5e14feeea8d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 293,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040f1c1b89e9fc6fc0faefc9109fc4a1247d9f54c7497b6cc975e6a5455bef410836cb3818548ac9b41e2b8336c3eb8d97075ae47e1827fa1ff93d4341d43c0c1d",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "eaae0e188c9427bf3c8b3ded772122204c328d5941e389d808e2724638f9aff8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 294,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004577069e8284a95f51dcab919b0536657058971dab76217f8d3ae722a64092e26e51f68a722cc0397f4801401771e9a3d1988d4af76f14f9e2f9c36e0773e29c2",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "fea0cce1358f1ff40ffeaaffbf91b2e8d426d4e31e9627731ace3a122eab6b0d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 295,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042406a2759050b925dd4f814c5033e355548f42bbf1afb791c110f0031f29f68099d5f4b005de3927f165abeff196a28c7217fab1be2b5209c324e7d62d2dd687",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "837621ea4827bba0376aaa8aa66cfe144a2ff1e359dc619a06441d3e055f9771",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 296,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ccaac61f35a27861183621642bc573af913356fb47cf582f0b5299099d6f6c6991f7272b83b738a7a5d30447c87f126a7d98ec72fa2609d0939d18db7ea7eb3a",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "63974ce6153762e5b364523cead93e8ce8bcc77dda56365d676136169fc4e39b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 297,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000401415917272f1984e7217a36fb311fd2904d41a6b13973f92aae3b90e85e4d56d97c822eb7b21a84d0d1be4867404a80c34867f43139dadcc3619e10b222562b",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "0a0488144bc36d690b62148ac3076047d46d48f7adbb0f34fee9a636295fe737",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 298,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b2575d100c6fa056bcd137ab111b5315a8908c29243b84f3dc996d0e45764b9166cabeb41885588ec08b47257df58bd58f7dcd9e012e2669fa2f52e25767fc4c",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "1232165538a44268aa7c199c54d6d207c4ef3f5aa790c10c926a20752ca645ce",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 299,
+          "comment" : "point with coordinate y = 1 in precomputation or right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c17355ed30ccd6427f9685709021b25c11ed176e9610c479bcc4cc7552a738e61f75114761dba0ec60cd264bbab763c5d5abcc75cd8fb5651d0645179988cc6d",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "dcab5e874e4fb76bc4312528e9d76dfae56145922533089734110bf5653f4d77",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 300,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004341592390ccce485de8880f3d727f664c381914a1becec383b35586751fc81c2add71852b87016e1019cae7a9080e75ce0b0b8aac175d692d5e7b4dad088f5cc",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "4ce2701b2be63a0083a4c53f7a0bf04cf871654f5edb6f625e3ea5e7d0bdcc90",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 301,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fa764b6b76a86c3b762120825d353a24766208c1f5cc0fe3fe7998026a2ec5c43bb2f948fd94cdaa5869b1e0e73a4d97035cc49357fb7b74d7ed0a2c5b8d54eb",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "7abef9765cca721320fbf8edcbef6d2ba25d17b70ffa1776029bc38fe677a12c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 302,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a71fbb617199bd585b4b66212ca33ca9e09370e6bf15c8ea0acefd9c8e945d06840f058863078e743e220ff99f23bbc1daa36835d4b1269f0a7536e63f06d853",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "5f61404dbbbc2867dff95c1f37ed44f4cb8fabcd223b03739d888308d13bc412",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 303,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000413c8292d854d39451c0c63a802b8c03e4fcb875ef01239896295ba1c0f386975f82df197086fd86032cb36b69a27876dd75a8e9679f36ffc2210edb128d4be13",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "8d673a577e35bf9d5d00676c08b2c739617c46a052188403aa06dc714af6acc1",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 304,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040cd9df415acc0c32fd4e3d6924ce53075b0452bf919a2ab2ebe26597570f1ecd5985d8d2c5df78fc100f87efb6dfa9543757bdffecf083dfcd1ecb38de6c23f8",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "a7835ffee0f2a69dfcf70d4e798dbe3ed32ba03cfddae5ddd11d8c0ac3d74f9b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 305,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d2dbea4046b23fd2b233d1ce31dceddb89b25f26c0627a9d2db3c5605c9cc99535bdc8de7451c1e27e97aa91402cce3882c71269d9cbdcb5d7ac0ceb911b9b6d",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "e98ea22209cd397edb6c319648c1eb24bc4d39598ab11995571926684ce2ceca",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 306,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004888fb044fb2b6caa60366bfa662adba479b8365a6555a29887d580f587086ba8482f4ec24082a48d6402afa1622143f26e61d91b7e30d6a4b223630ee10f70fb",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "91b65733860b1bdb9541d9f55895a3dbb3f13c199251d33006b6dcf90ac349ed",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 307,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042e2bec134249379d57700301f3a58e4b395a4d28370d2a06e65e7ac89ed76ac697dc960bd795cdf4fbcfdd75149057b8e022331c7b5461f383ac589d764df333",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "1fdf7c5c48047a113e5e5d1b7ed593337e769231cca5c7110160e0c1b97f4256",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 308,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c78cda7e3b9e1772ebed30b2b51dcf155a69a0fc504557836e25147cfb8127d2f8289cf38b033d3763c8f9f6c091787a3142fb83dff5719590282c6f852e0105",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "ba0abc3e71726cb51330489176357b81b8074d7690e4e82e9a3c00151e1fa318",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 309,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041e3df4dd7fb7718cb0aa0dd72f8a25c83c4e804e7cbd48c5e965651f9e23bf4ef0ff40dd9796e4a9a5eddd2c4ca4ebd10990d8fb8918d12d53c76001afa9de7f",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "16e632f9752d36602c95ec274b32ad594f39f6ac3bd4b0b20f8637392142cef4",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 310,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e5c5dc3fd88d85668b3b709fd6b4232f1f80949cbccb5588363e6c217a2b3ed88dbd0d6e3cc97f3081d16602aa3d1b655ee0791c87fcb5abe6217d8c8513807e",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "9eed4b96569f604a4d3f5af97499807111fc9888c458ece2e3000e245c2c02b0",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 311,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004021c41eceec24e0fba894ad7415a9598cbcd14fa6ca46e25575268a1d8e5bbc63f846c6a185fa3f23bb92c14e7e2cba8c74047c09af766f55ef0c907c80d9451",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "21ac32013838812621dbb584965bded6fc851d3a029810679bc57b2381bb7a7d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 312,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048e24192cd33335a114f5070266c014cb0d8c704d16d6042e89c17597bcd4e77ebdb4c5171704c2c09275c22a310e0c4fe092e4084856da99b94abbfa9f469f48",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "fc5978da01ca83e127dddf989a0358871b3c4ce0755bfb020633db467e21a53c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 313,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431c90ae47a93d09a2352b6f3677e7975ea62aadedb56c118eb8b9f771e2dd9f5f2601fb9cca2304e594423cf48064dbed17ae40452f18be6ae018321911e8cb3",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "9f417341261aa45d396b0ccf2a3dee7a466ca47e3ce86ecd2071d9c4db08820e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 314,
+          "comment" : "point with coordinate y = 1 in right to left addition chain",
+          "flags" : [
+            "EdgeCaseDoubling"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d2f211cfab84e01c8e5544036234debe35ae103bb878d7abcea6825f753e03a385f7f1870e64f1262af67a25ef9880419f45608e7f9da6dee83f5f46ceb53dcb",
+          "private" : "00809c461d8b39163537ff8f5ef5b977e4cdb980e70e38a7ee0b37cc876729e9ff",
+          "shared" : "f419febb32c254611adf569c2d583b17542b1538caa0001967f0a4bc34b8b789",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 315,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "03",
+          "shared" : "85a0b58519b28e70a694ec5198f72c4bfdabaa30a70f7143b5b1cd7536f716ca",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 316,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "00ffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "shared" : "a329a7d80424ea2d6c904393808e510dfbb28155092f1bac284dceda1f13afe5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 317,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "0100000000000000000000000000000000000000000000000000000000000000",
+          "shared" : "bd26d0293e8851c51ebe0d426345683ae94026aca545282a4759faa85fde6687",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 318,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "shared" : "ea9350b2490a2010c7abf43fb1a38be729a2de375ea7a6ac34ff58cc87e51b6c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 319,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "008000000000000000000000000000000000000000000000000000000000000000",
+          "shared" : "34eed3f6673d340b6f716913f6dfa36b5ac85fa667791e2d6a217b0c0b7ba807",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 320,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "00ffffffff00000000ffffffffffffffffbce6faada7179e83f3b9cac2fc632551",
+          "shared" : "1354ce6692c9df7b6fc3119d47c56338afbedccb62faa546c0fe6ed4959e41c3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 321,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3a9cac2fc632551",
+          "shared" : "fe7496c30d534995f0bf428b5471c21585aaafc81733916f0165597a55d12cb4",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 322,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b1cac2fc632551",
+          "shared" : "348bf8042e4edf1d03c8b36ab815156e77c201b764ed4562cfe2ee90638ffef5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 323,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac1fc632551",
+          "shared" : "6e4ec5479a7c20a537501700484f6f433a8a8fe53c288f7a25c8e8c92d39e8dc",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 324,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6324f3",
+          "shared" : "f7407d61fdf581be4f564621d590ca9b7ba37f31396150f9922f1501da8c83ef",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 325,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632533",
+          "shared" : "82236fd272208693e0574555ca465c6cc512163486084fa57f5e1bd2e2ccc0b3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 326,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632543",
+          "shared" : "06537149664dba1a9924654cb7f787ed224851b0df25ef53fcf54f8f26cd5f3f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 327,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254b",
+          "shared" : "f2b38539bce995d443c7bfeeefadc9e42cc2c89c60bf4e86eac95d51987bd112",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 328,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "shared" : "85a0b58519b28e70a694ec5198f72c4bfdabaa30a70f7143b5b1cd7536f716ca",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 329,
+          "comment" : "edge case private key",
+          "flags" : [
+            "AdditionChain"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000431028f3377fc8f2b1967edaab90213acad0da9f50897f08f57537f78f116744743a1930189363bbde2ac4cbd1649cdc6f451add71dd2f16a8a867f2b17caa16b",
+          "private" : "00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254f",
+          "shared" : "027b013a6f166db655d69d643c127ef8ace175311e667dff2520f5b5c75b7659",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 330,
+          "comment" : "CVE-2017-8932",
+          "flags" : [
+            "CVE-2017-8932"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004023819813ac969847059028ea88a1f30dfbcde03fc791d3a252c6b41211882eaf93e4ae433cc12cf2a43fc0ef26400c0e125508224cdb649380f25479148a4ad",
+          "private" : "2a265f8bcbdcaf94d58519141e578124cb40d64a501fba9c11847b28965bc737",
+          "shared" : "4d4de80f1534850d261075997e3049321a0864082d24a917863366c0724f5ae3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 331,
+          "comment" : "CVE-2017-8932",
+          "flags" : [
+            "CVE-2017-8932"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cc11887b2d66cbae8f4d306627192522932146b42f01d3c6f92bd5c8ba739b06a2f08a029cd06b46183085bae9248b0ed15b70280c7ef13a457f5af382426031",
+          "private" : "313f72ff9fe811bf573176231b286a3bdb6f1b14e05c40146590727a71c3bccd",
+          "shared" : "831c3f6b5f762d2f461901577af41354ac5f228c2591f84f8a6e51e2e3f17991",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 332,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 333,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000001",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 334,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000000000000000000000000000000000000000000000000000ffffffff00000001000000000000000000000000fffffffffffffffffffffffe",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 335,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000000000000000000000000000000000000000000000000000ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 336,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000000",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 337,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000001",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 338,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000000000000000000000000000000000000000000000000001ffffffff00000001000000000000000000000000fffffffffffffffffffffffe",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 339,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040000000000000000000000000000000000000000000000000000000000000001ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 340,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000fffffffffffffffffffffffe0000000000000000000000000000000000000000000000000000000000000000",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 341,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000fffffffffffffffffffffffe0000000000000000000000000000000000000000000000000000000000000001",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 342,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000fffffffffffffffffffffffeffffffff00000001000000000000000000000000fffffffffffffffffffffffe",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 343,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000fffffffffffffffffffffffeffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 344,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000000",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 345,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0000000000000000000000000000000000000000000000000000000000000001",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 346,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000ffffffffffffffffffffffffffffffff00000001000000000000000000000000fffffffffffffffffffffffe",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 347,
+          "comment" : "point is not on curve",
+          "flags" : [
+            "InvalidCurveAttack"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffffffff00000001000000000000000000000000ffffffffffffffffffffffffffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 348,
+          "comment" : "",
+          "flags" : [
+            "InvalidEncoding"
+          ],
+          "public" : "3018301306072a8648ce3d020106082a8648ce3d030107030100",
+          "private" : "7e4aa54f714bf01df85c50269bea3a86721f84afe74f7b41ea58abcf3474e88d",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 349,
+          "comment" : "public key has invalid point of order 2 on secp256k1. The point of the public key is a valid on secp256r1.",
+          "flags" : [
+            "WrongCurve"
+          ],
+          "public" : "3056301006072a8648ce3d020106052b8104000a03420004fffffffffffffffffffffffffffffffffffffffffffffffffffffffefffffc2f3d9df6defaca30298506113d7501978507d339fe0547962cac4cd6dfc56c9769",
+          "private" : "00fdba54b3c22de358d937431b148b4a52a314426afdac550caa8c0c04cf0baaf4",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 350,
+          "comment" : "public point not on curve",
+          "flags" : [
+            "ModifiedPublicPoint",
+            "InvalidPublic"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764c",
+          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 351,
+          "comment" : "public point = (0,0)",
+          "flags" : [
+            "ModifiedPublicPoint",
+            "InvalidPublic"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 352,
+          "comment" : "order = -115792089210356248762697446949407573529996955224135760342422259061068512044369",
+          "flags" : [
+            "WrongOrder",
+            "InvalidPublic",
+            "UnnamedCurve"
+          ],
+          "public" : "308201333081ec06072a8648ce3d02013081e0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f50221ff00000000ffffffff00000000000000004319055258e8617b0c46353d039cdaaf020101034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
           "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
           "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
-          "result" : "acceptable",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 353,
+          "comment" : "order = 0",
+          "flags" : [
+            "WrongOrder",
+            "InvalidPublic",
+            "UnnamedCurve"
+          ],
+          "public" : "308201133081cc06072a8648ce3d02013081c0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5020100020101034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
+          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
+          "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 354,
+          "comment" : "order = 1",
           "flags" : [
             "WrongOrder",
             "UnusedParam",
             "UnnamedCurve"
-          ]
+          ],
+          "public" : "308201133081cc06072a8648ce3d02013081c0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5020101020101034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
+          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
+          "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 99,
+          "tcId" : 355,
+          "comment" : "order = 26959946660873538060741835960514744168612397095220107664918121663170",
+          "flags" : [
+            "WrongOrder",
+            "UnusedParam",
+            "UnnamedCurve"
+          ],
+          "public" : "3082012f3081e806072a8648ce3d02013081dc020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5021d00ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2020101034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
+          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
+          "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 356,
           "comment" : "generator = (0,0)",
+          "flags" : [
+            "ModifiedGenerator",
+            "UnusedParam",
+            "UnnamedCurve"
+          ],
           "public" : "308201333081ec06072a8648ce3d02013081e0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b04410400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020101034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
           "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
           "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
-          "result" : "acceptable",
-          "flags" : [
-            "UnusedParam",
-            "UnnamedCurve"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 100,
+          "tcId" : 357,
           "comment" : "generator not on curve",
+          "flags" : [
+            "ModifiedGenerator",
+            "UnusedParam",
+            "UnnamedCurve"
+          ],
           "public" : "308201333081ec06072a8648ce3d02013081e0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f7022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020101034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
           "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
           "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
-          "result" : "acceptable",
-          "flags" : [
-            "UnusedParam",
-            "UnnamedCurve"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 101,
+          "tcId" : 358,
           "comment" : "cofactor = -1",
+          "flags" : [
+            "NegativeCofactor",
+            "InvalidPublic",
+            "UnnamedCurve"
+          ],
           "public" : "308201333081ec06072a8648ce3d02013081e0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510201ff034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
           "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
           "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
-          "result" : "invalid",
-          "flags" : [
-            "InvalidPublic",
-            "UnnamedCurve"
-          ]
+          "result" : "invalid"
         },
         {
-          "tcId" : 102,
+          "tcId" : 359,
           "comment" : "cofactor = 0",
-          "public" : "308201333081ec06072a8648ce3d02013081e0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020100034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
-          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
-          "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
-          "result" : "invalid",
           "flags" : [
+            "NegativeCofactor",
             "InvalidPublic",
             "UnnamedCurve"
-          ]
-        },
-        {
-          "tcId" : 103,
-          "comment" : "cofactor = 2",
-          "public" : "308201333081ec06072a8648ce3d02013081e0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020102034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
-          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
-          "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
-          "result" : "acceptable",
-          "flags" : [
-            "UnusedParam",
-            "UnnamedCurve"
-          ]
-        },
-        {
-          "tcId" : 104,
-          "comment" : "cofactor = 115792089210356248762697446949407573529996955224135760342422259061068512044369",
-          "public" : "308201553082010d06072a8648ce3d020130820100020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
-          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
-          "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
-          "result" : "invalid",
-          "flags" : [
-            "InvalidPublic",
-            "UnnamedCurve"
-          ]
-        },
-        {
-          "tcId" : 105,
-          "comment" : "cofactor = None",
+          ],
           "public" : "308201303081e906072a8648ce3d02013081dd020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
           "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
           "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
-          "result" : "acceptable",
-          "flags" : [
-            "UnusedParam",
-            "UnnamedCurve"
-          ]
+          "result" : "invalid"
         },
         {
-          "tcId" : 106,
-          "comment" : "modified prime",
-          "public" : "308201333081ec06072a8648ce3d02013081e0020101302c06072a8648ce3d0101022100fd091059a6893635f900e9449d63f572b2aebc4cff7b4e5e33f1b200e8bbc1453044042002f6efa55976c9cb06ff16bb629c0a8d4d5143b40084b1a1cc0e4dff17443eb704205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441040000000000000000000006597fa94b1fd90000000000000000000000000000021b8c7dd77f9a95627922eceefea73f028f1ec95ba9b8fa95a3ad24bdf9fff414022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020101034200040000000000000000000006597fa94b1fd90000000000000000000000000000021b8c7dd77f9a95627922eceefea73f028f1ec95ba9b8fa95a3ad24bdf9fff414",
+          "tcId" : 360,
+          "comment" : "cofactor = 2",
+          "flags" : [
+            "ModifiedCofactor",
+            "UnusedParam",
+            "UnnamedCurve"
+          ],
+          "public" : "308201333081ec06072a8648ce3d02013081e0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020102034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
           "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
-          "shared" : "cea0fbd8f20abc8cf8127c132e29756d25ff1530a88bf5c9e22dc1c137c36be9",
-          "result" : "invalid",
+          "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 361,
+          "comment" : "cofactor = n",
+          "flags" : [
+            "LargeCofactor",
+            "InvalidPublic",
+            "UnnamedCurve"
+          ],
+          "public" : "308201553082010d06072a8648ce3d020130820100020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
+          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
+          "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 362,
+          "comment" : "cofactor = None",
+          "flags" : [
+            "ModifiedCofactor",
+            "UnusedParam",
+            "UnnamedCurve"
+          ],
+          "public" : "308201303081e906072a8648ce3d02013081dd020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420ffffffff00000001000000000000000000000000fffffffffffffffffffffffc04205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
+          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
+          "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 363,
+          "comment" : "modified prime",
           "flags" : [
             "ModifiedPrime",
             "InvalidPublic",
             "UnnamedCurve"
-          ]
+          ],
+          "public" : "308201333081ec06072a8648ce3d02013081e0020101302c06072a8648ce3d0101022100fd091059a6893635f900e9449d63f572b2aebc4cff7b4e5e33f1b200e8bbc1453044042002f6efa55976c9cb06ff16bb629c0a8d4d5143b40084b1a1cc0e4dff17443eb704205ac635d8aa3a93e7b3ebbd55769886bc651d06b0cc53b0f63bce3c3e27d2604b0441040000000000000000000006597fa94b1fd90000000000000000000000000000021b8c7dd77f9a95627922eceefea73f028f1ec95ba9b8fa95a3ad24bdf9fff414022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020101034200040000000000000000000006597fa94b1fd90000000000000000000000000000021b8c7dd77f9a95627922eceefea73f028f1ec95ba9b8fa95a3ad24bdf9fff414",
+          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
+          "shared" : "cea0fbd8f20abc8cf8127c132e29756d25ff1530a88bf5c9e22dc1c137c36be9",
+          "result" : "invalid"
         },
         {
-          "tcId" : 107,
+          "tcId" : 364,
           "comment" : "using secp224r1",
+          "flags" : [
+            "ModifiedGroup",
+            "InvalidPublic"
+          ],
           "public" : "304e301006072a8648ce3d020106052b81040021033a0004074f56dc2ea648ef89c3b72e23bbd2da36f60243e4d2067b70604af1c2165cec2f86603d60c8a611d5b84ba3d91dfe1a480825bcc4af3bcf",
           "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : [
-            "InvalidPublic"
-          ]
+          "result" : "invalid"
         },
         {
-          "tcId" : 108,
+          "tcId" : 365,
           "comment" : "using secp256k1",
+          "flags" : [
+            "ModifiedGroup",
+            "InvalidPublic"
+          ],
           "public" : "3056301006072a8648ce3d020106052b8104000a03420004a1263e75b87ae0937060ff1472f330ee55cdf8f4329d6284a9ebfbcc856c11684225e72cbebff41e54fb6f00e11afe53a17937bedbf2df787f8ef9584f775838",
           "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : [
-            "InvalidPublic"
-          ]
+          "result" : "invalid"
         },
         {
-          "tcId" : 109,
+          "tcId" : 366,
           "comment" : "a = 0",
-          "public" : "308201143081cd06072a8648ce3d02013081c1020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff302504010004201b95c2f46065dbf0f3ff09153e4748ed71595e0774ba8e25c364ff1e6be039b70441041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020101034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
-          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
-          "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
-          "result" : "acceptable",
           "flags" : [
+            "Modified curve parameter",
             "UnusedParam",
             "UnnamedCurve"
-          ]
+          ],
+          "public" : "308201333081ec06072a8648ce3d02013081e0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff30440420000000000000000000000000000000000000000000000000000000000000000004201b95c2f46065dbf0f3ff09153e4748ed71595e0774ba8e25c364ff1e6be039b70441041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020101034200041510264c189c3d523ff9916abd7069efa6968d8dc7ddb6457d7869b53ea60cdcfafb7ed4786da15d29ee59256f536da3575a4888c1bb0a95b256f4a7e9fd764a",
+          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
+          "shared" : "d003f5cc83852584061f7a8a28bcb5671ecbda096e16e7accfa8f8d311a3db7a",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 110,
+          "tcId" : 367,
           "comment" : "public key of order 3",
-          "public" : "308201333081ec06072a8648ce3d02013081e0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff304404205a715b6a9ef865f5058e21e20b575d9d585533bd588a9d5fb61cd69534b4e581042036a1a972d367abf9054cce4d54424592882c345283dc9cf0ec47231711f56b22044104d68a3dfbaeb2d277742e833c51625c2ded89b13ea1ec5d33b9cbca77334d79ec89c97eb4143dc3c88d1925fc4f30baba454bb201e5c0d3158ec98bb1fd045e12022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63255102010103420004d68a3dfbaeb2d277742e833c51625c2ded89b13ea1ec5d33b9cbca77334d79ec7636814aebc23c3872e6da03b0cf4545bab44dff1a3f2cea7136744e02fba1ed",
-          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
-          "shared" : "f0652d1cc135c763cd51e429d320a6101634d13b59790c3b1db0063f9f00dc99",
-          "result" : "invalid",
           "flags" : [
             "WeakPublicKey",
             "InvalidPublic",
             "UnnamedCurve"
-          ]
+          ],
+          "public" : "308201333081ec06072a8648ce3d02013081e0020101302c06072a8648ce3d0101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff3044042084b73db8827e8b3be3e19999bfc0edbd1a8d7d4a769c98c908722ae616c2707504204b07e7fb93c8c70ac19473fb808237fd22283557803c4f9a40c7fc4451b5321a0441045496d929cd5407ffbb4511d623a153fb672a3842f13c31aa1c0279dc9812bcafc9198ab53fc4fa2b78e9743103402985880a15ea2246c3479ed617e419c29b83022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020101034200045496d929cd5407ffbb4511d623a153fb672a3842f13c31aa1c0279dc9812bcaf36e67549c03b05d587168bcefcbfd67a77f5ea16ddb93cb86129e81be63d647c",
+          "private" : "4f3414d1589b49f7172d439cbbe78e5b5350dc85dea40cd2d6274740c6e0239c",
+          "shared" : "",
+          "result" : "invalid"
         },
         {
-          "tcId" : 111,
+          "tcId" : 368,
           "comment" : "Public key uses wrong curve: secp224r1",
+          "flags" : [
+            "WrongCurve"
+          ],
           "public" : "304e301006072a8648ce3d020106052b81040021033a00042af270d2a6030e3dd38cc46e7d719f176c2ca4eb04d7e8b84290c8edbcaed964ebe226b2d7ce17251622804c0d3b7adce020a3cdc97cac6c",
-          "private" : "0b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 112,
+          "tcId" : 369,
           "comment" : "Public key uses wrong curve: secp384r1",
+          "flags" : [
+            "WrongCurve"
+          ],
           "public" : "3076301006072a8648ce3d020106052b81040022036200041f17901e731b06f349b6e9d7d17d45e8a2b46115a47485be16197932db87b39405b5c941b36fd61b9ef7dd20878e129e55a2277099c601dcdb3747f80ad6e166116378e1ebce2c95744a0986128cfeeaac7f90b71787d9a1cfe417cd4c8f6af5",
-          "private" : "0b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 113,
+          "tcId" : 370,
           "comment" : "Public key uses wrong curve: secp521r1",
+          "flags" : [
+            "WrongCurve"
+          ],
           "public" : "30819b301006072a8648ce3d020106052b81040023038186000400ed76e5888428fad409ff203ab298b0f24827c091939ae0f9b1245d865ac5fbcd2749f9ae6c90fa8e29414d1bc7dc7b3c4aca904cd824484421cc66fe6af43bdfd200c1f790a0b3ae994937f91b6bdb9778b08c83ecadb8cba22a78c37bf565dac164f18e719be0ef890ee5cbf20e17fcfc9a5585e5416470b9862f82fb769339994f4e",
-          "private" : "0b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 114,
+          "tcId" : 371,
           "comment" : "Public key uses wrong curve: secp256k1",
+          "flags" : [
+            "WrongCurve"
+          ],
           "public" : "3056301006072a8648ce3d020106052b8104000a034200048028d16082b07696d4aa4aab9d6b1f1463435ac097900631108f9888e13da67c4841fd8dd3ced6e7ad8c6fc656621c2f93d3db0eb29d48d1423154519865dbc1",
-          "private" : "0b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 115,
+          "tcId" : 372,
+          "comment" : "Public key uses wrong curve: secp224k1",
+          "flags" : [
+            "WrongCurve"
+          ],
+          "public" : "304e301006072a8648ce3d020106052b81040020033a0004dc79fc28da096ac19f3cf0bc70b8e52529a83861ac66b1d44b9f2e9c68856babaa94f5fa67a1edfce5bd1768f9b9a1621483d214436aab02",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 373,
           "comment" : "Public key uses wrong curve: brainpoolP224r1",
+          "flags" : [
+            "WrongCurve"
+          ],
           "public" : "3052301406072a8648ce3d020106092b2403030208010105033a0004a6bae3d155c1f9ca263928c986ede69acefd0dd9b3a19d2b9f4b0a3a66bea5d167318dcc028945fc1b40c60ce716ba2d414a743c6b856a6f",
-          "private" : "0b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 116,
+          "tcId" : 374,
           "comment" : "Public key uses wrong curve: brainpoolP256r1",
+          "flags" : [
+            "WrongCurve"
+          ],
           "public" : "305a301406072a8648ce3d020106092b2403030208010107034200045d3ddbbb9bc071d8b59855c74bdf3541ae4cb6c1a24ec439034df7abde16a346523edf6a67896b304cb2cd2a083eec2b16935bbc910e85ec6eae38b50230bf70",
-          "private" : "0b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 117,
+          "tcId" : 375,
           "comment" : "Public key uses wrong curve: brainpoolP320r1",
+          "flags" : [
+            "WrongCurve"
+          ],
           "public" : "306a301406072a8648ce3d020106092b240303020801010903520004a43c6ef2500723d54c1fc88f8844d83445ca5a0f585c10b8eb3f022d47d0e84862b7f5cbf97d352d4348ca730f600f2258d1d192da223f6ba83a7cc0d6da598d55c2b77824d326c8df000b8fff156d2c",
-          "private" : "0b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 118,
+          "tcId" : 376,
           "comment" : "Public key uses wrong curve: brainpoolP384r1",
+          "flags" : [
+            "WrongCurve"
+          ],
           "public" : "307a301406072a8648ce3d020106092b240303020801010b036200042391c062833d1e6d89ec256cf4a3989534c1ead5e1e14ffae933a53f962857e4713087e1b3d65ac79634c71577af24698b5ce959183835551f7b08aef7853378c299930b360813fd58d5e4da8b37d5a7473e891ee11cb02881bd848b364fb7d5",
-          "private" : "0b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 119,
+          "tcId" : 377,
           "comment" : "Public key uses wrong curve: brainpoolP512r1",
+          "flags" : [
+            "WrongCurve"
+          ],
           "public" : "30819b301406072a8648ce3d020106092b240303020801010d038182000484beae85096640953c1fd6ebbc32697263d53f89943cbaf14432061aea8c0318acbd9389ab1d2e904fa0e081d08cfabb614ed9bca618211142d94623c14b476a25e47abf98fd3b1da1417dfc2e2cfc8424b16ea14dd45e1422be7d4e0a5cc7f4d4ab5f198cdbaaa3f642ec6361842cbe869382ee78cd596ff5e740d9ec2c3ad6",
-          "private" : "0b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 120,
+          "tcId" : 378,
           "comment" : "Public key uses wrong curve: brainpoolP224t1",
+          "flags" : [
+            "WrongCurve"
+          ],
           "public" : "3052301406072a8648ce3d020106092b2403030208010106033a00042b0a1a858ffc44e7752940731d378f96570837e279ea3948fe00cff8b5f89adb4e2fe6f8781ba6426364f4590b34dd79fc80629de4a86084",
-          "private" : "0b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 121,
+          "tcId" : 379,
           "comment" : "Public key uses wrong curve: brainpoolP256t1",
+          "flags" : [
+            "WrongCurve"
+          ],
           "public" : "305a301406072a8648ce3d020106092b2403030208010108034200043037c01b4a5ac53742e3f5528dffb0f010ab6ebeb08d792b32e19e9006ca331a024b67698d7cf4b575ccd9389441d5c640b77c63771cef1bd85675361c6602a4",
-          "private" : "0b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 122,
+          "tcId" : 380,
           "comment" : "Public key uses wrong curve: brainpoolP320t1",
+          "flags" : [
+            "WrongCurve"
+          ],
           "public" : "306a301406072a8648ce3d020106092b240303020801010a035200040f0fd972a495a140124a4019291a20f5b39fb755c126bf268643bb3091eca44f2a3cda1dead6ab1f4fe08a4b3872423f71e5bf96b1c20bc0ca73b7e2c134cc14a5f77bc838ebcf01084da3bf15663536",
-          "private" : "0b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 123,
+          "tcId" : 381,
           "comment" : "Public key uses wrong curve: brainpoolP384t1",
+          "flags" : [
+            "WrongCurve"
+          ],
           "public" : "307a301406072a8648ce3d020106092b240303020801010c0362000403b65faf5a6bf74bd5c166278a4b566c6c705ac6363e61f3b0699e116d3c5b19e8b7021b75b005f78a8cea8de34c49397f9b3b2bfc8706eb8163c802371eff7dfc825c40aa84dd9d1c4b34615ee5ae28c6c05d58d2a8ccc3786382b712d3bcda",
-          "private" : "0b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 124,
+          "tcId" : 382,
           "comment" : "Public key uses wrong curve: brainpoolP512t1",
+          "flags" : [
+            "WrongCurve"
+          ],
           "public" : "30819b301406072a8648ce3d020106092b240303020801010e03818200047504d660943a69ab043378e44c034896534a346e0e95f35fcaad3503b490856bfb20a753ecabc6d7bfeec28d057f919923b7d3c086953eb16c5bd287b59788db72dbb7c273854294c927ea7eca205aae2f0830e5faaddad8316231bfc3572c85c33cb7054e04c8936e3ce059c907e59f40593444e590b31820bc1f514ed0ec8a",
-          "private" : "0b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 125,
+          "tcId" : 383,
+          "comment" : "Public key uses wrong curve: FRP256v1",
+          "flags" : [
+            "WrongCurve"
+          ],
+          "public" : "305b301506072a8648ce3d0201060a2a817a01815f6582000103420004199d4176e91a519f54d5669eb60ae0f212807b872288c789813e9dca6207db96bf53007961d1bb7fc07c479b66d4e9ac34e866652619093146f81791c2e1366f",
+          "private" : "00b44f9670fedba887ad8e806226063e77604b27c362836326e93ecb7fcc6dc297",
+          "shared" : "",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 384,
           "comment" : "invalid public key",
+          "flags" : [
+            "InvalidCompressedPublic",
+            "CompressedPoint"
+          ],
           "public" : "3039301306072a8648ce3d020106082a8648ce3d03010703220002fd4bf61763b46581fd9174d623516cf3c81edd40e29ffa2777fb6cb0ae3ce535",
           "private" : "6f953faff3599e6c762d7f4cabfeed092de2add1df1bc5748c6cbb725cf35458",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : [
-            "CompressedPoint"
-          ]
+          "result" : "invalid"
         },
         {
-          "tcId" : 126,
+          "tcId" : 385,
           "comment" : "public key is a low order point on twist",
+          "flags" : [
+            "WrongCurve",
+            "CompressedPoint"
+          ],
           "public" : "3039301306072a8648ce3d020106082a8648ce3d03010703220003efdde3b32872a9effcf3b94cbf73aa7b39f9683ece9121b9852167f4e3da609b",
-          "private" : "0d27edf0ff5b6b6b465753e7158370332c153b468a1be087ad0f490bdb99e5f02",
+          "private" : "00d27edf0ff5b6b6b465753e7158370332c153b468a1be087ad0f490bdb99e5f02",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : [
-            "CompressedPoint"
-          ]
+          "result" : "invalid"
         },
         {
-          "tcId" : 127,
+          "tcId" : 386,
           "comment" : "public key is a low order point on twist",
+          "flags" : [
+            "WrongCurve",
+            "CompressedPoint"
+          ],
           "public" : "3039301306072a8648ce3d020106082a8648ce3d03010703220002efdde3b32872a9effcf3b94cbf73aa7b39f9683ece9121b9852167f4e3da609b",
-          "private" : "0d27edf0ff5b6b6b465753e7158370332c153b468a1be087ad0f490bdb99e5f03",
+          "private" : "00d27edf0ff5b6b6b465753e7158370332c153b468a1be087ad0f490bdb99e5f03",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : [
-            "CompressedPoint"
-          ]
+          "result" : "invalid"
         },
         {
-          "tcId" : 128,
+          "tcId" : 387,
           "comment" : "public key is a low order point on twist",
+          "flags" : [
+            "WrongCurve",
+            "CompressedPoint"
+          ],
           "public" : "3039301306072a8648ce3d020106082a8648ce3d03010703220002c49524b2adfd8f5f972ef554652836e2efb2d306c6d3b0689234cec93ae73db5",
-          "private" : "095ead84540c2d027aa3130ff1b47888cc1ed67e8dda46156e71ce0991791e835",
+          "private" : "0095ead84540c2d027aa3130ff1b47888cc1ed67e8dda46156e71ce0991791e835",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : [
-            "CompressedPoint"
-          ]
+          "result" : "invalid"
         },
         {
-          "tcId" : 129,
+          "tcId" : 388,
           "comment" : "public key is a low order point on twist",
+          "flags" : [
+            "WrongCurve",
+            "CompressedPoint"
+          ],
           "public" : "3039301306072a8648ce3d020106082a8648ce3d0301070322000318f9bae7747cd844e98525b7ccd0daf6e1d20a818b2175a9a91e4eae5343bc98",
-          "private" : "0a8681ef67fb1f189647d95e8db00c52ceef6d41a85ba0a5bd74c44e8e62c8aa4",
+          "private" : "00a8681ef67fb1f189647d95e8db00c52ceef6d41a85ba0a5bd74c44e8e62c8aa4",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : [
-            "CompressedPoint"
-          ]
+          "result" : "invalid"
         },
         {
-          "tcId" : 130,
+          "tcId" : 389,
           "comment" : "public key is a low order point on twist",
+          "flags" : [
+            "WrongCurve",
+            "CompressedPoint"
+          ],
           "public" : "3039301306072a8648ce3d020106082a8648ce3d0301070322000218f9bae7747cd844e98525b7ccd0daf6e1d20a818b2175a9a91e4eae5343bc98",
-          "private" : "0a8681ef67fb1f189647d95e8db00c52ceef6d41a85ba0a5bd74c44e8e62c8aa5",
+          "private" : "00a8681ef67fb1f189647d95e8db00c52ceef6d41a85ba0a5bd74c44e8e62c8aa5",
           "shared" : "",
-          "result" : "invalid",
-          "flags" : [
-            "CompressedPoint"
-          ]
+          "result" : "invalid"
         },
         {
-          "tcId" : 131,
+          "tcId" : 390,
           "comment" : "public key is a low order point on twist",
-          "public" : "3039301306072a8648ce3d020106082a8648ce3d03010703220003c49524b2adfd8f5f972ef554652836e2efb2d306c6d3b0689234cec93ae73db5",
-          "private" : "095ead84540c2d027aa3130ff1b47888cc1ed67e8dda46156e71ce0991791e834",
-          "shared" : "",
-          "result" : "invalid",
           "flags" : [
+            "WrongCurve",
             "CompressedPoint"
-          ]
+          ],
+          "public" : "3039301306072a8648ce3d020106082a8648ce3d03010703220003c49524b2adfd8f5f972ef554652836e2efb2d306c6d3b0689234cec93ae73db5",
+          "private" : "0095ead84540c2d027aa3130ff1b47888cc1ed67e8dda46156e71ce0991791e834",
+          "shared" : "",
+          "result" : "invalid"
         },
         {
-          "tcId" : 132,
-          "comment" : "long form encoding of length",
+          "tcId" : 391,
+          "comment" : "length of sequence uses long form encoding",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "308159301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 133,
-          "comment" : "long form encoding of length",
+          "tcId" : 392,
+          "comment" : "length of sequence uses long form encoding",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305a30811306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 134,
-          "comment" : "long form encoding of length",
-          "public" : "305a30140681072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
+          "tcId" : 393,
+          "comment" : "length of sequence contains a leading 0",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 135,
-          "comment" : "long form encoding of length",
-          "public" : "305a301406072a8648ce3d02010681082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 136,
-          "comment" : "long form encoding of length",
-          "public" : "305a301306072a8648ce3d020106082a8648ce3d03010703814200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 137,
-          "comment" : "length contains leading 0",
+          ],
           "public" : "30820059301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 138,
-          "comment" : "length contains leading 0",
+          "tcId" : 394,
+          "comment" : "length of sequence contains a leading 0",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b3082001306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 139,
-          "comment" : "length contains leading 0",
-          "public" : "305b3015068200072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
+          "tcId" : 395,
+          "comment" : "length of sequence uses 90 instead of 89",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 140,
-          "comment" : "length contains leading 0",
-          "public" : "305b301506072a8648ce3d0201068200082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 141,
-          "comment" : "length contains leading 0",
-          "public" : "305b301306072a8648ce3d020106082a8648ce3d0301070382004200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 142,
-          "comment" : "wrong length",
+          ],
           "public" : "305a301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 143,
-          "comment" : "wrong length",
+          "tcId" : 396,
+          "comment" : "length of sequence uses 88 instead of 89",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3058301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 144,
-          "comment" : "wrong length",
-          "public" : "3059301406072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
+          "tcId" : 397,
+          "comment" : "uint32 overflow in length of sequence",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 145,
-          "comment" : "wrong length",
-          "public" : "3059301206072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 146,
-          "comment" : "wrong length",
-          "public" : "3059301306082a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 147,
-          "comment" : "wrong length",
-          "public" : "3059301306062a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 148,
-          "comment" : "wrong length",
-          "public" : "3059301306072a8648ce3d020106092a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 149,
-          "comment" : "wrong length",
-          "public" : "3059301306072a8648ce3d020106072a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 150,
-          "comment" : "wrong length",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034300042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 151,
-          "comment" : "wrong length",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034100042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 152,
-          "comment" : "uint32 overflow in length",
+          ],
           "public" : "30850100000059301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 153,
-          "comment" : "uint32 overflow in length",
+          "tcId" : 398,
+          "comment" : "uint32 overflow in length of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305e3085010000001306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 154,
-          "comment" : "uint32 overflow in length",
-          "public" : "305e3018068501000000072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
+          "tcId" : 399,
+          "comment" : "uint64 overflow in length of sequence",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 155,
-          "comment" : "uint32 overflow in length",
-          "public" : "305e301806072a8648ce3d0201068501000000082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 156,
-          "comment" : "uint32 overflow in length",
-          "public" : "305e301306072a8648ce3d020106082a8648ce3d0301070385010000004200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 157,
-          "comment" : "uint64 overflow in length",
+          ],
           "public" : "3089010000000000000059301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 158,
-          "comment" : "uint64 overflow in length",
+          "tcId" : 400,
+          "comment" : "uint64 overflow in length of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3062308901000000000000001306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 159,
-          "comment" : "uint64 overflow in length",
-          "public" : "3062301c06890100000000000000072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
+          "tcId" : 401,
+          "comment" : "length of sequence = 2**31 - 1",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 160,
-          "comment" : "uint64 overflow in length",
-          "public" : "3062301c06072a8648ce3d020106890100000000000000082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 161,
-          "comment" : "uint64 overflow in length",
-          "public" : "3062301306072a8648ce3d020106082a8648ce3d030107038901000000000000004200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 162,
-          "comment" : "length = 2**31 - 1",
+          ],
           "public" : "30847fffffff301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 163,
-          "comment" : "length = 2**31 - 1",
+          "tcId" : 402,
+          "comment" : "length of sequence = 2**31 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305d30847fffffff06072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 164,
-          "comment" : "length = 2**31 - 1",
-          "public" : "305d301706847fffffff2a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
+          "tcId" : 403,
+          "comment" : "length of sequence = 2**32 - 1",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 165,
-          "comment" : "length = 2**31 - 1",
-          "public" : "305d301706072a8648ce3d020106847fffffff2a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 166,
-          "comment" : "length = 2**31 - 1",
-          "public" : "305d301306072a8648ce3d020106082a8648ce3d03010703847fffffff00042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 167,
-          "comment" : "length = 2**32 - 1",
+          ],
           "public" : "3084ffffffff301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 168,
-          "comment" : "length = 2**32 - 1",
+          "tcId" : 404,
+          "comment" : "length of sequence = 2**32 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305d3084ffffffff06072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 169,
-          "comment" : "length = 2**32 - 1",
-          "public" : "305d30170684ffffffff2a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
+          "tcId" : 405,
+          "comment" : "length of sequence = 2**40 - 1",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 170,
-          "comment" : "length = 2**32 - 1",
-          "public" : "305d301706072a8648ce3d02010684ffffffff2a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 171,
-          "comment" : "length = 2**32 - 1",
-          "public" : "305d301306072a8648ce3d020106082a8648ce3d0301070384ffffffff00042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 172,
-          "comment" : "length = 2**40 - 1",
+          ],
           "public" : "3085ffffffffff301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 173,
-          "comment" : "length = 2**40 - 1",
+          "tcId" : 406,
+          "comment" : "length of sequence = 2**40 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305e3085ffffffffff06072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 174,
-          "comment" : "length = 2**40 - 1",
-          "public" : "305e30180685ffffffffff2a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
+          "tcId" : 407,
+          "comment" : "length of sequence = 2**64 - 1",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 175,
-          "comment" : "length = 2**40 - 1",
-          "public" : "305e301806072a8648ce3d02010685ffffffffff2a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 176,
-          "comment" : "length = 2**40 - 1",
-          "public" : "305e301306072a8648ce3d020106082a8648ce3d0301070385ffffffffff00042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 177,
-          "comment" : "length = 2**64 - 1",
+          ],
           "public" : "3088ffffffffffffffff301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 178,
-          "comment" : "length = 2**64 - 1",
+          "tcId" : 408,
+          "comment" : "length of sequence = 2**64 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "30613088ffffffffffffffff06072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 179,
-          "comment" : "length = 2**64 - 1",
-          "public" : "3061301b0688ffffffffffffffff2a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
+          "tcId" : 409,
+          "comment" : "incorrect length of sequence",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 180,
-          "comment" : "length = 2**64 - 1",
-          "public" : "3061301b06072a8648ce3d02010688ffffffffffffffff2a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 181,
-          "comment" : "length = 2**64 - 1",
-          "public" : "3061301306072a8648ce3d020106082a8648ce3d0301070388ffffffffffffffff00042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 182,
-          "comment" : "incorrect length",
+          ],
           "public" : "30ff301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 183,
-          "comment" : "incorrect length",
+          "tcId" : 410,
+          "comment" : "incorrect length of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305930ff06072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 184,
-          "comment" : "incorrect length",
-          "public" : "3059301306ff2a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
+          "tcId" : 411,
+          "comment" : "replaced sequence by an indefinite length tag without termination",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 185,
-          "comment" : "incorrect length",
-          "public" : "3059301306072a8648ce3d020106ff2a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 186,
-          "comment" : "incorrect length",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703ff00042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 187,
-          "comment" : "indefinite length without termination",
+          ],
           "public" : "3080301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 188,
-          "comment" : "indefinite length without termination",
+          "tcId" : 412,
+          "comment" : "replaced sequence by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059308006072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 189,
-          "comment" : "indefinite length without termination",
-          "public" : "3059301306802a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 190,
-          "comment" : "indefinite length without termination",
-          "public" : "3059301306072a8648ce3d020106802a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 191,
-          "comment" : "indefinite length without termination",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107038000042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 192,
+          "tcId" : 413,
           "comment" : "removing sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 193,
+          "tcId" : 414,
           "comment" : "removing sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3044034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 194,
+          "tcId" : 415,
           "comment" : "lonely sequence tag",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "30",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 195,
+          "tcId" : 416,
           "comment" : "lonely sequence tag",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "304530034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 196,
+          "tcId" : 417,
           "comment" : "appending 0's to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b0000",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 197,
+          "tcId" : 418,
           "comment" : "appending 0's to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301506072a8648ce3d020106082a8648ce3d0301070000034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 198,
+          "tcId" : 419,
           "comment" : "prepending 0's to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b0000301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 199,
+          "tcId" : 420,
           "comment" : "prepending 0's to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b3015000006072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 200,
+          "tcId" : 421,
           "comment" : "appending unused 0's to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b0000",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 201,
+          "tcId" : 422,
           "comment" : "appending unused 0's to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301306072a8648ce3d020106082a8648ce3d0301070000034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 202,
+          "tcId" : 423,
           "comment" : "appending null value to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b0500",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 203,
+          "tcId" : 424,
           "comment" : "appending null value to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301506072a8648ce3d020106082a8648ce3d0301070500034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 204,
-          "comment" : "including garbage",
+          "tcId" : 425,
+          "comment" : "prepending garbage to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305e4981773059301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 205,
-          "comment" : "including garbage",
+          "tcId" : 426,
+          "comment" : "prepending garbage to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305d25003059301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 206,
-          "comment" : "including garbage",
-          "public" : "305b3059301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b0004deadbeef",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
+          "tcId" : 427,
+          "comment" : "prepending garbage to sequence",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 207,
-          "comment" : "including garbage",
+          ],
           "public" : "305e3018498177301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 208,
-          "comment" : "including garbage",
+          "tcId" : 428,
+          "comment" : "prepending garbage to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305d30172500301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 209,
-          "comment" : "including garbage",
+          "tcId" : 429,
+          "comment" : "appending garbage to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305b3059301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b0004deadbeef",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 430,
+          "comment" : "appending garbage to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "30613015301306072a8648ce3d020106082a8648ce3d0301070004deadbeef034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 210,
-          "comment" : "including garbage",
-          "public" : "305e3018260c49817706072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 211,
-          "comment" : "including garbage",
-          "public" : "305d3017260b250006072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 212,
-          "comment" : "including garbage",
-          "public" : "3061301b260906072a8648ce3d02010004deadbeef06082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 213,
-          "comment" : "including garbage",
-          "public" : "305e301806072a8648ce3d0201260d49817706082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 214,
-          "comment" : "including garbage",
-          "public" : "305d301706072a8648ce3d0201260c250006082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 215,
-          "comment" : "including garbage",
-          "public" : "3061301b06072a8648ce3d0201260a06082a8648ce3d0301070004deadbeef034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 216,
-          "comment" : "including garbage",
-          "public" : "305e301306072a8648ce3d020106082a8648ce3d0301072347498177034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 217,
-          "comment" : "including garbage",
-          "public" : "305d301306072a8648ce3d020106082a8648ce3d03010723462500034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 218,
-          "comment" : "including garbage",
-          "public" : "3061301306072a8648ce3d020106082a8648ce3d0301072344034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b0004deadbeef",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 219,
+          "tcId" : 431,
           "comment" : "including undefined tags",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3061aa00bb00cd003059301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 220,
+          "tcId" : 432,
           "comment" : "including undefined tags",
-          "public" : "305faa02aabb3059301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 221,
-          "comment" : "including undefined tags",
+          ],
           "public" : "3061301baa00bb00cd00301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 222,
+          "tcId" : 433,
           "comment" : "including undefined tags",
-          "public" : "305f3019aa02aabb301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 223,
-          "comment" : "including undefined tags",
+          ],
           "public" : "3061301b260faa00bb00cd0006072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 224,
+          "tcId" : 434,
           "comment" : "including undefined tags",
-          "public" : "305f3019260daa02aabb06072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 225,
-          "comment" : "including undefined tags",
+          ],
           "public" : "3061301b06072a8648ce3d02012610aa00bb00cd0006082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 226,
+          "tcId" : 435,
           "comment" : "including undefined tags",
-          "public" : "305f301906072a8648ce3d0201260eaa02aabb06082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 227,
-          "comment" : "including undefined tags",
+          ],
           "public" : "3061301306072a8648ce3d020106082a8648ce3d030107234aaa00bb00cd00034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 228,
-          "comment" : "including undefined tags",
-          "public" : "305f301306072a8648ce3d020106082a8648ce3d0301072348aa02aabb034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
-        },
-        {
-          "tcId" : 229,
+          "tcId" : 436,
           "comment" : "truncated length of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3081",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 230,
+          "tcId" : 437,
           "comment" : "truncated length of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "30463081034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 231,
+          "tcId" : 438,
+          "comment" : "including undefined tags to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305faa02aabb3059301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 439,
+          "comment" : "including undefined tags to sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305f3019aa02aabb301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 440,
           "comment" : "Replacing sequence with NULL",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "0500",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 232,
+          "tcId" : 441,
           "comment" : "Replacing sequence with NULL",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "30460500034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 233,
+          "tcId" : 442,
           "comment" : "changing tag value of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "2e59301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 234,
+          "tcId" : 443,
           "comment" : "changing tag value of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "2f59301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 235,
+          "tcId" : 444,
           "comment" : "changing tag value of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3159301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 236,
+          "tcId" : 445,
           "comment" : "changing tag value of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3259301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 237,
+          "tcId" : 446,
           "comment" : "changing tag value of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "ff59301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 238,
+          "tcId" : 447,
           "comment" : "changing tag value of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "30592e1306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 239,
+          "tcId" : 448,
           "comment" : "changing tag value of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "30592f1306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 240,
+          "tcId" : 449,
           "comment" : "changing tag value of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059311306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 241,
+          "tcId" : 450,
           "comment" : "changing tag value of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059321306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 242,
+          "tcId" : 451,
           "comment" : "changing tag value of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059ff1306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 243,
+          "tcId" : 452,
           "comment" : "dropping value of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3000",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 244,
+          "tcId" : 453,
           "comment" : "dropping value of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "30463000034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 245,
-          "comment" : "truncate sequence",
+          "tcId" : 454,
+          "comment" : "truncated sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3058301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add6",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 246,
-          "comment" : "truncate sequence",
+          "tcId" : 455,
+          "comment" : "truncated sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "30581306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 247,
-          "comment" : "truncate sequence",
+          "tcId" : 456,
+          "comment" : "truncated sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3058301206072a8648ce3d020106082a8648ce3d0301034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 248,
-          "comment" : "truncate sequence",
+          "tcId" : 457,
+          "comment" : "truncated sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "30583012072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 249,
+          "tcId" : 458,
+          "comment" : "sequence of size 4186 to check for overflows",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3082105a301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 459,
           "comment" : "indefinite length",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3080301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b0000",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 250,
+          "tcId" : 460,
           "comment" : "indefinite length",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b308006072a8648ce3d020106082a8648ce3d0301070000034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 251,
+          "tcId" : 461,
           "comment" : "indefinite length with truncated delimiter",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3080301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b00",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 252,
+          "tcId" : 462,
           "comment" : "indefinite length with truncated delimiter",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305a308006072a8648ce3d020106082a8648ce3d03010700034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 253,
+          "tcId" : 463,
           "comment" : "indefinite length with additional element",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3080301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b05000000",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 254,
+          "tcId" : 464,
           "comment" : "indefinite length with additional element",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305d308006072a8648ce3d020106082a8648ce3d03010705000000034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 255,
+          "tcId" : 465,
           "comment" : "indefinite length with truncated element",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3080301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b060811220000",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 256,
+          "tcId" : 466,
           "comment" : "indefinite length with truncated element",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305f308006072a8648ce3d020106082a8648ce3d030107060811220000034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 257,
+          "tcId" : 467,
           "comment" : "indefinite length with garbage",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3080301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b0000fe02beef",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 258,
+          "tcId" : 468,
           "comment" : "indefinite length with garbage",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305f308006072a8648ce3d020106082a8648ce3d0301070000fe02beef034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 259,
+          "tcId" : 469,
           "comment" : "indefinite length with nonempty EOC",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3080301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b0002beef",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 260,
+          "tcId" : 470,
           "comment" : "indefinite length with nonempty EOC",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305d308006072a8648ce3d020106082a8648ce3d0301070002beef034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 261,
+          "tcId" : 471,
           "comment" : "prepend empty sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b3000301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 262,
+          "tcId" : 472,
           "comment" : "prepend empty sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b3015300006072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 263,
+          "tcId" : 473,
           "comment" : "append empty sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b3000",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 264,
+          "tcId" : 474,
           "comment" : "append empty sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301506072a8648ce3d020106082a8648ce3d0301073000034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 265,
+          "tcId" : 475,
+          "comment" : "append garbage with high tag number",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305c301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66bbf7f00",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 476,
+          "comment" : "append garbage with high tag number",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305c301606072a8648ce3d020106082a8648ce3d030107bf7f00034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 477,
+          "comment" : "append null with explicit tag",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305d301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66ba0020500",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 478,
+          "comment" : "append null with explicit tag",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305d301706072a8648ce3d020106082a8648ce3d030107a0020500034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 479,
+          "comment" : "append null with implicit tag",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305b301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66ba000",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 480,
+          "comment" : "append null with implicit tag",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305b301506072a8648ce3d020106082a8648ce3d030107a000034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 481,
           "comment" : "sequence of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b3059301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 266,
+          "tcId" : 482,
           "comment" : "sequence of sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b3015301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 267,
-          "comment" : "truncated sequence",
+          "tcId" : 483,
+          "comment" : "truncated sequence: removed last 1 elements",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3015301306072a8648ce3d020106082a8648ce3d030107",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 268,
-          "comment" : "truncated sequence",
+          "tcId" : 484,
+          "comment" : "truncated sequence: removed last 1 elements",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "304f300906072a8648ce3d0201034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 269,
-          "comment" : "repeat element in sequence",
+          "tcId" : 485,
+          "comment" : "repeating element in sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "30819d301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 270,
-          "comment" : "repeat element in sequence",
+          "tcId" : 486,
+          "comment" : "repeating element in sequence",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3063301d06072a8648ce3d020106082a8648ce3d03010706082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 271,
+          "tcId" : 487,
+          "comment" : "length of sequence uses 20 instead of 19",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3059301406072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 488,
+          "comment" : "length of sequence uses 18 instead of 19",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3059301206072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 489,
+          "comment" : "sequence of size 4116 to check for overflows",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3082105c3082101406072a8648ce3d020106082a8648ce3d0301070000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 490,
+          "comment" : "length of oid uses long form encoding",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305a30140681072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 491,
+          "comment" : "length of oid uses long form encoding",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305a301406072a8648ce3d02010681082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 492,
+          "comment" : "length of oid contains a leading 0",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305b3015068200072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 493,
+          "comment" : "length of oid contains a leading 0",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305b301506072a8648ce3d0201068200082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 494,
+          "comment" : "length of oid uses 8 instead of 7",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3059301306082a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 495,
+          "comment" : "length of oid uses 6 instead of 7",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3059301306062a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 496,
+          "comment" : "uint32 overflow in length of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305e3018068501000000072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 497,
+          "comment" : "uint32 overflow in length of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305e301806072a8648ce3d0201068501000000082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 498,
+          "comment" : "uint64 overflow in length of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3062301c06890100000000000000072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 499,
+          "comment" : "uint64 overflow in length of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3062301c06072a8648ce3d020106890100000000000000082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 500,
+          "comment" : "length of oid = 2**31 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305d301706847fffffff2a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 501,
+          "comment" : "length of oid = 2**31 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305d301706072a8648ce3d020106847fffffff2a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 502,
+          "comment" : "length of oid = 2**32 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305d30170684ffffffff2a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 503,
+          "comment" : "length of oid = 2**32 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305d301706072a8648ce3d02010684ffffffff2a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 504,
+          "comment" : "length of oid = 2**40 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305e30180685ffffffffff2a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 505,
+          "comment" : "length of oid = 2**40 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305e301806072a8648ce3d02010685ffffffffff2a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 506,
+          "comment" : "length of oid = 2**64 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3061301b0688ffffffffffffffff2a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 507,
+          "comment" : "length of oid = 2**64 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3061301b06072a8648ce3d02010688ffffffffffffffff2a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 508,
+          "comment" : "incorrect length of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3059301306ff2a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 509,
+          "comment" : "incorrect length of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3059301306072a8648ce3d020106ff2a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 510,
+          "comment" : "replaced oid by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3059301306802a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 511,
+          "comment" : "replaced oid by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3059301306072a8648ce3d020106802a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 512,
           "comment" : "removing oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3050300a06082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 272,
+          "tcId" : 513,
           "comment" : "lonely oid tag",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3051300b0606082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 273,
+          "tcId" : 514,
           "comment" : "lonely oid tag",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3050300a06072a8648ce3d020106034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 274,
+          "tcId" : 515,
           "comment" : "appending 0's to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301506092a8648ce3d0201000006082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 275,
+          "tcId" : 516,
           "comment" : "appending 0's to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301506072a8648ce3d0201060a2a8648ce3d0301070000034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 276,
+          "tcId" : 517,
           "comment" : "prepending 0's to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b3015060900002a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 277,
+          "tcId" : 518,
           "comment" : "prepending 0's to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301506072a8648ce3d0201060a00002a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 278,
+          "tcId" : 519,
           "comment" : "appending unused 0's to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301506072a8648ce3d0201000006082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 279,
+          "tcId" : 520,
           "comment" : "appending null value to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301506092a8648ce3d0201050006082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 280,
+          "tcId" : 521,
           "comment" : "appending null value to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301506072a8648ce3d0201060a2a8648ce3d0301070500034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 281,
+          "tcId" : 522,
+          "comment" : "prepending garbage to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305e3018260c49817706072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 523,
+          "comment" : "prepending garbage to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305d3017260b250006072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 524,
+          "comment" : "prepending garbage to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305e301806072a8648ce3d0201260d49817706082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 525,
+          "comment" : "prepending garbage to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305d301706072a8648ce3d0201260c250006082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 526,
+          "comment" : "appending garbage to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3061301b260906072a8648ce3d02010004deadbeef06082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 527,
+          "comment" : "appending garbage to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3061301b06072a8648ce3d0201260a06082a8648ce3d0301070004deadbeef034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 528,
           "comment" : "truncated length of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3052300c068106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 282,
+          "tcId" : 529,
           "comment" : "truncated length of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3051300b06072a8648ce3d02010681034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 283,
+          "tcId" : 530,
+          "comment" : "including undefined tags to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305f3019260daa02aabb06072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 531,
+          "comment" : "including undefined tags to oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305f301906072a8648ce3d0201260eaa02aabb06082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 532,
           "comment" : "Replacing oid with NULL",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3052300c050006082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 284,
+          "tcId" : 533,
           "comment" : "Replacing oid with NULL",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3051300b06072a8648ce3d02010500034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 285,
+          "tcId" : 534,
           "comment" : "changing tag value of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301304072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 286,
+          "tcId" : 535,
           "comment" : "changing tag value of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301305072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 287,
+          "tcId" : 536,
           "comment" : "changing tag value of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301307072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 288,
+          "tcId" : 537,
           "comment" : "changing tag value of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301308072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 289,
+          "tcId" : 538,
           "comment" : "changing tag value of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "30593013ff072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 290,
+          "tcId" : 539,
           "comment" : "changing tag value of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d020104082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 291,
+          "tcId" : 540,
           "comment" : "changing tag value of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d020105082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 292,
+          "tcId" : 541,
           "comment" : "changing tag value of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d020107082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 293,
+          "tcId" : 542,
           "comment" : "changing tag value of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d020108082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 294,
+          "tcId" : 543,
           "comment" : "changing tag value of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d0201ff082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 295,
+          "tcId" : 544,
           "comment" : "dropping value of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3052300c060006082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 296,
+          "tcId" : 545,
           "comment" : "dropping value of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3051300b06072a8648ce3d02010600034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 297,
-          "comment" : "modify first byte of oid",
+          "tcId" : 546,
+          "comment" : "modifying first byte of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305930130607288648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 298,
-          "comment" : "modify first byte of oid",
+          "tcId" : 547,
+          "comment" : "modifying first byte of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d02010608288648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 299,
-          "comment" : "modify last byte of oid",
+          "tcId" : 548,
+          "comment" : "modifying last byte of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d028106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 300,
-          "comment" : "modify last byte of oid",
+          "tcId" : 549,
+          "comment" : "modifying last byte of oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d030187034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 301,
-          "comment" : "truncate oid",
+          "tcId" : 550,
+          "comment" : "truncated oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3058301206062a8648ce3d0206082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 302,
-          "comment" : "truncate oid",
+          "tcId" : 551,
+          "comment" : "truncated oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3058301206068648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 303,
-          "comment" : "truncate oid",
+          "tcId" : 552,
+          "comment" : "truncated oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3058301206072a8648ce3d020106072a8648ce3d0301034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 304,
-          "comment" : "truncate oid",
+          "tcId" : 553,
+          "comment" : "truncated oid",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3058301206072a8648ce3d020106078648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 305,
+          "tcId" : 554,
+          "comment" : "oid of size 4104 to check for overflows",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3082105e30821016068210082a8648ce3d0201000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 555,
           "comment" : "wrong oid",
-          "public" : "305c3016060a3262306530333032316106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "3057301106052b0e03021a06082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 306,
+          "tcId" : 556,
           "comment" : "wrong oid",
-          "public" : "3064301e061236303836343830313635303330343032303106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "305b3015060960864801650304020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 307,
+          "tcId" : 557,
           "comment" : "wrong oid",
-          "public" : "305b301506072a8648ce3d0201060a32623065303330323161034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "3056301006072a8648ce3d020106052b0e03021a034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 308,
+          "tcId" : 558,
           "comment" : "wrong oid",
-          "public" : "3063301d06072a8648ce3d02010612363038363438303136353033303430323031034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "305a301406072a8648ce3d02010609608648016503040201034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 309,
+          "tcId" : 559,
           "comment" : "longer oid",
-          "public" : "3062301c06103261383634386365336430323031303106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "305a301406082a8648ce3d02010106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 310,
+          "tcId" : 560,
           "comment" : "longer oid",
-          "public" : "3063301d06072a8648ce3d02010612326138363438636533643033303130373031034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "305a301406072a8648ce3d020106092a8648ce3d03010701034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 311,
+          "tcId" : 561,
           "comment" : "oid with modified node",
-          "public" : "3060301a060e326138363438636533643032313106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "3059301306072a8648ce3d021106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 312,
+          "tcId" : 562,
           "comment" : "oid with modified node",
-          "public" : "3068302206163261383634386365336430323838383038303830303106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "305d3017060b2a8648ce3d02888080800106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 313,
+          "tcId" : 563,
           "comment" : "oid with modified node",
-          "public" : "3061301b06072a8648ce3d0201061032613836343863653364303330313137034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030117034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 314,
+          "tcId" : 564,
           "comment" : "oid with modified node",
-          "public" : "3069302306072a8648ce3d02010618326138363438636533643033303138383830383038303037034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "305d301706072a8648ce3d0201060c2a8648ce3d03018880808007034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 315,
+          "tcId" : 565,
           "comment" : "large integer in oid",
-          "public" : "3072302c0620326138363438636533643032383238303830383038303830383038303830303106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "3062301c06102a8648ce3d028280808080808080800106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 316,
+          "tcId" : 566,
           "comment" : "large integer in oid",
-          "public" : "3073302d06072a8648ce3d0201062232613836343863653364303330313832383038303830383038303830383038303037034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "3062301c06072a8648ce3d020106112a8648ce3d030182808080808080808007034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 317,
+          "tcId" : 567,
           "comment" : "oid with invalid node",
-          "public" : "3063301d0611326138363438636533643032303165303306082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "305a301406082a8648ce3d0201e006082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 318,
+          "tcId" : 568,
           "comment" : "oid with invalid node",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305a301406082a808648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 319,
+          "tcId" : 569,
           "comment" : "oid with invalid node",
-          "public" : "3064301e06072a8648ce3d0201061332613836343863653364303330313037653033034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "305a301406072a8648ce3d020106092a8648ce3d030107e0034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 320,
+          "tcId" : 570,
           "comment" : "oid with invalid node",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305a301406072a8648ce3d020106092a808648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 321,
+          "tcId" : 571,
+          "comment" : "oid with 263 nodes",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3082015e30820116068201082a8648ce3d0201010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 572,
+          "comment" : "length of oid uses 9 instead of 8",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3059301306072a8648ce3d020106092a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 573,
+          "comment" : "length of oid uses 7 instead of 8",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3059301306072a8648ce3d020106072a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 574,
+          "comment" : "oid of size 4105 to check for overflows",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3082105e3082101606072a8648ce3d0201068210092a8648ce3d0301070000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 575,
+          "comment" : "oid with 264 nodes",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3082015e3082011606072a8648ce3d0201068201092a8648ce3d0301070101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101010101034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 576,
+          "comment" : "length of bit string uses long form encoding",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305a301306072a8648ce3d020106082a8648ce3d03010703814200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 577,
+          "comment" : "length of bit string contains a leading 0",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305b301306072a8648ce3d020106082a8648ce3d0301070382004200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 578,
+          "comment" : "length of bit string uses 67 instead of 66",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034300042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 579,
+          "comment" : "length of bit string uses 65 instead of 66",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034100042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 580,
+          "comment" : "uint32 overflow in length of bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305e301306072a8648ce3d020106082a8648ce3d0301070385010000004200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 581,
+          "comment" : "uint64 overflow in length of bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3062301306072a8648ce3d020106082a8648ce3d030107038901000000000000004200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 582,
+          "comment" : "length of bit string = 2**31 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305d301306072a8648ce3d020106082a8648ce3d03010703847fffffff00042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 583,
+          "comment" : "length of bit string = 2**32 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305d301306072a8648ce3d020106082a8648ce3d0301070384ffffffff00042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 584,
+          "comment" : "length of bit string = 2**40 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305e301306072a8648ce3d020106082a8648ce3d0301070385ffffffffff00042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 585,
+          "comment" : "length of bit string = 2**64 - 1",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3061301306072a8648ce3d020106082a8648ce3d0301070388ffffffffffffffff00042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 586,
+          "comment" : "incorrect length of bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d03010703ff00042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 587,
+          "comment" : "replaced bit string by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107038000042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 588,
           "comment" : "lonely bit string tag",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3016301306072a8648ce3d020106082a8648ce3d03010703",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 322,
+          "tcId" : 589,
           "comment" : "appending 0's to bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301306072a8648ce3d020106082a8648ce3d030107034400042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b0000",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 323,
+          "tcId" : 590,
           "comment" : "prepending 0's to bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301306072a8648ce3d020106082a8648ce3d0301070344000000042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 324,
+          "tcId" : 591,
           "comment" : "appending null value to bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305b301306072a8648ce3d020106082a8648ce3d030107034400042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b0500",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 325,
+          "tcId" : 592,
+          "comment" : "prepending garbage to bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305e301306072a8648ce3d020106082a8648ce3d0301072347498177034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 593,
+          "comment" : "prepending garbage to bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305d301306072a8648ce3d020106082a8648ce3d03010723462500034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 594,
+          "comment" : "appending garbage to bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3061301306072a8648ce3d020106082a8648ce3d0301072344034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b0004deadbeef",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 595,
           "comment" : "truncated length of bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3017301306072a8648ce3d020106082a8648ce3d0301070381",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 326,
+          "tcId" : 596,
+          "comment" : "including undefined tags to bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "305f301306072a8648ce3d020106082a8648ce3d0301072348aa02aabb034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 597,
           "comment" : "Replacing bit string with NULL",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3017301306072a8648ce3d020106082a8648ce3d0301070500",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 327,
+          "tcId" : 598,
           "comment" : "changing tag value of bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d030107014200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 328,
+          "tcId" : 599,
           "comment" : "changing tag value of bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d030107024200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 329,
+          "tcId" : 600,
           "comment" : "changing tag value of bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d030107044200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 330,
+          "tcId" : 601,
           "comment" : "changing tag value of bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d030107054200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 331,
+          "tcId" : 602,
           "comment" : "changing tag value of bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d030107ff4200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 332,
+          "tcId" : 603,
           "comment" : "dropping value of bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3017301306072a8648ce3d020106082a8648ce3d0301070300",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 333,
-          "comment" : "modify first byte of bit string",
+          "tcId" : 604,
+          "comment" : "modifying first byte of bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034202042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 334,
-          "comment" : "modify last byte of bit string",
+          "tcId" : 605,
+          "comment" : "modifying last byte of bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add6eb",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 335,
-          "comment" : "truncate bit string",
+          "tcId" : 606,
+          "comment" : "truncated bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3058301306072a8648ce3d020106082a8648ce3d030107034100042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add6",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 336,
-          "comment" : "truncate bit string",
+          "tcId" : 607,
+          "comment" : "truncated bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3058301306072a8648ce3d020106082a8648ce3d0301070341042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 337,
-          "comment" : "declaring bits as unused in a bit-string",
+          "tcId" : 608,
+          "comment" : "bit string of size 4163 to check for overflows",
+          "flags" : [
+            "InvalidAsn"
+          ],
+          "public" : "3082105c301306072a8648ce3d020106082a8648ce3d0301070382104300042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
+        },
+        {
+          "tcId" : 609,
+          "comment" : "declaring bits as unused in bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034201042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 338,
-          "comment" : "unused bits in a bit-string",
+          "tcId" : 610,
+          "comment" : "unused bits in bit string",
+          "flags" : [
+            "InvalidAsn"
+          ],
           "public" : "305d301306072a8648ce3d020106082a8648ce3d030107034620042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b01020304",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
           "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
-          "flags" : [
-            "InvalidAsn"
-          ]
+          "result" : "acceptable"
         },
         {
-          "tcId" : 339,
+          "tcId" : 611,
           "comment" : "unused bits in empty bit-string",
-          "public" : "3018301306072a8648ce3d020106082a8648ce3d030107030103",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "3018301306072a8648ce3d020106082a8648ce3d030107030103",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         },
         {
-          "tcId" : 340,
+          "tcId" : 612,
           "comment" : "128 unused bits",
-          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034280042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
-          "private" : "0c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
-          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
-          "result" : "acceptable",
           "flags" : [
             "InvalidAsn"
-          ]
+          ],
+          "public" : "3059301306072a8648ce3d020106082a8648ce3d030107034280042998705a9a71c783e1cf4397dbed9375a44e4cb88053594b0ea982203b6363b063d0af4971d1c3813db3c7799f9f9324cbe1b90054c81b510ff6297160add66b",
+          "private" : "00c9551ffe53ce60d73cbf8af553d0cb5f7632ece499590182c28cb6db2e3978d2",
+          "shared" : "f0b6d851dcd8e9a8c474d695137962f082c4f2a1a2eefb182df58d88a72829e4",
+          "result" : "acceptable"
         }
       ]
     }


### PR DESCRIPTION
Update Wycheproof testvector [ecdh_secp256r1_test v0](https://github.com/google/wycheproof/blob/master/testvectors/ecdh_secp256r1_test.json) to [ecdh_secp256r1_test v1](https://github.com/google/wycheproof/blob/master/testvectors_v1/ecdh_secp256r1_test.json).

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

We ought to use as many and as up to date test vectors as possible. Wycheproofs v0 were created 4 years ago and were due some upgrade.

### Modifications:

* Replaced the v0 with the v1 version.
* Changed `fatalError` in test code with a failable init.

### Result:

Number of tests is now `612` instead of v0's test count of ~`340`~.