### PR TITLE
Update Wycheproof multiple ECDSA test vectors to v1

### DIFF
--- a/Tests/CryptoTests/Signatures/ECDSA/ECDSASignatureTests.swift
+++ b/Tests/CryptoTests/Signatures/ECDSA/ECDSASignatureTests.swift
@@ -25,7 +25,7 @@ import XCTest
 
 struct ECDSATestGroup: Codable {
     let tests: [SignatureTestVector]
-    let key: ECDSAKey
+    let publicKey: ECDSAKey
 }
 
 struct ECDSAKey: Codable {
@@ -149,7 +149,7 @@ class SignatureTests: XCTestCase {
     }
     
     func testGroup<C: NISTSigning, HF: HashFunction>(group: ECDSATestGroup, curve: C.Type, hashFunction: HF.Type, file: StaticString = #file, line: UInt = #line) throws where C.ECDSASignature == C.PublicKey.Signature {
-        let keyBytes = try orFail(file: file, line: line) { try Array(hexString: group.key.uncompressed) }
+        let keyBytes = try orFail(file: file, line: line) { try Array(hexString: group.publicKey.uncompressed) }
         let key = try orFail(file: file, line: line) { try C.PublicKey(x963Representation: keyBytes) }
 
         for testVector in group.tests {

--- a/Tests/Test Vectors/ecdsa_secp256r1_sha256_test.json
+++ b/Tests/Test Vectors/ecdsa_secp256r1_sha256_test.json
@@ -1,4396 +1,6500 @@
 {
   "algorithm" : "ECDSA",
-  "generatorVersion" : "0.4.12",
+  "schema" : "ecdsa_verify_schema.json",
+  "generatorVersion" : "0.9rc5",
+  "numberOfTests" : 471,
+  "header" : [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of ASN encoded ECDSA signatures."
+  ],
   "notes" : {
-    "BER" : "This is a signature with correct values for (r, s) but using some alternative BER encoding instead of DER encoding. Implementations should not accept such signatures to limit signature malleability.",
-    "EdgeCase" : "Edge case values such as r=1 and s=0 can lead to forgeries if the ECDSA implementation does not check boundaries and computes s^(-1)==0.",
-    "MissingZero" : "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
-    "PointDuplication" : "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission."
+    "ArithmeticError" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "cves" : [
+        "CVE-2017-18146"
+      ]
+    },
+    "BerEncodedSignature" : {
+      "bugType" : "BER_ENCODING",
+      "description" : "ECDSA signatures are usually DER encoded. This signature contains valid values for r and s, but it uses alternative BER encoding.",
+      "effect" : "Accepting alternative BER encodings may be benign in some cases, or be an issue if protocol requires signature malleability.",
+      "cves" : [
+        "CVE-2020-14966",
+        "CVE-2020-13822",
+        "CVE-2019-14859",
+        "CVE-2016-1000342"
+      ]
+    },
+    "EdgeCasePublicKey" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidEncoding" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "ECDSA signatures are encoded using ASN.1. This test vector contains an incorrectly encoded signature. The test vector itself was generated from a valid signature by modifying its encoding.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature" : {
+      "bugType" : "AUTH_BYPASS",
+      "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "cves" : [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "InvalidTypesInSignature" : {
+      "bugType" : "AUTH_BYPASS",
+      "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "cves" : [
+        "CVE-2022-21449"
+      ]
+    },
+    "MissingZero" : {
+      "bugType" : "LEGACY",
+      "description" : "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
+      "effect" : "While signatures are more malleable if such signatures are accepted, this typically leads to no vulnerability, since a badly encoded signature can be reencoded correctly."
+    },
+    "ModifiedInteger" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModifiedSignature" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an invalid signature that was generated from a valid signature by modifying it.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect" : "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves" : [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves" : [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SmallRandS" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect" : "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves" : [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "ValidSignature" : {
+      "bugType" : "BASIC",
+      "description" : "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
   },
-  "numberOfTests" : 371,
-  "header" : [],
   "testGroups" : [
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
-        "wx" : "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838",
-        "wy" : "0c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
+        "uncompressed" : "0404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+        "wx" : "04aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad5",
+        "wy" : "0087d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKSexBRK64+3c/kZ4KBKLrSkDJpkZ\n9whgacjE32xzKDjHeHlk6qwA5ZIfsUmKYPRgZ2az2WhQAVWNGpdOc0FRPg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKrsc2NXJvIT+4qeZNo7hjLkFJWp\nRNAEW1IuunJA+tWH2TFXmKqjpboBd1eHztBeqve04J/IHW0apUboNl1SXQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
           "tcId" : 1,
-          "comment" : "signature malleability",
-          "msg" : "313233343030",
-          "sig" : "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802204cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd76",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
+          "msg" : "",
+          "sig" : "3045022100b292a619339f6e567a305c951c0dcbcc42d16e47f219f9e98e76e09d8770b34a02200177e60492c5a8242f76f07bfe3661bde59ec2a17ce5bd2dab2abebdf89a62e2",
+          "result" : "valid"
         },
         {
           "tcId" : 2,
-          "comment" : "Legacy:ASN encoding of s misses leading 0",
-          "msg" : "313233343030",
-          "sig" : "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180220b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "acceptable",
+          "comment" : "pseudorandom signature",
           "flags" : [
-            "MissingZero"
-          ]
+            "ValidSignature"
+          ],
+          "msg" : "4d7367",
+          "sig" : "30450220530bd6b0c9af2d69ba897f6b5fb59695cfbf33afe66dbadcf5b8d2a2a6538e23022100d85e489cb7a161fd55ededcedbf4cc0c0987e3e3f0f242cae934c72caa3f43e9",
+          "result" : "valid"
         },
         {
           "tcId" : 3,
-          "comment" : "valid",
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "valid",
-          "flags" : []
+          "sig" : "3046022100a8ea150cb80125d7381c4c1f1da8e9de2711f9917060406a73d7904519e51388022100f3ab9fa68bd47973a73b2d40480c2ba50c22c9d76ec217257288293285449b86",
+          "result" : "valid"
         },
         {
           "tcId" : 4,
-          "comment" : "long form encoding of length",
-          "msg" : "313233343030",
-          "sig" : "30814502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
+          "comment" : "pseudorandom signature",
           "flags" : [
-            "BER"
-          ]
-        },
+            "ValidSignature"
+          ],
+          "msg" : "0000000000000000000000000000000000000000",
+          "sig" : "3045022100986e65933ef2ed4ee5aada139f52b70539aaf63f00a91f29c69178490d57fb7102203dafedfb8da6189d372308cbf1489bbbdabf0c0217d1c0ff0f701aaa7a694b9c",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+        "wx" : "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838",
+        "wy" : "00c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKSexBRK64+3c/kZ4KBKLrSkDJpkZ\n9whgacjE32xzKDjHeHlk6qwA5ZIfsUmKYPRgZ2az2WhQAVWNGpdOc0FRPg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
         {
           "tcId" : 5,
-          "comment" : "long form encoding of length",
-          "msg" : "313233343030",
-          "sig" : "30460281202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
+          "comment" : "signature malleability",
           "flags" : [
-            "BER"
-          ]
+            "ValidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802204cd60b855d442f5b3c7b11eb6c4e0ae7525fe710fab9aa7c77a67f79e6fadd76",
+          "result" : "valid"
         },
         {
           "tcId" : 6,
-          "comment" : "long form encoding of length",
-          "msg" : "313233343030",
-          "sig" : "304602202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802812100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
+          "comment" : "Legacy: ASN encoding of s misses leading 0",
           "flags" : [
-            "BER"
-          ]
+            "MissingZero"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180220b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 7,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "3082004502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
+          "comment" : "valid",
           "flags" : [
-            "BER"
-          ]
+            "ValidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "valid"
         },
         {
           "tcId" : 8,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "3047028200202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
+          "comment" : "length of sequence [r, s] uses long form encoding",
           "flags" : [
-            "BER"
-          ]
+            "BerEncodedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30814502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 9,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180282002100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
+          "comment" : "length of sequence [r, s] contains a leading 0",
           "flags" : [
-            "BER"
-          ]
+            "BerEncodedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3082004502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 10,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] uses 70 instead of 69",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
           "sig" : "304602202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
           "tcId" : 11,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] uses 68 instead of 69",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
           "sig" : "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
           "tcId" : 12,
-          "comment" : "wrong length",
+          "comment" : "uint32 overflow in length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502212ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3085010000004502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 13,
-          "comment" : "wrong length",
+          "comment" : "uint64 overflow in length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3045021f2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308901000000000000004502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 14,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022200b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30847fffffff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 15,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30848000000002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 16,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3085010000004502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3084ffffffff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 17,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**40 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304a028501000000202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3085ffffffffff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 18,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304a02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180285010000002100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3088ffffffffffffffff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 19,
-          "comment" : "uint64 overflow in length",
+          "comment" : "incorrect length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308901000000000000004502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30ff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 20,
-          "comment" : "uint64 overflow in length",
+          "comment" : "replaced sequence [r, s] by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304e02890100000000000000202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 21,
-          "comment" : "uint64 overflow in length",
+          "comment" : "removing sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304e02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18028901000000000000002100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "",
+          "result" : "invalid"
         },
         {
           "tcId" : 22,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "lonely sequence tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30847fffffff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30",
+          "result" : "invalid"
         },
         {
           "tcId" : 23,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "appending 0's to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304902847fffffff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 24,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "prepending 0's to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802847fffffff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3047000002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 25,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "appending unused 0's to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3084ffffffff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 26,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "appending null value to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30490284ffffffff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 27,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "prepending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180284ffffffff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304a498177304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 28,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "prepending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3085ffffffffff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30492500304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 29,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "appending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304a0285ffffffffff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3047304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0004deadbeef",
+          "result" : "invalid"
         },
         {
           "tcId" : 30,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304a02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180285ffffffffff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304daa00bb00cd00304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 31,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3088ffffffffffffffff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304d2228aa00bb00cd0002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 32,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304d0288ffffffffffffffff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304d02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182229aa00bb00cd00022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 33,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "truncated length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304d02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180288ffffffffffffffff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3081",
+          "result" : "invalid"
         },
         {
           "tcId" : 34,
-          "comment" : "incorrect length",
+          "comment" : "including undefined tags to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30ff02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304baa02aabb304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 35,
-          "comment" : "incorrect length",
+          "comment" : "using composition with indefinite length for sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502ff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 36,
-          "comment" : "incorrect length",
+          "comment" : "using composition with wrong tag for sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802ff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080314502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 37,
-          "comment" : "indefinite length without termination",
+          "comment" : "Replacing sequence [r, s] with NULL",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 38,
-          "comment" : "indefinite length without termination",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502802ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "2e4502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 39,
-          "comment" : "indefinite length without termination",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18028000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "2f4502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 40,
-          "comment" : "removing sequence",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "314502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 41,
-          "comment" : "lonely sequence tag",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "324502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 42,
-          "comment" : "appending 0's to sequence",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "ff4502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 43,
-          "comment" : "prepending 0's to sequence",
+          "comment" : "dropping value of sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3047000002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 44,
-          "comment" : "appending unused 0's to sequence",
+          "comment" : "using composition for sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30493001023044202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 45,
-          "comment" : "appending null value to sequence",
+          "comment" : "truncated sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847",
+          "result" : "invalid"
         },
         {
           "tcId" : 46,
-          "comment" : "including garbage",
+          "comment" : "truncated sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304a498177304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3044202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 47,
-          "comment" : "including garbage",
+          "comment" : "sequence [r, s] of size 4166 to check for overflows",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30492500304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3082104602202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 48,
-          "comment" : "including garbage",
+          "comment" : "indefinite length",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3047304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0004deadbeef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 49,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with truncated delimiter",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304a222549817702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db00",
+          "result" : "invalid"
         },
         {
           "tcId" : 50,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with additional element",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30492224250002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db05000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 51,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with truncated element",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304d222202202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180004deadbeef022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db060811220000",
+          "result" : "invalid"
         },
         {
           "tcId" : 52,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with garbage",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304a02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182226498177022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000fe02beef",
+          "result" : "invalid"
         },
         {
           "tcId" : 53,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with nonempty EOC",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1822252500022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0002beef",
+          "result" : "invalid"
         },
         {
           "tcId" : 54,
-          "comment" : "including garbage",
+          "comment" : "prepend empty sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304d02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182223022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0004deadbeef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3047300002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 55,
-          "comment" : "including undefined tags",
+          "comment" : "append empty sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304daa00bb00cd00304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 56,
-          "comment" : "including undefined tags",
+          "comment" : "append zero",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304baa02aabb304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304802202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 57,
-          "comment" : "including undefined tags",
+          "comment" : "append garbage with high tag number",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304d2228aa00bb00cd0002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304802202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847dbbf7f00",
+          "result" : "invalid"
         },
         {
           "tcId" : 58,
-          "comment" : "including undefined tags",
+          "comment" : "append null with explicit tag",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304b2226aa02aabb02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847dba0020500",
+          "result" : "invalid"
         },
         {
           "tcId" : 59,
-          "comment" : "including undefined tags",
+          "comment" : "append null with implicit tag",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304d02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182229aa00bb00cd00022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847dba000",
+          "result" : "invalid"
         },
         {
           "tcId" : 60,
-          "comment" : "including undefined tags",
+          "comment" : "sequence of sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304b02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182227aa02aabb022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3047304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 61,
-          "comment" : "truncated length of sequence",
+          "comment" : "truncated sequence: removed last 1 elements",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3081",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "302202202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18",
+          "result" : "invalid"
         },
         {
           "tcId" : 62,
-          "comment" : "using composition with indefinite length",
+          "comment" : "repeating element in sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306802202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 63,
-          "comment" : "using composition with indefinite length",
+          "comment" : "flipped bit 0 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3049228002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180000022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30432ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e19022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 64,
-          "comment" : "using composition with indefinite length",
+          "comment" : "flipped bit 32 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182280022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30432ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af8bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 65,
-          "comment" : "using composition with wrong tag",
+          "comment" : "flipped bit 48 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080314502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30432ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cd6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 66,
-          "comment" : "using composition with wrong tag",
+          "comment" : "flipped bit 64 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3049228003202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180000022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30432ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee858b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 67,
-          "comment" : "using composition with wrong tag",
+          "comment" : "length of r uses long form encoding",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182280032100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30460281202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 68,
-          "comment" : "Replacing sequence with NULL",
+          "comment" : "length of r contains a leading 0",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "0500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3047028200202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 69,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r uses 33 instead of 32",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "2e4502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502212ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 70,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r uses 31 instead of 32",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "2f4502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3045021f2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 71,
-          "comment" : "changing tag value of sequence",
+          "comment" : "uint32 overflow in length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "314502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304a028501000000202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 72,
-          "comment" : "changing tag value of sequence",
+          "comment" : "uint64 overflow in length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "324502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304e02890100000000000000202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 73,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "ff4502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902847fffffff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 74,
-          "comment" : "dropping value of sequence",
+          "comment" : "length of r = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30490284800000002ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 75,
-          "comment" : "using composition for sequence",
+          "comment" : "length of r = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30493001023044202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30490284ffffffff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 76,
-          "comment" : "truncate sequence",
+          "comment" : "length of r = 2**40 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304a0285ffffffffff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 77,
-          "comment" : "truncate sequence",
+          "comment" : "length of r = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3044202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304d0288ffffffffffffffff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 78,
-          "comment" : "indefinite length",
-          "msg" : "313233343030",
-          "sig" : "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
-          "result" : "invalid",
+          "comment" : "incorrect length of r",
           "flags" : [
-            "BER"
-          ]
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502ff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 79,
-          "comment" : "indefinite length with truncated delimiter",
+          "comment" : "replaced r by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db00",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502802ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 80,
-          "comment" : "indefinite length with additional element",
+          "comment" : "removing r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db05000000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3023022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 81,
-          "comment" : "indefinite length with truncated element",
+          "comment" : "lonely integer tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db060811220000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "302402022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 82,
-          "comment" : "indefinite length with garbage",
+          "comment" : "lonely integer tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000fe02beef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "302302202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802",
+          "result" : "invalid"
         },
         {
           "tcId" : 83,
-          "comment" : "indefinite length with nonempty EOC",
+          "comment" : "appending 0's to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0002beef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702222ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180000022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 84,
-          "comment" : "prepend empty sequence",
+          "comment" : "prepending 0's to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3047300002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3047022200002ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 85,
-          "comment" : "append empty sequence",
+          "comment" : "appending unused 0's to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db3000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180000022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 86,
-          "comment" : "sequence of sequence",
+          "comment" : "appending null value to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3047304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702222ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180500022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 87,
-          "comment" : "truncated sequence",
+          "comment" : "prepending garbage to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "302202202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304a222549817702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 88,
-          "comment" : "repeat element in sequence",
+          "comment" : "prepending garbage to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306802202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30492224250002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 89,
-          "comment" : "removing integer",
+          "comment" : "appending garbage to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3023022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304d222202202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180004deadbeef022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 90,
-          "comment" : "lonely integer tag",
+          "comment" : "truncated length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "302402022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30250281022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 91,
-          "comment" : "lonely integer tag",
+          "comment" : "including undefined tags to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "302302202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304b2226aa02aabb02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 92,
-          "comment" : "appending 0's to integer",
+          "comment" : "using composition with indefinite length for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702222ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180000022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3049228002202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180000022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 93,
-          "comment" : "appending 0's to integer",
+          "comment" : "using composition with wrong tag for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022300b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3049228003202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180000022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 94,
-          "comment" : "prepending 0's to integer",
-          "msg" : "313233343030",
-          "sig" : "3047022200002ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
+          "comment" : "Replacing r with NULL",
           "flags" : [
-            "BER"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30250500022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 95,
-          "comment" : "prepending 0's to integer",
-          "msg" : "313233343030",
-          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180223000000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
+          "comment" : "changing tag value of r",
           "flags" : [
-            "BER"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304500202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 96,
-          "comment" : "appending unused 0's to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180000022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304501202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 97,
-          "comment" : "appending null value to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702222ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180500022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304503202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 98,
-          "comment" : "appending null value to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022300b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304504202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 99,
-          "comment" : "truncated length of integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30250281022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3045ff202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 100,
-          "comment" : "truncated length of integer",
+          "comment" : "dropping value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "302402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180281",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30250200022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 101,
-          "comment" : "Replacing integer with NULL",
+          "comment" : "using composition for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30250500022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3049222402012b021fa3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 102,
-          "comment" : "Replacing integer with NULL",
+          "comment" : "modifying first byte of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "302402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3045022029a3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 103,
-          "comment" : "changing tag value of integer",
+          "comment" : "modifying last byte of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304500202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e98022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 104,
-          "comment" : "changing tag value of integer",
+          "comment" : "truncated r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304501202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3044021f2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 105,
-          "comment" : "changing tag value of integer",
+          "comment" : "truncated r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304503202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3044021fa3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 106,
-          "comment" : "changing tag value of integer",
+          "comment" : "r of size 4129 to check for overflows",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304504202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30821048028210212ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 107,
-          "comment" : "changing tag value of integer",
+          "comment" : "leading ff in r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3045ff202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30460221ff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 108,
-          "comment" : "changing tag value of integer",
+          "comment" : "replaced r by infinity",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18002100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3026090180022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 109,
-          "comment" : "changing tag value of integer",
+          "comment" : "replacing r with zero",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18012100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3026020100022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 110,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 0 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18032100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304302202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1800b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847da",
+          "result" : "invalid"
         },
         {
           "tcId" : 111,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 32 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18042100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304302202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1800b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b48156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 112,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 48 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18ff2100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304302202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1800b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c124b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 113,
-          "comment" : "dropping value of integer",
+          "comment" : "flipped bit 64 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30250200022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304302202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1800b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4097c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 114,
-          "comment" : "dropping value of integer",
+          "comment" : "length of s uses long form encoding",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "302402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180200",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304602202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802812100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 115,
-          "comment" : "using composition for integer",
+          "comment" : "length of s contains a leading 0",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3049222402012b021fa3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180282002100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 116,
-          "comment" : "using composition for integer",
+          "comment" : "length of s uses 34 instead of 33",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1822250201000220b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022200b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 117,
-          "comment" : "modify first byte of integer",
+          "comment" : "length of s uses 32 instead of 33",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3045022029a3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 118,
-          "comment" : "modify first byte of integer",
+          "comment" : "uint32 overflow in length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022102b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304a02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180285010000002100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 119,
-          "comment" : "modify last byte of integer",
+          "comment" : "uint64 overflow in length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e98022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304e02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18028901000000000000002100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 120,
-          "comment" : "modify last byte of integer",
+          "comment" : "length of s = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b491568475b",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802847fffffff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 121,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3044021f2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802848000000000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 122,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3044021fa3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180284ffffffff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 123,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**40 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304a02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180285ffffffffff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 124,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180220b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304d02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180288ffffffffffffffff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 125,
-          "comment" : "leading ff in integer",
+          "comment" : "incorrect length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30460221ff2ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802ff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 126,
-          "comment" : "leading ff in integer",
+          "comment" : "replaced s by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304602202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180222ff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18028000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 127,
-          "comment" : "infinity",
+          "comment" : "appending 0's to s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3026090180022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022300b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 128,
-          "comment" : "infinity",
+          "comment" : "prepending 0's to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "302502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18090180",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180223000000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 129,
-          "comment" : "replacing integer with zero",
+          "comment" : "appending null value to s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3026020100022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022300b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 130,
-          "comment" : "replacing integer with zero",
+          "comment" : "prepending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "302502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18020100",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304a02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182226498177022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 131,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "prepending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30460221012ba3a8bd6b94d5ed80a6d9d1190a436ebccc0833490686deac8635bcb9bf5369022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1822252500022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 132,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "appending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30460221ff2ba3a8bf6b94d5eb80a6d9d1190a436f42fe12d7fad749d4c512a036c0f908c7022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304d02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182223022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0004deadbeef",
+          "result" : "invalid"
         },
         {
           "tcId" : 133,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "truncated length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30450220d45c5741946b2a137f59262ee6f5bc91001af27a5e1117a64733950642a3d1e8022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "302402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180281",
+          "result" : "invalid"
         },
         {
           "tcId" : 134,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "including undefined tags to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3046022100d45c5740946b2a147f59262ee6f5bc90bd01ed280528b62b3aed5fc93f06f739022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304b02202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182227aa02aabb022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 135,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "using composition with indefinite length for s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30460221fed45c5742946b2a127f59262ee6f5bc914333f7ccb6f979215379ca434640ac97022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182280022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 136,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "using composition with wrong tag for s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30460221012ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e182280032100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 137,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "Replacing s with NULL",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3046022100d45c5741946b2a137f59262ee6f5bc91001af27a5e1117a64733950642a3d1e8022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "302402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180500",
+          "result" : "invalid"
         },
         {
           "tcId" : 138,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022101b329f478a2bbd0a6c384ee1493b1f518276e0e4a5375928d6fcd160c11cb6d2c",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18002100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 139,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180220b329f47aa2bbd0a4c384ee1493b1f518ada018ef05465583885980861905228a",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18012100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 140,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180221ff4cd60b865d442f5a3c7b11eb6c4e0ae79578ec6353a20bf783ecb4b6ea97b825",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18032100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 141,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180221fe4cd60b875d442f593c7b11eb6c4e0ae7d891f1b5ac8a6d729032e9f3ee3492d4",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18042100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 142,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022101b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18ff2100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 143,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "dropping value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1802204cd60b865d442f5a3c7b11eb6c4e0ae79578ec6353a20bf783ecb4b6ea97b825",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "302402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180200",
+          "result" : "invalid"
         },
         {
           "tcId" : 144,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020100020100",
-          "result" : "invalid",
+          "comment" : "using composition for s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304902202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e1822250201000220b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 145,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020100020101",
-          "result" : "invalid",
+          "comment" : "modifying first byte of s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022102b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 146,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201000201ff",
-          "result" : "invalid",
+          "comment" : "modifying last byte of s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b491568475b",
+          "result" : "invalid"
         },
         {
           "tcId" : 147,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "truncated s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304402202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847",
+          "result" : "invalid"
         },
         {
           "tcId" : 148,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "s of size 4130 to check for overflows",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3082104802202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180282102200b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 149,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "leading ff in s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304602202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e180222ff00b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 150,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020100022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "replaced s by infinity",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18090180",
+          "result" : "invalid"
         },
         {
           "tcId" : 151,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020100022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "replacing s with zero",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302502202ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 152,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3008020100090380fe01",
-          "result" : "invalid",
+          "comment" : "replaced r by r + n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30460221012ba3a8bd6b94d5ed80a6d9d1190a436ebccc0833490686deac8635bcb9bf5369022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 153,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020101020100",
-          "result" : "invalid",
+          "comment" : "replaced r by r - n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30460221ff2ba3a8bf6b94d5eb80a6d9d1190a436f42fe12d7fad749d4c512a036c0f908c7022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 154,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020101020101",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 256 * n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047022201002ba3a7be6b94d6ec80a6d9d1190a432be6dfbb2cb98d6d4d72972df620817f18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 155,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201010201ff",
-          "result" : "invalid",
+          "comment" : "replaced r by -r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30450220d45c5741946b2a137f59262ee6f5bc91001af27a5e1117a64733950642a3d1e8022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 156,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "replaced r by n - r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100d45c5740946b2a147f59262ee6f5bc90bd01ed280528b62b3aed5fc93f06f739022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 157,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "replaced r by -n - r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30460221fed45c5742946b2a127f59262ee6f5bc914333f7ccb6f979215379ca434640ac97022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 158,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 2**256",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30460221012ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 159,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 2**320",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304e02290100000000000000002ba3a8be6b94d5ec80a6d9d1190a436effe50d85a1eee859b8cc6af9bd5c2e18022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 160,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020101022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "replaced s by s + n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022101b329f478a2bbd0a6c384ee1493b1f518276e0e4a5375928d6fcd160c11cb6d2c022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 161,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3008020101090380fe01",
-          "result" : "invalid",
+          "comment" : "replaced s by s - n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30450220b329f47aa2bbd0a4c384ee1493b1f518ada018ef05465583885980861905228a022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 162,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff020100",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 256 * n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304702220100b329f379a2bbd1a5c384ee1493b1f4d55181c143c3fc78fc35de0e45788d98db022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 163,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff020101",
-          "result" : "invalid",
+          "comment" : "replaced s by -s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30460221ff4cd60b865d442f5a3c7b11eb6c4e0ae79578ec6353a20bf783ecb4b6ea97b825022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 164,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff0201ff",
-          "result" : "invalid",
+          "comment" : "replaced s by -n - s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30460221fe4cd60b875d442f593c7b11eb6c4e0ae7d891f1b5ac8a6d729032e9f3ee3492d4022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 165,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 2**256",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022101b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 166,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "replaced s by s - 2**256",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30450220b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 167,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 2**320",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304e0229010000000000000000b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db022100b329f479a2bbd0a5c384ee1493b1f5186a87139cac5df4087c134b49156847db",
+          "result" : "invalid"
         },
         {
           "tcId" : 168,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30260201ff022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 169,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30260201ff022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 170,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30080201ff090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201000201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 171,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 172,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 173,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 174,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020100022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 175,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020100022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 176,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 177,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 178,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201010201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 179,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3028022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 180,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 181,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 182,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325500201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 183,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020101022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 184,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 185,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 186,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff0201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 187,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 188,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3028022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 189,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 190,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260201ff022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 191,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325520201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260201ff022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 192,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 193,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 194,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 195,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 196,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 197,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3028022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 198,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 199,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 200,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 201,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 202,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325500201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 203,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 204,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 205,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 206,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3028022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 207,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000001000000000000000000000001000000000000000000000000020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 208,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000001000000000000000000000001000000000000000000000000020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 209,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff000000010000000000000000000000010000000000000000000000000201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 210,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325520201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 211,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 212,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 213,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 214,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 215,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3028022100ffffffff00000001000000000000000000000001000000000000000000000000090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 216,
-          "comment" : "Edge case for Shamir multiplication",
-          "msg" : "3639383139",
-          "sig" : "3044022064a1aab5000d0e804f3e2fc02bdee9be8ff312334e2ba16d11547c97711c898e02206af015971cc30be6d1a206d4e013e0997772a2f91d73286ffd683b9bb2cf4f1b",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=0",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 217,
-          "comment" : "special case hash",
-          "msg" : "343236343739373234",
-          "sig" : "3044022016aea964a2f6506d6f78c81c91fc7e8bded7d397738448de1e19a0ec580bf2660220252cd762130c6667cfe8b7bc47d27d78391e8e80c578d1cd38c3ff033be928e9",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 218,
-          "comment" : "special case hash",
-          "msg" : "37313338363834383931",
-          "sig" : "30450221009cc98be2347d469bf476dfc26b9b733df2d26d6ef524af917c665baccb23c8820220093496459effe2d8d70727b82462f61d0ec1b7847929d10ea631dacb16b56c32",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=-1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 219,
-          "comment" : "special case hash",
-          "msg" : "3130333539333331363638",
-          "sig" : "3044022073b3c90ecd390028058164524dde892703dce3dea0d53fa8093999f07ab8aa4302202f67b0b8e20636695bb7d8bf0a651c802ed25a395387b5f4188c0c4075c88634",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 220,
-          "comment" : "special case hash",
-          "msg" : "33393439343031323135",
-          "sig" : "3046022100bfab3098252847b328fadf2f89b95c851a7f0eb390763378f37e90119d5ba3dd022100bdd64e234e832b1067c2d058ccb44d978195ccebb65c2aaf1e2da9b8b4987e3b",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n - 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 221,
-          "comment" : "special case hash",
-          "msg" : "31333434323933303739",
-          "sig" : "30440220204a9784074b246d8bf8bf04a4ceb1c1f1c9aaab168b1596d17093c5cd21d2cd022051cce41670636783dc06a759c8847868a406c2506fe17975582fe648d1d88b52",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 222,
-          "comment" : "special case hash",
-          "msg" : "33373036323131373132",
-          "sig" : "3046022100ed66dc34f551ac82f63d4aa4f81fe2cb0031a91d1314f835027bca0f1ceeaa0302210099ca123aa09b13cd194a422e18d5fda167623c3f6e5d4d6abb8953d67c0c48c7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=p",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 223,
-          "comment" : "special case hash",
-          "msg" : "333433363838373132",
-          "sig" : "30450220060b700bef665c68899d44f2356a578d126b062023ccc3c056bf0f60a237012b0221008d186c027832965f4fcc78a3366ca95dedbb410cbef3f26d6be5d581c11d3610",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=p + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 224,
-          "comment" : "special case hash",
-          "msg" : "31333531353330333730",
-          "sig" : "30460221009f6adfe8d5eb5b2c24d7aa7934b6cf29c93ea76cd313c9132bb0c8e38c96831d022100b26a9c9e40e55ee0890c944cf271756c906a33e66b5bd15e051593883b5e9902",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=0",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000001000000000000000000000000020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 225,
-          "comment" : "special case hash",
-          "msg" : "36353533323033313236",
-          "sig" : "3045022100a1af03ca91677b673ad2f33615e56174a1abf6da168cebfa8868f4ba273f16b7022020aa73ffe48afa6435cd258b173d0c2377d69022e7d098d75caf24c8c5e06b1c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000001000000000000000000000000020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 226,
-          "comment" : "special case hash",
-          "msg" : "31353634333436363033",
-          "sig" : "3045022100fdc70602766f8eed11a6c99a71c973d5659355507b843da6e327a28c11893db902203df5349688a085b137b1eacf456a9e9e0f6d15ec0078ca60a7f83f2b10d21350",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=-1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff000000010000000000000000000000010000000000000000000000000201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 227,
-          "comment" : "special case hash",
-          "msg" : "34343239353339313137",
-          "sig" : "3046022100b516a314f2fce530d6537f6a6c49966c23456f63c643cf8e0dc738f7b876e675022100d39ffd033c92b6d717dd536fbc5efdf1967c4bd80954479ba66b0120cd16fff2",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 228,
-          "comment" : "special case hash",
-          "msg" : "3130393533323631333531",
-          "sig" : "304402203b2cbf046eac45842ecb7984d475831582717bebb6492fd0a485c101e29ff0a802204c9b7b47a98b0f82de512bc9313aaf51701099cac5f76e68c8595fc1c1d99258",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n - 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 229,
-          "comment" : "special case hash",
-          "msg" : "35393837333530303431",
-          "sig" : "3044022030c87d35e636f540841f14af54e2f9edd79d0312cfa1ab656c3fb15bfde48dcf022047c15a5a82d24b75c85a692bd6ecafeb71409ede23efd08e0db9abf6340677ed",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 230,
-          "comment" : "special case hash",
-          "msg" : "33343633303036383738",
-          "sig" : "3044022038686ff0fda2cef6bc43b58cfe6647b9e2e8176d168dec3c68ff262113760f520220067ec3b651f422669601662167fa8717e976e2db5e6a4cf7c2ddabb3fde9d67d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=p",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 231,
-          "comment" : "special case hash",
-          "msg" : "39383137333230323837",
-          "sig" : "3044022044a3e23bf314f2b344fc25c7f2de8b6af3e17d27f5ee844b225985ab6e2775cf02202d48e223205e98041ddc87be532abed584f0411f5729500493c9cc3f4dd15e86",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=p + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 232,
-          "comment" : "special case hash",
-          "msg" : "33323232303431303436",
-          "sig" : "304402202ded5b7ec8e90e7bf11f967a3d95110c41b99db3b5aa8d330eb9d638781688e902207d5792c53628155e1bfc46fb1a67e3088de049c328ae1f44ec69238a009808f9",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008020100090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 233,
-          "comment" : "special case hash",
-          "msg" : "36363636333037313034",
-          "sig" : "3046022100bdae7bcb580bf335efd3bc3d31870f923eaccafcd40ec2f605976f15137d8b8f022100f6dfa12f19e525270b0106eecfe257499f373a4fb318994f24838122ce7ec3c7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 234,
-          "comment" : "special case hash",
-          "msg" : "31303335393531383938",
-          "sig" : "3045022050f9c4f0cd6940e162720957ffff513799209b78596956d21ece251c2401f1c6022100d7033a0a787d338e889defaaabb106b95a4355e411a59c32aa5167dfab244726",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 235,
-          "comment" : "special case hash",
-          "msg" : "31383436353937313935",
-          "sig" : "3045022100f612820687604fa01906066a378d67540982e29575d019aabe90924ead5c860d02203f9367702dd7dd4f75ea98afd20e328a1a99f4857b316525328230ce294b0fef",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 236,
-          "comment" : "special case hash",
-          "msg" : "33313336303436313839",
-          "sig" : "30460221009505e407657d6e8bc93db5da7aa6f5081f61980c1949f56b0f2f507da5782a7a022100c60d31904e3669738ffbeccab6c3656c08e0ed5cb92b3cfa5e7f71784f9c5021",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201000500",
+          "result" : "invalid"
         },
         {
           "tcId" : 237,
-          "comment" : "special case hash",
-          "msg" : "32363633373834323534",
-          "sig" : "3046022100bbd16fbbb656b6d0d83e6a7787cd691b08735aed371732723e1c68a40404517d0221009d8e35dba96028b7787d91315be675877d2d097be5e8ee34560e3e7fd25c0f00",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201000c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 238,
-          "comment" : "special case hash",
-          "msg" : "31363532313030353234",
-          "sig" : "304402202ec9760122db98fd06ea76848d35a6da442d2ceef7559a30cf57c61e92df327e02207ab271da90859479701fccf86e462ee3393fb6814c27b760c4963625c0a19878",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201000c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 239,
-          "comment" : "special case hash",
-          "msg" : "35373438303831363936",
-          "sig" : "3044022054e76b7683b6650baa6a7fc49b1c51eed9ba9dd463221f7a4f1005a89fe00c5902202ea076886c773eb937ec1cc8374b7915cfd11b1c1ae1166152f2f7806a31c8fd",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201003000",
+          "result" : "invalid"
         },
         {
           "tcId" : 240,
-          "comment" : "special case hash",
-          "msg" : "36333433393133343638",
-          "sig" : "304402205291deaf24659ffbbce6e3c26f6021097a74abdbb69be4fb10419c0c496c9466022065d6fcf336d27cc7cdb982bb4e4ecef5827f84742f29f10abf83469270a03dc3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201003003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 241,
-          "comment" : "special case hash",
-          "msg" : "31353431313033353938",
-          "sig" : "30450220207a3241812d75d947419dc58efb05e8003b33fc17eb50f9d15166a88479f107022100cdee749f2e492b213ce80b32d0574f62f1c5d70793cf55e382d5caadf7592767",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008020101090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 242,
-          "comment" : "special case hash",
-          "msg" : "3130343738353830313238",
-          "sig" : "304502206554e49f82a855204328ac94913bf01bbe84437a355a0a37c0dee3cf81aa7728022100aea00de2507ddaf5c94e1e126980d3df16250a2eaebc8be486effe7f22b4f929",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 243,
-          "comment" : "special case hash",
-          "msg" : "3130353336323835353638",
-          "sig" : "3046022100a54c5062648339d2bff06f71c88216c26c6e19b4d80a8c602990ac82707efdfc022100e99bbe7fcfafae3e69fd016777517aa01056317f467ad09aff09be73c9731b0d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 244,
-          "comment" : "special case hash",
-          "msg" : "393533393034313035",
-          "sig" : "3045022100975bd7157a8d363b309f1f444012b1a1d23096593133e71b4ca8b059cff37eaf02207faa7a28b1c822baa241793f2abc930bd4c69840fe090f2aacc46786bf919622",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 245,
-          "comment" : "special case hash",
-          "msg" : "393738383438303339",
-          "sig" : "304402205694a6f84b8f875c276afd2ebcfe4d61de9ec90305afb1357b95b3e0da43885e02200dffad9ffd0b757d8051dec02ebdf70d8ee2dc5c7870c0823b6ccc7c679cbaa4",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201010500",
+          "result" : "invalid"
         },
         {
           "tcId" : 246,
-          "comment" : "special case hash",
-          "msg" : "33363130363732343432",
-          "sig" : "3045022100a0c30e8026fdb2b4b4968a27d16a6d08f7098f1a98d21620d7454ba9790f1ba602205e470453a8a399f15baf463f9deceb53acc5ca64459149688bd2760c65424339",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201010c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 247,
-          "comment" : "special case hash",
-          "msg" : "31303534323430373035",
-          "sig" : "30440220614ea84acf736527dd73602cd4bb4eea1dfebebd5ad8aca52aa0228cf7b99a880220737cc85f5f2d2f60d1b8183f3ed490e4de14368e96a9482c2a4dd193195c902f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201010c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 248,
-          "comment" : "special case hash",
-          "msg" : "35313734343438313937",
-          "sig" : "3045022100bead6734ebe44b810d3fb2ea00b1732945377338febfd439a8d74dfbd0f942fa02206bb18eae36616a7d3cad35919fd21a8af4bbe7a10f73b3e036a46b103ef56e2a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201013000",
+          "result" : "invalid"
         },
         {
           "tcId" : 249,
-          "comment" : "special case hash",
-          "msg" : "31393637353631323531",
-          "sig" : "30440220499625479e161dacd4db9d9ce64854c98d922cbf212703e9654fae182df9bad2022042c177cf37b8193a0131108d97819edd9439936028864ac195b64fca76d9d693",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201013003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 250,
-          "comment" : "special case hash",
-          "msg" : "33343437323533333433",
-          "sig" : "3045022008f16b8093a8fb4d66a2c8065b541b3d31e3bfe694f6b89c50fb1aaa6ff6c9b20221009d6455e2d5d1779748573b611cb95d4a21f967410399b39b535ba3e5af81ca2e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201ff090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 251,
-          "comment" : "special case hash",
-          "msg" : "333638323634333138",
-          "sig" : "3046022100be26231b6191658a19dd72ddb99ed8f8c579b6938d19bce8eed8dc2b338cb5f8022100e1d9a32ee56cffed37f0f22b2dcb57d5c943c14f79694a03b9c5e96952575c89",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 252,
-          "comment" : "special case hash",
-          "msg" : "33323631313938363038",
-          "sig" : "3045022015e76880898316b16204ac920a02d58045f36a229d4aa4f812638c455abe0443022100e74d357d3fcb5c8c5337bd6aba4178b455ca10e226e13f9638196506a1939123",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 253,
-          "comment" : "special case hash",
-          "msg" : "39363738373831303934",
-          "sig" : "30440220352ecb53f8df2c503a45f9846fc28d1d31e6307d3ddbffc1132315cc07f16dad02201348dfa9c482c558e1d05c5242ca1c39436726ecd28258b1899792887dd0a3c6",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 254,
-          "comment" : "special case hash",
-          "msg" : "34393538383233383233",
-          "sig" : "304402204a40801a7e606ba78a0da9882ab23c7677b8642349ed3d652c5bfa5f2a9558fb02203a49b64848d682ef7f605f2832f7384bdc24ed2925825bf8ea77dc5981725782",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 255,
-          "comment" : "special case hash",
-          "msg" : "383234363337383337",
-          "sig" : "3045022100eacc5e1a8304a74d2be412b078924b3bb3511bac855c05c9e5e9e44df3d61e9602207451cd8e18d6ed1885dd827714847f96ec4bb0ed4c36ce9808db8f714204f6d1",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff0c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 256,
-          "comment" : "special case hash",
-          "msg" : "3131303230383333373736",
-          "sig" : "304502202f7a5e9e5771d424f30f67fdab61e8ce4f8cd1214882adb65f7de94c31577052022100ac4e69808345809b44acb0b2bd889175fb75dd050c5a449ab9528f8f78daa10c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff0c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 257,
-          "comment" : "special case hash",
-          "msg" : "313333383731363438",
-          "sig" : "3045022100ffcda40f792ce4d93e7e0f0e95e1a2147dddd7f6487621c30a03d710b3300219022079938b55f8a17f7ed7ba9ade8f2065a1fa77618f0b67add8d58c422c2453a49a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 258,
-          "comment" : "special case hash",
-          "msg" : "333232313434313632",
-          "sig" : "304602210081f2359c4faba6b53d3e8c8c3fcc16a948350f7ab3a588b28c17603a431e39a8022100cd6f6a5cc3b55ead0ff695d06c6860b509e46d99fccefb9f7f9e101857f74300",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201ff3003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 259,
-          "comment" : "special case hash",
-          "msg" : "3130363836363535353436",
-          "sig" : "3045022100dfc8bf520445cbb8ee1596fb073ea283ea130251a6fdffa5c3f5f2aaf75ca8080220048e33efce147c9dd92823640e338e68bfd7d0dc7a4905b3a7ac711e577e90e7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3028022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 260,
-          "comment" : "special case hash",
-          "msg" : "3632313535323436",
-          "sig" : "3046022100ad019f74c6941d20efda70b46c53db166503a0e393e932f688227688ba6a576202210093320eb7ca0710255346bdbb3102cdcf7964ef2e0988e712bc05efe16c199345",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 261,
-          "comment" : "special case hash",
-          "msg" : "37303330383138373734",
-          "sig" : "3046022100ac8096842e8add68c34e78ce11dd71e4b54316bd3ebf7fffdeb7bd5a3ebc1883022100f5ca2f4f23d674502d4caf85d187215d36e3ce9f0ce219709f21a3aac003b7a8",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 262,
-          "comment" : "special case hash",
-          "msg" : "35393234353233373434",
-          "sig" : "30440220677b2d3a59b18a5ff939b70ea002250889ddcd7b7b9d776854b4943693fb92f702206b4ba856ade7677bf30307b21f3ccda35d2f63aee81efd0bab6972cc0795db55",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 263,
-          "comment" : "special case hash",
-          "msg" : "31343935353836363231",
-          "sig" : "30450220479e1ded14bcaed0379ba8e1b73d3115d84d31d4b7c30e1f05e1fc0d5957cfb0022100918f79e35b3d89487cf634a4f05b2e0c30857ca879f97c771e877027355b2443",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3025022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510500",
+          "result" : "invalid"
         },
         {
           "tcId" : 264,
-          "comment" : "special case hash",
-          "msg" : "34303035333134343036",
-          "sig" : "3044022043dfccd0edb9e280d9a58f01164d55c3d711e14b12ac5cf3b64840ead512a0a302201dbe33fa8ba84533cd5c4934365b3442ca1174899b78ef9a3199f49584389772",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3025022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 265,
-          "comment" : "special case hash",
-          "msg" : "33303936343537353132",
-          "sig" : "304402205b09ab637bd4caf0f4c7c7e4bca592fea20e9087c259d26a38bb4085f0bbff11022045b7eb467b6748af618e9d80d6fdcd6aa24964e5a13f885bca8101de08eb0d75",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 266,
-          "comment" : "special case hash",
-          "msg" : "32373834303235363230",
-          "sig" : "304502205e9b1c5a028070df5728c5c8af9b74e0667afa570a6cfa0114a5039ed15ee06f022100b1360907e2d9785ead362bb8d7bd661b6c29eeffd3c5037744edaeb9ad990c20",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3025022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325513000",
+          "result" : "invalid"
         },
         {
           "tcId" : 267,
-          "comment" : "special case hash",
-          "msg" : "32363138373837343138",
-          "sig" : "304502200671a0a85c2b72d54a2fb0990e34538b4890050f5a5712f6d1a7a5fb8578f32e022100db1846bab6b7361479ab9c3285ca41291808f27fd5bd4fdac720e5854713694c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3028022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325513003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 268,
-          "comment" : "special case hash",
-          "msg" : "31363432363235323632",
-          "sig" : "304402207673f8526748446477dbbb0590a45492c5d7d69859d301abbaedb35b2095103a02203dc70ddf9c6b524d886bed9e6af02e0e4dec0d417a414fed3807ef4422913d7c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3028022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 269,
-          "comment" : "special case hash",
-          "msg" : "36383234313839343336",
-          "sig" : "304402207f085441070ecd2bb21285089ebb1aa6450d1a06c36d3ff39dfd657a796d12b50220249712012029870a2459d18d47da9aa492a5e6cb4b2d8dafa9e4c5c54a2b9a8b",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 270,
-          "comment" : "special case hash",
-          "msg" : "343834323435343235",
-          "sig" : "3046022100914c67fb61dd1e27c867398ea7322d5ab76df04bc5aa6683a8e0f30a5d287348022100fa07474031481dda4953e3ac1959ee8cea7e66ec412b38d6c96d28f6d37304ea",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp256r1",
-        "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "040ad99500288d466940031d72a9f5445a4d43784640855bf0a69874d2de5fe103c5011e6ef2c42dcd50d5d3d29f99ae6eba2c80c9244f4c5422f0979ff0c3ba5e",
-        "wx" : "0ad99500288d466940031d72a9f5445a4d43784640855bf0a69874d2de5fe103",
-        "wy" : "0c5011e6ef2c42dcd50d5d3d29f99ae6eba2c80c9244f4c5422f0979ff0c3ba5e"
-      },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040ad99500288d466940031d72a9f5445a4d43784640855bf0a69874d2de5fe103c5011e6ef2c42dcd50d5d3d29f99ae6eba2c80c9244f4c5422f0979ff0c3ba5e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECtmVACiNRmlAAx1yqfVEWk1DeEZA\nhVvwpph00t5f4QPFAR5u8sQtzVDV09Kfma5uuiyAySRPTFQi8Jef8MO6Xg==\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-256",
-      "type" : "ECDSAVer",
-      "tests" : [
+          "comment" : "Signature encoding contains incorrect types: r=p, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff010101",
+          "result" : "invalid"
+        },
         {
           "tcId" : 271,
-          "comment" : "k*G has a large x-coordinate",
+          "comment" : "Signature encoding contains incorrect types: r=p, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "303502104319055358e8617b0c46353d039cdaab022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
-          "result" : "valid",
-          "flags" : []
+          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 272,
-          "comment" : "r too large",
+          "comment" : "Signature encoding contains incorrect types: r=p, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000000fffffffffffffffffffffffc022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
-          "result" : "invalid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp256r1",
-        "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "04ab05fd9d0de26b9ce6f4819652d9fc69193d0aa398f0fba8013e09c58220455419235271228c786759095d12b75af0692dd4103f19f6a8c32f49435a1e9b8d45",
-        "wx" : "0ab05fd9d0de26b9ce6f4819652d9fc69193d0aa398f0fba8013e09c582204554",
-        "wy" : "19235271228c786759095d12b75af0692dd4103f19f6a8c32f49435a1e9b8d45"
-      },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ab05fd9d0de26b9ce6f4819652d9fc69193d0aa398f0fba8013e09c58220455419235271228c786759095d12b75af0692dd4103f19f6a8c32f49435a1e9b8d45",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqwX9nQ3ia5zm9IGWUtn8aRk9CqOY\n8PuoAT4JxYIgRVQZI1JxIox4Z1kJXRK3WvBpLdQQPxn2qMMvSUNaHpuNRQ==\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-256",
-      "type" : "ECDSAVer",
-      "tests" : [
+          "sig" : "3025022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0500",
+          "result" : "invalid"
+        },
         {
           "tcId" : 273,
-          "comment" : "r,s are large",
+          "comment" : "Signature encoding contains incorrect types: r=p, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254f022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp256r1",
-        "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "0480984f39a1ff38a86a68aa4201b6be5dfbfecf876219710b07badf6fdd4c6c5611feb97390d9826e7a06dfb41871c940d74415ed3cac2089f1445019bb55ed95",
-        "wx" : "080984f39a1ff38a86a68aa4201b6be5dfbfecf876219710b07badf6fdd4c6c56",
-        "wy" : "11feb97390d9826e7a06dfb41871c940d74415ed3cac2089f1445019bb55ed95"
-      },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000480984f39a1ff38a86a68aa4201b6be5dfbfecf876219710b07badf6fdd4c6c5611feb97390d9826e7a06dfb41871c940d74415ed3cac2089f1445019bb55ed95",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgJhPOaH/OKhqaKpCAba+Xfv+z4di\nGXELB7rfb91MbFYR/rlzkNmCbnoG37QYcclA10QV7TysIInxRFAZu1XtlQ==\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-256",
-      "type" : "ECDSAVer",
-      "tests" : [
+          "sig" : "3025022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0c00",
+          "result" : "invalid"
+        },
         {
           "tcId" : 274,
-          "comment" : "r and s^-1 have a large Hamming weight",
+          "comment" : "Signature encoding contains incorrect types: r=p, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100909135bdb6799286170f5ead2de4f6511453fe50914f3df2de54a36383df8dd4",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp256r1",
-        "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "044201b4272944201c3294f5baa9a3232b6dd687495fcc19a70a95bc602b4f7c0595c37eba9ee8171c1bb5ac6feaf753bc36f463e3aef16629572c0c0a8fb0800e",
-        "wx" : "4201b4272944201c3294f5baa9a3232b6dd687495fcc19a70a95bc602b4f7c05",
-        "wy" : "095c37eba9ee8171c1bb5ac6feaf753bc36f463e3aef16629572c0c0a8fb0800e"
-      },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044201b4272944201c3294f5baa9a3232b6dd687495fcc19a70a95bc602b4f7c0595c37eba9ee8171c1bb5ac6feaf753bc36f463e3aef16629572c0c0a8fb0800e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQgG0JylEIBwylPW6qaMjK23Wh0lf\nzBmnCpW8YCtPfAWVw366nugXHBu1rG/q91O8NvRj467xZilXLAwKj7CADg==\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-256",
-      "type" : "ECDSAVer",
-      "tests" : [
+          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0c0130",
+          "result" : "invalid"
+        },
         {
           "tcId" : 275,
-          "comment" : "r and s^-1 have a large Hamming weight",
+          "comment" : "Signature encoding contains incorrect types: r=p, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022027b4577ca009376f71303fd5dd227dcef5deb773ad5f5a84360644669ca249a5",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp256r1",
-        "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "04a71af64de5126a4a4e02b7922d66ce9415ce88a4c9d25514d91082c8725ac9575d47723c8fbe580bb369fec9c2665d8e30a435b9932645482e7c9f11e872296b",
-        "wx" : "0a71af64de5126a4a4e02b7922d66ce9415ce88a4c9d25514d91082c8725ac957",
-        "wy" : "5d47723c8fbe580bb369fec9c2665d8e30a435b9932645482e7c9f11e872296b"
-      },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a71af64de5126a4a4e02b7922d66ce9415ce88a4c9d25514d91082c8725ac9575d47723c8fbe580bb369fec9c2665d8e30a435b9932645482e7c9f11e872296b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpxr2TeUSakpOAreSLWbOlBXOiKTJ\n0lUU2RCCyHJayVddR3I8j75YC7Np/snCZl2OMKQ1uZMmRUgufJ8R6HIpaw==\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-256",
-      "type" : "ECDSAVer",
-      "tests" : [
+          "sig" : "3025022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff3000",
+          "result" : "invalid"
+        },
         {
           "tcId" : 276,
-          "comment" : "small r and s",
+          "comment" : "Signature encoding contains incorrect types: r=p, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3006020105020101",
-          "result" : "valid",
-          "flags" : []
+          "sig" : "3028022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff3003020100",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 277,
+          "comment" : "Signature encoding contains incorrect types: r=0.25, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300a090380fe01090380fe01",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 278,
+          "comment" : "Signature encoding contains incorrect types: r=nan, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006090142090142",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 279,
+          "comment" : "Signature encoding contains incorrect types: r=True, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010101010101",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 280,
+          "comment" : "Signature encoding contains incorrect types: r=False, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010100010100",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 281,
+          "comment" : "Signature encoding contains incorrect types: r=Null, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300405000500",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 282,
+          "comment" : "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30040c000c00",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 283,
+          "comment" : "Signature encoding contains incorrect types: r=\"0\", s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060c01300c0130",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 284,
+          "comment" : "Signature encoding contains incorrect types: r=empty list, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300430003000",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 285,
+          "comment" : "Signature encoding contains incorrect types: r=list containing 0, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300a30030201003003020100",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 286,
+          "comment" : "Signature encoding contains incorrect types: r=0.25, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008090380fe01020100",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 287,
+          "comment" : "Signature encoding contains incorrect types: r=nan, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006090142020100",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 288,
+          "comment" : "Signature encoding contains incorrect types: r=True, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010101020100",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 289,
+          "comment" : "Signature encoding contains incorrect types: r=False, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010100020100",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 290,
+          "comment" : "Signature encoding contains incorrect types: r=Null, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050500020100",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 291,
+          "comment" : "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050c00020100",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 292,
+          "comment" : "Signature encoding contains incorrect types: r=\"0\", s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060c0130020100",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 293,
+          "comment" : "Signature encoding contains incorrect types: r=empty list, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30053000020100",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 294,
+          "comment" : "Signature encoding contains incorrect types: r=list containing 0, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30083003020100020100",
+          "result" : "invalid"
+        },
+        {
+          "tcId" : 295,
+          "comment" : "Edge case for Shamir multiplication",
+          "flags" : [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg" : "3639383139",
+          "sig" : "3044022064a1aab5000d0e804f3e2fc02bdee9be8ff312334e2ba16d11547c97711c898e02206af015971cc30be6d1a206d4e013e0997772a2f91d73286ffd683b9bb2cf4f1b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 296,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "343236343739373234",
+          "sig" : "3044022016aea964a2f6506d6f78c81c91fc7e8bded7d397738448de1e19a0ec580bf2660220252cd762130c6667cfe8b7bc47d27d78391e8e80c578d1cd38c3ff033be928e9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 297,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37313338363834383931",
+          "sig" : "30450221009cc98be2347d469bf476dfc26b9b733df2d26d6ef524af917c665baccb23c8820220093496459effe2d8d70727b82462f61d0ec1b7847929d10ea631dacb16b56c32",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 298,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130333539333331363638",
+          "sig" : "3044022073b3c90ecd390028058164524dde892703dce3dea0d53fa8093999f07ab8aa4302202f67b0b8e20636695bb7d8bf0a651c802ed25a395387b5f4188c0c4075c88634",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 299,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33393439343031323135",
+          "sig" : "3046022100bfab3098252847b328fadf2f89b95c851a7f0eb390763378f37e90119d5ba3dd022100bdd64e234e832b1067c2d058ccb44d978195ccebb65c2aaf1e2da9b8b4987e3b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 300,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31333434323933303739",
+          "sig" : "30440220204a9784074b246d8bf8bf04a4ceb1c1f1c9aaab168b1596d17093c5cd21d2cd022051cce41670636783dc06a759c8847868a406c2506fe17975582fe648d1d88b52",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 301,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33373036323131373132",
+          "sig" : "3046022100ed66dc34f551ac82f63d4aa4f81fe2cb0031a91d1314f835027bca0f1ceeaa0302210099ca123aa09b13cd194a422e18d5fda167623c3f6e5d4d6abb8953d67c0c48c7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 302,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "333433363838373132",
+          "sig" : "30450220060b700bef665c68899d44f2356a578d126b062023ccc3c056bf0f60a237012b0221008d186c027832965f4fcc78a3366ca95dedbb410cbef3f26d6be5d581c11d3610",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 303,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31333531353330333730",
+          "sig" : "30460221009f6adfe8d5eb5b2c24d7aa7934b6cf29c93ea76cd313c9132bb0c8e38c96831d022100b26a9c9e40e55ee0890c944cf271756c906a33e66b5bd15e051593883b5e9902",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 304,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36353533323033313236",
+          "sig" : "3045022100a1af03ca91677b673ad2f33615e56174a1abf6da168cebfa8868f4ba273f16b7022020aa73ffe48afa6435cd258b173d0c2377d69022e7d098d75caf24c8c5e06b1c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 305,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31353634333436363033",
+          "sig" : "3045022100fdc70602766f8eed11a6c99a71c973d5659355507b843da6e327a28c11893db902203df5349688a085b137b1eacf456a9e9e0f6d15ec0078ca60a7f83f2b10d21350",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 306,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34343239353339313137",
+          "sig" : "3046022100b516a314f2fce530d6537f6a6c49966c23456f63c643cf8e0dc738f7b876e675022100d39ffd033c92b6d717dd536fbc5efdf1967c4bd80954479ba66b0120cd16fff2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 307,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130393533323631333531",
+          "sig" : "304402203b2cbf046eac45842ecb7984d475831582717bebb6492fd0a485c101e29ff0a802204c9b7b47a98b0f82de512bc9313aaf51701099cac5f76e68c8595fc1c1d99258",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 308,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35393837333530303431",
+          "sig" : "3044022030c87d35e636f540841f14af54e2f9edd79d0312cfa1ab656c3fb15bfde48dcf022047c15a5a82d24b75c85a692bd6ecafeb71409ede23efd08e0db9abf6340677ed",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 309,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33343633303036383738",
+          "sig" : "3044022038686ff0fda2cef6bc43b58cfe6647b9e2e8176d168dec3c68ff262113760f520220067ec3b651f422669601662167fa8717e976e2db5e6a4cf7c2ddabb3fde9d67d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 310,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "39383137333230323837",
+          "sig" : "3044022044a3e23bf314f2b344fc25c7f2de8b6af3e17d27f5ee844b225985ab6e2775cf02202d48e223205e98041ddc87be532abed584f0411f5729500493c9cc3f4dd15e86",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 311,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323232303431303436",
+          "sig" : "304402202ded5b7ec8e90e7bf11f967a3d95110c41b99db3b5aa8d330eb9d638781688e902207d5792c53628155e1bfc46fb1a67e3088de049c328ae1f44ec69238a009808f9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 312,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36363636333037313034",
+          "sig" : "3046022100bdae7bcb580bf335efd3bc3d31870f923eaccafcd40ec2f605976f15137d8b8f022100f6dfa12f19e525270b0106eecfe257499f373a4fb318994f24838122ce7ec3c7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 313,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31303335393531383938",
+          "sig" : "3045022050f9c4f0cd6940e162720957ffff513799209b78596956d21ece251c2401f1c6022100d7033a0a787d338e889defaaabb106b95a4355e411a59c32aa5167dfab244726",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 314,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31383436353937313935",
+          "sig" : "3045022100f612820687604fa01906066a378d67540982e29575d019aabe90924ead5c860d02203f9367702dd7dd4f75ea98afd20e328a1a99f4857b316525328230ce294b0fef",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 315,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33313336303436313839",
+          "sig" : "30460221009505e407657d6e8bc93db5da7aa6f5081f61980c1949f56b0f2f507da5782a7a022100c60d31904e3669738ffbeccab6c3656c08e0ed5cb92b3cfa5e7f71784f9c5021",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 316,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32363633373834323534",
+          "sig" : "3046022100bbd16fbbb656b6d0d83e6a7787cd691b08735aed371732723e1c68a40404517d0221009d8e35dba96028b7787d91315be675877d2d097be5e8ee34560e3e7fd25c0f00",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 317,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31363532313030353234",
+          "sig" : "304402202ec9760122db98fd06ea76848d35a6da442d2ceef7559a30cf57c61e92df327e02207ab271da90859479701fccf86e462ee3393fb6814c27b760c4963625c0a19878",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 318,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35373438303831363936",
+          "sig" : "3044022054e76b7683b6650baa6a7fc49b1c51eed9ba9dd463221f7a4f1005a89fe00c5902202ea076886c773eb937ec1cc8374b7915cfd11b1c1ae1166152f2f7806a31c8fd",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 319,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36333433393133343638",
+          "sig" : "304402205291deaf24659ffbbce6e3c26f6021097a74abdbb69be4fb10419c0c496c9466022065d6fcf336d27cc7cdb982bb4e4ecef5827f84742f29f10abf83469270a03dc3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 320,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31353431313033353938",
+          "sig" : "30450220207a3241812d75d947419dc58efb05e8003b33fc17eb50f9d15166a88479f107022100cdee749f2e492b213ce80b32d0574f62f1c5d70793cf55e382d5caadf7592767",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 321,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130343738353830313238",
+          "sig" : "304502206554e49f82a855204328ac94913bf01bbe84437a355a0a37c0dee3cf81aa7728022100aea00de2507ddaf5c94e1e126980d3df16250a2eaebc8be486effe7f22b4f929",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 322,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130353336323835353638",
+          "sig" : "3046022100a54c5062648339d2bff06f71c88216c26c6e19b4d80a8c602990ac82707efdfc022100e99bbe7fcfafae3e69fd016777517aa01056317f467ad09aff09be73c9731b0d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 323,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "393533393034313035",
+          "sig" : "3045022100975bd7157a8d363b309f1f444012b1a1d23096593133e71b4ca8b059cff37eaf02207faa7a28b1c822baa241793f2abc930bd4c69840fe090f2aacc46786bf919622",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 324,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "393738383438303339",
+          "sig" : "304402205694a6f84b8f875c276afd2ebcfe4d61de9ec90305afb1357b95b3e0da43885e02200dffad9ffd0b757d8051dec02ebdf70d8ee2dc5c7870c0823b6ccc7c679cbaa4",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 325,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33363130363732343432",
+          "sig" : "3045022100a0c30e8026fdb2b4b4968a27d16a6d08f7098f1a98d21620d7454ba9790f1ba602205e470453a8a399f15baf463f9deceb53acc5ca64459149688bd2760c65424339",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 326,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31303534323430373035",
+          "sig" : "30440220614ea84acf736527dd73602cd4bb4eea1dfebebd5ad8aca52aa0228cf7b99a880220737cc85f5f2d2f60d1b8183f3ed490e4de14368e96a9482c2a4dd193195c902f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 327,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35313734343438313937",
+          "sig" : "3045022100bead6734ebe44b810d3fb2ea00b1732945377338febfd439a8d74dfbd0f942fa02206bb18eae36616a7d3cad35919fd21a8af4bbe7a10f73b3e036a46b103ef56e2a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 328,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31393637353631323531",
+          "sig" : "30440220499625479e161dacd4db9d9ce64854c98d922cbf212703e9654fae182df9bad2022042c177cf37b8193a0131108d97819edd9439936028864ac195b64fca76d9d693",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 329,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33343437323533333433",
+          "sig" : "3045022008f16b8093a8fb4d66a2c8065b541b3d31e3bfe694f6b89c50fb1aaa6ff6c9b20221009d6455e2d5d1779748573b611cb95d4a21f967410399b39b535ba3e5af81ca2e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 330,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "333638323634333138",
+          "sig" : "3046022100be26231b6191658a19dd72ddb99ed8f8c579b6938d19bce8eed8dc2b338cb5f8022100e1d9a32ee56cffed37f0f22b2dcb57d5c943c14f79694a03b9c5e96952575c89",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 331,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323631313938363038",
+          "sig" : "3045022015e76880898316b16204ac920a02d58045f36a229d4aa4f812638c455abe0443022100e74d357d3fcb5c8c5337bd6aba4178b455ca10e226e13f9638196506a1939123",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 332,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "39363738373831303934",
+          "sig" : "30440220352ecb53f8df2c503a45f9846fc28d1d31e6307d3ddbffc1132315cc07f16dad02201348dfa9c482c558e1d05c5242ca1c39436726ecd28258b1899792887dd0a3c6",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 333,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34393538383233383233",
+          "sig" : "304402204a40801a7e606ba78a0da9882ab23c7677b8642349ed3d652c5bfa5f2a9558fb02203a49b64848d682ef7f605f2832f7384bdc24ed2925825bf8ea77dc5981725782",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 334,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "383234363337383337",
+          "sig" : "3045022100eacc5e1a8304a74d2be412b078924b3bb3511bac855c05c9e5e9e44df3d61e9602207451cd8e18d6ed1885dd827714847f96ec4bb0ed4c36ce9808db8f714204f6d1",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 335,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131303230383333373736",
+          "sig" : "304502202f7a5e9e5771d424f30f67fdab61e8ce4f8cd1214882adb65f7de94c31577052022100ac4e69808345809b44acb0b2bd889175fb75dd050c5a449ab9528f8f78daa10c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 336,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "313333383731363438",
+          "sig" : "3045022100ffcda40f792ce4d93e7e0f0e95e1a2147dddd7f6487621c30a03d710b3300219022079938b55f8a17f7ed7ba9ade8f2065a1fa77618f0b67add8d58c422c2453a49a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 337,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "333232313434313632",
+          "sig" : "304602210081f2359c4faba6b53d3e8c8c3fcc16a948350f7ab3a588b28c17603a431e39a8022100cd6f6a5cc3b55ead0ff695d06c6860b509e46d99fccefb9f7f9e101857f74300",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 338,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130363836363535353436",
+          "sig" : "3045022100dfc8bf520445cbb8ee1596fb073ea283ea130251a6fdffa5c3f5f2aaf75ca8080220048e33efce147c9dd92823640e338e68bfd7d0dc7a4905b3a7ac711e577e90e7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 339,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3632313535323436",
+          "sig" : "3046022100ad019f74c6941d20efda70b46c53db166503a0e393e932f688227688ba6a576202210093320eb7ca0710255346bdbb3102cdcf7964ef2e0988e712bc05efe16c199345",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 340,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37303330383138373734",
+          "sig" : "3046022100ac8096842e8add68c34e78ce11dd71e4b54316bd3ebf7fffdeb7bd5a3ebc1883022100f5ca2f4f23d674502d4caf85d187215d36e3ce9f0ce219709f21a3aac003b7a8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 341,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35393234353233373434",
+          "sig" : "30440220677b2d3a59b18a5ff939b70ea002250889ddcd7b7b9d776854b4943693fb92f702206b4ba856ade7677bf30307b21f3ccda35d2f63aee81efd0bab6972cc0795db55",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 342,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31343935353836363231",
+          "sig" : "30450220479e1ded14bcaed0379ba8e1b73d3115d84d31d4b7c30e1f05e1fc0d5957cfb0022100918f79e35b3d89487cf634a4f05b2e0c30857ca879f97c771e877027355b2443",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 343,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34303035333134343036",
+          "sig" : "3044022043dfccd0edb9e280d9a58f01164d55c3d711e14b12ac5cf3b64840ead512a0a302201dbe33fa8ba84533cd5c4934365b3442ca1174899b78ef9a3199f49584389772",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 344,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33303936343537353132",
+          "sig" : "304402205b09ab637bd4caf0f4c7c7e4bca592fea20e9087c259d26a38bb4085f0bbff11022045b7eb467b6748af618e9d80d6fdcd6aa24964e5a13f885bca8101de08eb0d75",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 345,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32373834303235363230",
+          "sig" : "304502205e9b1c5a028070df5728c5c8af9b74e0667afa570a6cfa0114a5039ed15ee06f022100b1360907e2d9785ead362bb8d7bd661b6c29eeffd3c5037744edaeb9ad990c20",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 346,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32363138373837343138",
+          "sig" : "304502200671a0a85c2b72d54a2fb0990e34538b4890050f5a5712f6d1a7a5fb8578f32e022100db1846bab6b7361479ab9c3285ca41291808f27fd5bd4fdac720e5854713694c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 347,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31363432363235323632",
+          "sig" : "304402207673f8526748446477dbbb0590a45492c5d7d69859d301abbaedb35b2095103a02203dc70ddf9c6b524d886bed9e6af02e0e4dec0d417a414fed3807ef4422913d7c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 348,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36383234313839343336",
+          "sig" : "304402207f085441070ecd2bb21285089ebb1aa6450d1a06c36d3ff39dfd657a796d12b50220249712012029870a2459d18d47da9aa492a5e6cb4b2d8dafa9e4c5c54a2b9a8b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 349,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "343834323435343235",
+          "sig" : "3046022100914c67fb61dd1e27c867398ea7322d5ab76df04bc5aa6683a8e0f30a5d287348022100fa07474031481dda4953e3ac1959ee8cea7e66ec412b38d6c96d28f6d37304ea",
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
+        "uncompressed" : "040ad99500288d466940031d72a9f5445a4d43784640855bf0a69874d2de5fe103c5011e6ef2c42dcd50d5d3d29f99ae6eba2c80c9244f4c5422f0979ff0c3ba5e",
+        "wx" : "0ad99500288d466940031d72a9f5445a4d43784640855bf0a69874d2de5fe103",
+        "wy" : "00c5011e6ef2c42dcd50d5d3d29f99ae6eba2c80c9244f4c5422f0979ff0c3ba5e"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040ad99500288d466940031d72a9f5445a4d43784640855bf0a69874d2de5fe103c5011e6ef2c42dcd50d5d3d29f99ae6eba2c80c9244f4c5422f0979ff0c3ba5e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECtmVACiNRmlAAx1yqfVEWk1DeEZA\nhVvwpph00t5f4QPFAR5u8sQtzVDV09Kfma5uuiyAySRPTFQi8Jef8MO6Xg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 350,
+          "comment" : "k*G has a large x-coordinate",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303502104319055358e8617b0c46353d039cdaab022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 351,
+          "comment" : "r too large",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000000fffffffffffffffffffffffc022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04ab05fd9d0de26b9ce6f4819652d9fc69193d0aa398f0fba8013e09c58220455419235271228c786759095d12b75af0692dd4103f19f6a8c32f49435a1e9b8d45",
+        "wx" : "00ab05fd9d0de26b9ce6f4819652d9fc69193d0aa398f0fba8013e09c582204554",
+        "wy" : "19235271228c786759095d12b75af0692dd4103f19f6a8c32f49435a1e9b8d45"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ab05fd9d0de26b9ce6f4819652d9fc69193d0aa398f0fba8013e09c58220455419235271228c786759095d12b75af0692dd4103f19f6a8c32f49435a1e9b8d45",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqwX9nQ3ia5zm9IGWUtn8aRk9CqOY\n8PuoAT4JxYIgRVQZI1JxIox4Z1kJXRK3WvBpLdQQPxn2qMMvSUNaHpuNRQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 352,
+          "comment" : "r,s are large",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254f022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0480984f39a1ff38a86a68aa4201b6be5dfbfecf876219710b07badf6fdd4c6c5611feb97390d9826e7a06dfb41871c940d74415ed3cac2089f1445019bb55ed95",
+        "wx" : "0080984f39a1ff38a86a68aa4201b6be5dfbfecf876219710b07badf6fdd4c6c56",
+        "wy" : "11feb97390d9826e7a06dfb41871c940d74415ed3cac2089f1445019bb55ed95"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000480984f39a1ff38a86a68aa4201b6be5dfbfecf876219710b07badf6fdd4c6c5611feb97390d9826e7a06dfb41871c940d74415ed3cac2089f1445019bb55ed95",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgJhPOaH/OKhqaKpCAba+Xfv+z4di\nGXELB7rfb91MbFYR/rlzkNmCbnoG37QYcclA10QV7TysIInxRFAZu1XtlQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 353,
+          "comment" : "r and s^-1 have a large Hamming weight",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100909135bdb6799286170f5ead2de4f6511453fe50914f3df2de54a36383df8dd4",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "044201b4272944201c3294f5baa9a3232b6dd687495fcc19a70a95bc602b4f7c0595c37eba9ee8171c1bb5ac6feaf753bc36f463e3aef16629572c0c0a8fb0800e",
+        "wx" : "4201b4272944201c3294f5baa9a3232b6dd687495fcc19a70a95bc602b4f7c05",
+        "wy" : "0095c37eba9ee8171c1bb5ac6feaf753bc36f463e3aef16629572c0c0a8fb0800e"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044201b4272944201c3294f5baa9a3232b6dd687495fcc19a70a95bc602b4f7c0595c37eba9ee8171c1bb5ac6feaf753bc36f463e3aef16629572c0c0a8fb0800e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQgG0JylEIBwylPW6qaMjK23Wh0lf\nzBmnCpW8YCtPfAWVw366nugXHBu1rG/q91O8NvRj467xZilXLAwKj7CADg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 354,
+          "comment" : "r and s^-1 have a large Hamming weight",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022027b4577ca009376f71303fd5dd227dcef5deb773ad5f5a84360644669ca249a5",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04a71af64de5126a4a4e02b7922d66ce9415ce88a4c9d25514d91082c8725ac9575d47723c8fbe580bb369fec9c2665d8e30a435b9932645482e7c9f11e872296b",
+        "wx" : "00a71af64de5126a4a4e02b7922d66ce9415ce88a4c9d25514d91082c8725ac957",
+        "wy" : "5d47723c8fbe580bb369fec9c2665d8e30a435b9932645482e7c9f11e872296b"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a71af64de5126a4a4e02b7922d66ce9415ce88a4c9d25514d91082c8725ac9575d47723c8fbe580bb369fec9c2665d8e30a435b9932645482e7c9f11e872296b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpxr2TeUSakpOAreSLWbOlBXOiKTJ\n0lUU2RCCyHJayVddR3I8j75YC7Np/snCZl2OMKQ1uZMmRUgufJ8R6HIpaw==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 355,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020105020101",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
         "uncompressed" : "046627cec4f0731ea23fc2931f90ebe5b7572f597d20df08fc2b31ee8ef16b15726170ed77d8d0a14fc5c9c3c4c9be7f0d3ee18f709bb275eaf2073e258fe694a5",
         "wx" : "6627cec4f0731ea23fc2931f90ebe5b7572f597d20df08fc2b31ee8ef16b1572",
         "wy" : "6170ed77d8d0a14fc5c9c3c4c9be7f0d3ee18f709bb275eaf2073e258fe694a5"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046627cec4f0731ea23fc2931f90ebe5b7572f597d20df08fc2b31ee8ef16b15726170ed77d8d0a14fc5c9c3c4c9be7f0d3ee18f709bb275eaf2073e258fe694a5",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZifOxPBzHqI/wpMfkOvlt1cvWX0g\n3wj8KzHujvFrFXJhcO132NChT8XJw8TJvn8NPuGPcJuyderyBz4lj+aUpQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046627cec4f0731ea23fc2931f90ebe5b7572f597d20df08fc2b31ee8ef16b15726170ed77d8d0a14fc5c9c3c4c9be7f0d3ee18f709bb275eaf2073e258fe694a5",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZifOxPBzHqI/wpMfkOvlt1cvWX0g\n3wj8KzHujvFrFXJhcO132NChT8XJw8TJvn8NPuGPcJuyderyBz4lj+aUpQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 277,
+          "tcId" : 356,
           "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3006020105020103",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "045a7c8825e85691cce1f5e7544c54e73f14afc010cb731343262ca7ec5a77f5bfef6edf62a4497c1bd7b147fb6c3d22af3c39bfce95f30e13a16d3d7b2812f813",
         "wx" : "5a7c8825e85691cce1f5e7544c54e73f14afc010cb731343262ca7ec5a77f5bf",
-        "wy" : "0ef6edf62a4497c1bd7b147fb6c3d22af3c39bfce95f30e13a16d3d7b2812f813"
+        "wy" : "00ef6edf62a4497c1bd7b147fb6c3d22af3c39bfce95f30e13a16d3d7b2812f813"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045a7c8825e85691cce1f5e7544c54e73f14afc010cb731343262ca7ec5a77f5bfef6edf62a4497c1bd7b147fb6c3d22af3c39bfce95f30e13a16d3d7b2812f813",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWnyIJehWkczh9edUTFTnPxSvwBDL\ncxNDJiyn7Fp39b/vbt9ipEl8G9exR/tsPSKvPDm/zpXzDhOhbT17KBL4Ew==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045a7c8825e85691cce1f5e7544c54e73f14afc010cb731343262ca7ec5a77f5bfef6edf62a4497c1bd7b147fb6c3d22af3c39bfce95f30e13a16d3d7b2812f813",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWnyIJehWkczh9edUTFTnPxSvwBDL\ncxNDJiyn7Fp39b/vbt9ipEl8G9exR/tsPSKvPDm/zpXzDhOhbT17KBL4Ew==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 278,
+          "tcId" : 357,
           "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3006020105020105",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04cbe0c29132cd738364fedd603152990c048e5e2fff996d883fa6caca7978c73770af6a8ce44cb41224b2603606f4c04d188e80bff7cc31ad5189d4ab0d70e8c1",
-        "wx" : "0cbe0c29132cd738364fedd603152990c048e5e2fff996d883fa6caca7978c737",
+        "wx" : "00cbe0c29132cd738364fedd603152990c048e5e2fff996d883fa6caca7978c737",
         "wy" : "70af6a8ce44cb41224b2603606f4c04d188e80bff7cc31ad5189d4ab0d70e8c1"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cbe0c29132cd738364fedd603152990c048e5e2fff996d883fa6caca7978c73770af6a8ce44cb41224b2603606f4c04d188e80bff7cc31ad5189d4ab0d70e8c1",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEy+DCkTLNc4Nk/t1gMVKZDASOXi//\nmW2IP6bKynl4xzdwr2qM5Ey0EiSyYDYG9MBNGI6Av/fMMa1RidSrDXDowQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cbe0c29132cd738364fedd603152990c048e5e2fff996d883fa6caca7978c73770af6a8ce44cb41224b2603606f4c04d188e80bff7cc31ad5189d4ab0d70e8c1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEy+DCkTLNc4Nk/t1gMVKZDASOXi//\nmW2IP6bKynl4xzdwr2qM5Ey0EiSyYDYG9MBNGI6Av/fMMa1RidSrDXDowQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 279,
+          "tcId" : 358,
           "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3006020105020106",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "042ef747671c97d9c7f9cb2f6a30d678c3d84757ba241ef7183d51a29f52d87c2ea8fb2ea635b761baefc1c4ded2099281b844e13e044c328553bbbafa337d8a76",
+        "wx" : "2ef747671c97d9c7f9cb2f6a30d678c3d84757ba241ef7183d51a29f52d87c2e",
+        "wy" : "00a8fb2ea635b761baefc1c4ded2099281b844e13e044c328553bbbafa337d8a76"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042ef747671c97d9c7f9cb2f6a30d678c3d84757ba241ef7183d51a29f52d87c2ea8fb2ea635b761baefc1c4ded2099281b844e13e044c328553bbbafa337d8a76",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELvdHZxyX2cf5yy9qMNZ4w9hHV7ok\nHvcYPVGin1LYfC6o+y6mNbdhuu/BxN7SCZKBuEThPgRMMoVTu7r6M32Kdg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 359,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020106020101",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04931cc49cda4d87d25b1601c56c3b83b4f45e44971998f2d3e7d3c55152214edf058dc140abbba42fc1ddbf30dab8eb9b46ee7338b3f7ee96242bf45e1df5e995",
+        "wx" : "00931cc49cda4d87d25b1601c56c3b83b4f45e44971998f2d3e7d3c55152214edf",
+        "wy" : "058dc140abbba42fc1ddbf30dab8eb9b46ee7338b3f7ee96242bf45e1df5e995"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004931cc49cda4d87d25b1601c56c3b83b4f45e44971998f2d3e7d3c55152214edf058dc140abbba42fc1ddbf30dab8eb9b46ee7338b3f7ee96242bf45e1df5e995",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkxzEnNpNh9JbFgHFbDuDtPReRJcZ\nmPLT59PFUVIhTt8FjcFAq7ukL8HdvzDauOubRu5zOLP37pYkK/ReHfXplQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 360,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020106020103",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04899a4af61867e3f3c190dbb48f8bc9fc74b70a467a4a1f06477b3af2f39ab8ed47ac000f9ea8a3034939bf48ad5d061a69fc8495ae4df2dbec7effa03a0062b3",
+        "wx" : "00899a4af61867e3f3c190dbb48f8bc9fc74b70a467a4a1f06477b3af2f39ab8ed",
+        "wy" : "47ac000f9ea8a3034939bf48ad5d061a69fc8495ae4df2dbec7effa03a0062b3"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004899a4af61867e3f3c190dbb48f8bc9fc74b70a467a4a1f06477b3af2f39ab8ed47ac000f9ea8a3034939bf48ad5d061a69fc8495ae4df2dbec7effa03a0062b3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEiZpK9hhn4/PBkNu0j4vJ/HS3CkZ6\nSh8GR3s68vOauO1HrAAPnqijA0k5v0itXQYaafyEla5N8tvsfv+gOgBisw==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 361,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020106020106",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04d03eb09913cc20c6a8d0070f0d8d2a7f63527fafa44117fce6bd1ef2aa4ae3c46d5df3f45ac58fa334c6d102381b3120b7a2455600dcaff3d1a845514f12bf46",
+        "wx" : "00d03eb09913cc20c6a8d0070f0d8d2a7f63527fafa44117fce6bd1ef2aa4ae3c4",
+        "wy" : "6d5df3f45ac58fa334c6d102381b3120b7a2455600dcaff3d1a845514f12bf46"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d03eb09913cc20c6a8d0070f0d8d2a7f63527fafa44117fce6bd1ef2aa4ae3c46d5df3f45ac58fa334c6d102381b3120b7a2455600dcaff3d1a845514f12bf46",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0D6wmRPMIMao0AcPDY0qf2NSf6+k\nQRf85r0e8qpK48RtXfP0WsWPozTG0QI4GzEgt6JFVgDcr/PRqEVRTxK/Rg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 362,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020106020107",
+          "result" : "valid"
         },
         {
-          "tcId" : 280,
+          "tcId" : 363,
           "comment" : "r is larger than n",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632556020106",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632557020107",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "044be4178097002f0deab68f0d9a130e0ed33a6795d02a20796db83444b037e13920f13051e0eecdcfce4dacea0f50d1f247caa669f193c1b4075b51ae296d2d56",
-        "wx" : "4be4178097002f0deab68f0d9a130e0ed33a6795d02a20796db83444b037e139",
-        "wy" : "20f13051e0eecdcfce4dacea0f50d1f247caa669f193c1b4075b51ae296d2d56"
+        "uncompressed" : "043a72476291571193b4d109b2c37b59f2807e8fe9cffd804eacded903e77ca0da592dbc74fee0ca7508cc7bc282b0c51a143286ff53c60131668e7a0929e4ed04",
+        "wx" : "3a72476291571193b4d109b2c37b59f2807e8fe9cffd804eacded903e77ca0da",
+        "wy" : "592dbc74fee0ca7508cc7bc282b0c51a143286ff53c60131668e7a0929e4ed04"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044be4178097002f0deab68f0d9a130e0ed33a6795d02a20796db83444b037e13920f13051e0eecdcfce4dacea0f50d1f247caa669f193c1b4075b51ae296d2d56",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAES+QXgJcALw3qto8NmhMODtM6Z5XQ\nKiB5bbg0RLA34Tkg8TBR4O7Nz85NrOoPUNHyR8qmafGTwbQHW1GuKW0tVg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043a72476291571193b4d109b2c37b59f2807e8fe9cffd804eacded903e77ca0da592dbc74fee0ca7508cc7bc282b0c51a143286ff53c60131668e7a0929e4ed04",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEOnJHYpFXEZO00Qmyw3tZ8oB+j+nP\n/YBOrN7ZA+d8oNpZLbx0/uDKdQjMe8KCsMUaFDKG/1PGATFmjnoJKeTtBA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 281,
+          "tcId" : 364,
           "comment" : "s is larger than n",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
-          "sig" : "3026020105022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc75fbd8",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3026020106022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc75fbd8",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04d0f73792203716afd4be4329faa48d269f15313ebbba379d7783c97bf3e890d9971f4a3206605bec21782bf5e275c714417e8f566549e6bc68690d2363c89cc1",
-        "wx" : "0d0f73792203716afd4be4329faa48d269f15313ebbba379d7783c97bf3e890d9",
-        "wy" : "0971f4a3206605bec21782bf5e275c714417e8f566549e6bc68690d2363c89cc1"
+        "wx" : "00d0f73792203716afd4be4329faa48d269f15313ebbba379d7783c97bf3e890d9",
+        "wy" : "00971f4a3206605bec21782bf5e275c714417e8f566549e6bc68690d2363c89cc1"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d0f73792203716afd4be4329faa48d269f15313ebbba379d7783c97bf3e890d9971f4a3206605bec21782bf5e275c714417e8f566549e6bc68690d2363c89cc1",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0Pc3kiA3Fq/UvkMp+qSNJp8VMT67\nujedd4PJe/PokNmXH0oyBmBb7CF4K/XidccUQX6PVmVJ5rxoaQ0jY8icwQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d0f73792203716afd4be4329faa48d269f15313ebbba379d7783c97bf3e890d9971f4a3206605bec21782bf5e275c714417e8f566549e6bc68690d2363c89cc1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0Pc3kiA3Fq/UvkMp+qSNJp8VMT67\nujedd4PJe/PokNmXH0oyBmBb7CF4K/XidccUQX6PVmVJ5rxoaQ0jY8icwQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 282,
+          "tcId" : 365,
           "comment" : "small r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3027020201000221008f1e3c7862c58b16bb76eddbb76eddbb516af4f63f2d74d76e0d28c9bb75ea88",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "044838b2be35a6276a80ef9e228140f9d9b96ce83b7a254f71ccdebbb8054ce05ffa9cbc123c919b19e00238198d04069043bd660a828814051fcb8aac738a6c6b",
         "wx" : "4838b2be35a6276a80ef9e228140f9d9b96ce83b7a254f71ccdebbb8054ce05f",
-        "wy" : "0fa9cbc123c919b19e00238198d04069043bd660a828814051fcb8aac738a6c6b"
+        "wy" : "00fa9cbc123c919b19e00238198d04069043bd660a828814051fcb8aac738a6c6b"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044838b2be35a6276a80ef9e228140f9d9b96ce83b7a254f71ccdebbb8054ce05ffa9cbc123c919b19e00238198d04069043bd660a828814051fcb8aac738a6c6b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESDiyvjWmJ2qA754igUD52bls6Dt6\nJU9xzN67uAVM4F/6nLwSPJGbGeACOBmNBAaQQ71mCoKIFAUfy4qsc4psaw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044838b2be35a6276a80ef9e228140f9d9b96ce83b7a254f71ccdebbb8054ce05ffa9cbc123c919b19e00238198d04069043bd660a828814051fcb8aac738a6c6b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAESDiyvjWmJ2qA754igUD52bls6Dt6\nJU9xzN67uAVM4F/6nLwSPJGbGeACOBmNBAaQQ71mCoKIFAUfy4qsc4psaw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 283,
+          "tcId" : 366,
           "comment" : "smallish r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "302c02072d9b4d347952d6022100ef3043e7329581dbb3974497710ab11505ee1c87ff907beebadd195a0ffe6d7a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "047393983ca30a520bbc4783dc9960746aab444ef520c0a8e771119aa4e74b0f64e9d7be1ab01a0bf626e709863e6a486dbaf32793afccf774e2c6cd27b1857526",
         "wx" : "7393983ca30a520bbc4783dc9960746aab444ef520c0a8e771119aa4e74b0f64",
-        "wy" : "0e9d7be1ab01a0bf626e709863e6a486dbaf32793afccf774e2c6cd27b1857526"
+        "wy" : "00e9d7be1ab01a0bf626e709863e6a486dbaf32793afccf774e2c6cd27b1857526"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047393983ca30a520bbc4783dc9960746aab444ef520c0a8e771119aa4e74b0f64e9d7be1ab01a0bf626e709863e6a486dbaf32793afccf774e2c6cd27b1857526",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEc5OYPKMKUgu8R4PcmWB0aqtETvUg\nwKjncRGapOdLD2Tp174asBoL9ibnCYY+akhtuvMnk6/M93Tixs0nsYV1Jg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047393983ca30a520bbc4783dc9960746aab444ef520c0a8e771119aa4e74b0f64e9d7be1ab01a0bf626e709863e6a486dbaf32793afccf774e2c6cd27b1857526",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEc5OYPKMKUgu8R4PcmWB0aqtETvUg\nwKjncRGapOdLD2Tp174asBoL9ibnCYY+akhtuvMnk6/M93Tixs0nsYV1Jg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 284,
+          "tcId" : 367,
           "comment" : "100-bit r and small s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3032020d1033e67e37b32b445580bf4eff0221008b748b74000000008b748b748b748b7466e769ad4a16d3dcd87129b8e91d1b4d",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "045ac331a1103fe966697379f356a937f350588a05477e308851b8a502d5dfcdc5fe9993df4b57939b2b8da095bf6d794265204cfe03be995a02e65d408c871c0b",
         "wx" : "5ac331a1103fe966697379f356a937f350588a05477e308851b8a502d5dfcdc5",
-        "wy" : "0fe9993df4b57939b2b8da095bf6d794265204cfe03be995a02e65d408c871c0b"
+        "wy" : "00fe9993df4b57939b2b8da095bf6d794265204cfe03be995a02e65d408c871c0b"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045ac331a1103fe966697379f356a937f350588a05477e308851b8a502d5dfcdc5fe9993df4b57939b2b8da095bf6d794265204cfe03be995a02e65d408c871c0b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWsMxoRA/6WZpc3nzVqk381BYigVH\nfjCIUbilAtXfzcX+mZPfS1eTmyuNoJW/bXlCZSBM/gO+mVoC5l1AjIccCw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045ac331a1103fe966697379f356a937f350588a05477e308851b8a502d5dfcdc5fe9993df4b57939b2b8da095bf6d794265204cfe03be995a02e65d408c871c0b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEWsMxoRA/6WZpc3nzVqk381BYigVH\nfjCIUbilAtXfzcX+mZPfS1eTmyuNoJW/bXlCZSBM/gO+mVoC5l1AjIccCw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 285,
+          "tcId" : 368,
           "comment" : "small r and 100 bit s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "302702020100022100ef9f6ba4d97c09d03178fa20b4aaad83be3cf9cb824a879fec3270fc4b81ef5b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "041d209be8de2de877095a399d3904c74cc458d926e27bb8e58e5eae5767c41509dd59e04c214f7b18dce351fc2a549893a6860e80163f38cc60a4f2c9d040d8c9",
         "wx" : "1d209be8de2de877095a399d3904c74cc458d926e27bb8e58e5eae5767c41509",
-        "wy" : "0dd59e04c214f7b18dce351fc2a549893a6860e80163f38cc60a4f2c9d040d8c9"
+        "wy" : "00dd59e04c214f7b18dce351fc2a549893a6860e80163f38cc60a4f2c9d040d8c9"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041d209be8de2de877095a399d3904c74cc458d926e27bb8e58e5eae5767c41509dd59e04c214f7b18dce351fc2a549893a6860e80163f38cc60a4f2c9d040d8c9",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHSCb6N4t6HcJWjmdOQTHTMRY2Sbi\ne7jljl6uV2fEFQndWeBMIU97GNzjUfwqVJiTpoYOgBY/OMxgpPLJ0EDYyQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041d209be8de2de877095a399d3904c74cc458d926e27bb8e58e5eae5767c41509dd59e04c214f7b18dce351fc2a549893a6860e80163f38cc60a4f2c9d040d8c9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHSCb6N4t6HcJWjmdOQTHTMRY2Sbi\ne7jljl6uV2fEFQndWeBMIU97GNzjUfwqVJiTpoYOgBY/OMxgpPLJ0EDYyQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 286,
+          "tcId" : 369,
           "comment" : "100-bit r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3032020d062522bbd3ecbe7c39e93e7c25022100ef9f6ba4d97c09d03178fa20b4aaad83be3cf9cb824a879fec3270fc4b81ef5b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04083539fbee44625e3acaafa2fcb41349392cef0633a1b8fabecee0c133b10e99915c1ebe7bf00df8535196770a58047ae2a402f26326bb7d41d4d7616337911e",
         "wx" : "083539fbee44625e3acaafa2fcb41349392cef0633a1b8fabecee0c133b10e99",
-        "wy" : "0915c1ebe7bf00df8535196770a58047ae2a402f26326bb7d41d4d7616337911e"
+        "wy" : "00915c1ebe7bf00df8535196770a58047ae2a402f26326bb7d41d4d7616337911e"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004083539fbee44625e3acaafa2fcb41349392cef0633a1b8fabecee0c133b10e99915c1ebe7bf00df8535196770a58047ae2a402f26326bb7d41d4d7616337911e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECDU5++5EYl46yq+i/LQTSTks7wYz\nobj6vs7gwTOxDpmRXB6+e/AN+FNRlncKWAR64qQC8mMmu31B1NdhYzeRHg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004083539fbee44625e3acaafa2fcb41349392cef0633a1b8fabecee0c133b10e99915c1ebe7bf00df8535196770a58047ae2a402f26326bb7d41d4d7616337911e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECDU5++5EYl46yq+i/LQTSTks7wYz\nobj6vs7gwTOxDpmRXB6+e/AN+FNRlncKWAR64qQC8mMmu31B1NdhYzeRHg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 287,
+          "tcId" : 370,
           "comment" : "r and s^-1 are close to n",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3045022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6324d50220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "048aeb368a7027a4d64abdea37390c0c1d6a26f399e2d9734de1eb3d0e1937387405bd13834715e1dbae9b875cf07bd55e1b6691c7f7536aef3b19bf7a4adf576d",
-        "wx" : "08aeb368a7027a4d64abdea37390c0c1d6a26f399e2d9734de1eb3d0e19373874",
-        "wy" : "5bd13834715e1dbae9b875cf07bd55e1b6691c7f7536aef3b19bf7a4adf576d"
+        "uncompressed" : "04e075effd9607d08d5f34e3652f64cfa3bd6d20c58d0a232f058491260ab212a4cc61760ac8b0680c1b644c03cc628ba9dc4a3c0561368489c692bd40f43aa3ca",
+        "wx" : "00e075effd9607d08d5f34e3652f64cfa3bd6d20c58d0a232f058491260ab212a4",
+        "wy" : "00cc61760ac8b0680c1b644c03cc628ba9dc4a3c0561368489c692bd40f43aa3ca"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048aeb368a7027a4d64abdea37390c0c1d6a26f399e2d9734de1eb3d0e1937387405bd13834715e1dbae9b875cf07bd55e1b6691c7f7536aef3b19bf7a4adf576d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEius2inAnpNZKveo3OQwMHWom85ni\n2XNN4es9Dhk3OHQFvRODRxXh266bh1zwe9VeG2aRx/dTau87Gb96St9XbQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e075effd9607d08d5f34e3652f64cfa3bd6d20c58d0a232f058491260ab212a4cc61760ac8b0680c1b644c03cc628ba9dc4a3c0561368489c692bd40f43aa3ca",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE4HXv/ZYH0I1fNONlL2TPo71tIMWN\nCiMvBYSRJgqyEqTMYXYKyLBoDBtkTAPMYoup3Eo8BWE2hInGkr1A9Dqjyg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 288,
+          "tcId" : 371,
+          "comment" : "r and s are 64-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30160209009c44febf31c3594f020900839ed28247c2b06b",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04cffb758c3073ea3c08efd9f7f17a85b6ae385c5a140c146ad5f1f5a826718bc8dfdc6bebc894144c6d418ac5d97339726ad2ae925df868426e5628e9f4e62342",
+        "wx" : "00cffb758c3073ea3c08efd9f7f17a85b6ae385c5a140c146ad5f1f5a826718bc8",
+        "wy" : "00dfdc6bebc894144c6d418ac5d97339726ad2ae925df868426e5628e9f4e62342"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cffb758c3073ea3c08efd9f7f17a85b6ae385c5a140c146ad5f1f5a826718bc8dfdc6bebc894144c6d418ac5d97339726ad2ae925df868426e5628e9f4e62342",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEz/t1jDBz6jwI79n38XqFtq44XFoU\nDBRq1fH1qCZxi8jf3GvryJQUTG1BisXZczlyatKukl34aEJuVijp9OYjQg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 372,
+          "comment" : "r and s are 100-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "301e020d09df8b682430beef6f5fd7c7cd020d0fd0a62e13778f4222a0d61c8a",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04b98740e69e61a325d5f772e3b5c4f67fb7150b16a9afeca9ddc4afcbb6fa0549c446e814138e4ebc82dbf86a390056d4595dcf45e381fef217a4597d7bd51498",
+        "wx" : "00b98740e69e61a325d5f772e3b5c4f67fb7150b16a9afeca9ddc4afcbb6fa0549",
+        "wy" : "00c446e814138e4ebc82dbf86a390056d4595dcf45e381fef217a4597d7bd51498"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b98740e69e61a325d5f772e3b5c4f67fb7150b16a9afeca9ddc4afcbb6fa0549c446e814138e4ebc82dbf86a390056d4595dcf45e381fef217a4597d7bd51498",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEuYdA5p5hoyXV93LjtcT2f7cVCxap\nr+yp3cSvy7b6BUnERugUE45OvILb+Go5AFbUWV3PReOB/vIXpFl9e9UUmA==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 373,
+          "comment" : "r and s are 128-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260211008a598e563a89f526c32ebec8de26367c02110084f633e2042630e99dd0f1e16f7a04bf",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0484536a270c3932bb2084732adf2c768efc6d3977e5220229ea9a44888b8f9d7b1766398cdac2fc8000017b29a7ba15a58f196037f35f7008ed4286ddff00fd46",
+        "wx" : "0084536a270c3932bb2084732adf2c768efc6d3977e5220229ea9a44888b8f9d7b",
+        "wy" : "1766398cdac2fc8000017b29a7ba15a58f196037f35f7008ed4286ddff00fd46"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000484536a270c3932bb2084732adf2c768efc6d3977e5220229ea9a44888b8f9d7b1766398cdac2fc8000017b29a7ba15a58f196037f35f7008ed4286ddff00fd46",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhFNqJww5MrsghHMq3yx2jvxtOXfl\nIgIp6ppEiIuPnXsXZjmM2sL8gAABeymnuhWljxlgN/NfcAjtQobd/wD9Rg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 374,
+          "comment" : "r and s are 160-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302e021500aa6eeb5823f7fa31b466bb473797f0d0314c0bdf021500e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "048aeb368a7027a4d64abdea37390c0c1d6a26f399e2d9734de1eb3d0e1937387405bd13834715e1dbae9b875cf07bd55e1b6691c7f7536aef3b19bf7a4adf576d",
+        "wx" : "008aeb368a7027a4d64abdea37390c0c1d6a26f399e2d9734de1eb3d0e19373874",
+        "wy" : "05bd13834715e1dbae9b875cf07bd55e1b6691c7f7536aef3b19bf7a4adf576d"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048aeb368a7027a4d64abdea37390c0c1d6a26f399e2d9734de1eb3d0e1937387405bd13834715e1dbae9b875cf07bd55e1b6691c7f7536aef3b19bf7a4adf576d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEius2inAnpNZKveo3OQwMHWom85ni\n2XNN4es9Dhk3OHQFvRODRxXh266bh1zwe9VeG2aRx/dTau87Gb96St9XbQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 375,
           "comment" : "s == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30250220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70020101",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 289,
+          "tcId" : 376,
           "comment" : "s == 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30250220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70020100",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "04b533d4695dd5b8c5e07757e55e6e516f7e2c88fa0239e23f60e8ec07dd70f2871b134ee58cc583278456863f33c3a85d881f7d4a39850143e29d4eaf009afe47",
-        "wx" : "0b533d4695dd5b8c5e07757e55e6e516f7e2c88fa0239e23f60e8ec07dd70f287",
-        "wy" : "1b134ee58cc583278456863f33c3a85d881f7d4a39850143e29d4eaf009afe47"
+        "uncompressed" : "0461722eaba731c697c7a9ba4d0afdbb5713d8aa12b0eab601bb33dbaf792c5adc272cd993b2b663aba5b3a26c101182ff178684945e83879e71598b95fe647dfc",
+        "wx" : "61722eaba731c697c7a9ba4d0afdbb5713d8aa12b0eab601bb33dbaf792c5adc",
+        "wy" : "272cd993b2b663aba5b3a26c101182ff178684945e83879e71598b95fe647dfc"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b533d4695dd5b8c5e07757e55e6e516f7e2c88fa0239e23f60e8ec07dd70f2871b134ee58cc583278456863f33c3a85d881f7d4a39850143e29d4eaf009afe47",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtTPUaV3VuMXgd1flXm5Rb34siPoC\nOeI/YOjsB91w8ocbE07ljMWDJ4RWhj8zw6hdiB99SjmFAUPinU6vAJr+Rw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000461722eaba731c697c7a9ba4d0afdbb5713d8aa12b0eab601bb33dbaf792c5adc272cd993b2b663aba5b3a26c101182ff178684945e83879e71598b95fe647dfc",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYXIuq6cxxpfHqbpNCv27VxPYqhKw\n6rYBuzPbr3ksWtwnLNmTsrZjq6WzomwQEYL/F4aElF6Dh55xWYuV/mR9/A==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 290,
-          "comment" : "point at infinity during verify",
+          "tcId" : 377,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a80220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022002f676969f451a8ccafa4c4f09791810e6d632dbd60b1d5540f3284fbe1889b0",
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
+        "uncompressed" : "04c4c91981e720e20d7e478ff19d09b95a98f58c0f469b72801a8ce844a347316594afcd4188182e7779889b3258d0368ece1e66797fe7c648c6f0b9e26bd71871",
+        "wx" : "00c4c91981e720e20d7e478ff19d09b95a98f58c0f469b72801a8ce844a3473165",
+        "wy" : "0094afcd4188182e7779889b3258d0368ece1e66797fe7c648c6f0b9e26bd71871"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c4c91981e720e20d7e478ff19d09b95a98f58c0f469b72801a8ce844a347316594afcd4188182e7779889b3258d0368ece1e66797fe7c648c6f0b9e26bd71871",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExMkZgecg4g1+R4/xnQm5Wpj1jA9G\nm3KAGozoRKNHMWWUr81BiBgud3mImzJY0DaOzh5meX/nxkjG8Lnia9cYcQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 378,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002204e260962e33362ef0046126d2d5a4edc6947ab20e19b8ec19cf79e5908b6e628",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04d58d47bf49bc8f416641f6f760fcbca80aa52a814e56a5fa40bab44fd6f6317216deaa84d45d8e0e29cc9ecf5653f8ee6444750813becae8deb42b04ba07a634",
+        "wx" : "00d58d47bf49bc8f416641f6f760fcbca80aa52a814e56a5fa40bab44fd6f63172",
+        "wy" : "16deaa84d45d8e0e29cc9ecf5653f8ee6444750813becae8deb42b04ba07a634"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d58d47bf49bc8f416641f6f760fcbca80aa52a814e56a5fa40bab44fd6f6317216deaa84d45d8e0e29cc9ecf5653f8ee6444750813becae8deb42b04ba07a634",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE1Y1Hv0m8j0FmQfb3YPy8qAqlKoFO\nVqX6QLq0T9b2MXIW3qqE1F2ODinMns9WU/juZER1CBO+yujetCsEugemNA==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 379,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220077ed0d8f20f697d8fc591ac64dd5219c7932122b4f9b9ec6441e44a0092cf21",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0491e305822e5e44f3fdb616e2ef42cd98f241b86e9f68815bc4dba6a945e4eefb3c5937e2ac1d9466f6d65e49b35fc8d75ffc22e1fe2f32af42f5fa3c26f9b4b0",
+        "wx" : "0091e305822e5e44f3fdb616e2ef42cd98f241b86e9f68815bc4dba6a945e4eefb",
+        "wy" : "3c5937e2ac1d9466f6d65e49b35fc8d75ffc22e1fe2f32af42f5fa3c26f9b4b0"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000491e305822e5e44f3fdb616e2ef42cd98f241b86e9f68815bc4dba6a945e4eefb3c5937e2ac1d9466f6d65e49b35fc8d75ffc22e1fe2f32af42f5fa3c26f9b4b0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkeMFgi5eRPP9thbi70LNmPJBuG6f\naIFbxNumqUXk7vs8WTfirB2UZvbWXkmzX8jXX/wi4f4vMq9C9fo8Jvm0sA==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 380,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002203e0292a67e181c6c0105ee35e956e78e9bdd033c6e71ae57884039a245e4175f",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0424a0bc4d16dbbd40d2fd81a7c3f8d8ec741607d5bb406a0611cc60d0e683bd46b575cad039c15f7f3dffcfc007b4b0f743c871ecc76a504a32672fd84526d861",
+        "wx" : "24a0bc4d16dbbd40d2fd81a7c3f8d8ec741607d5bb406a0611cc60d0e683bd46",
+        "wy" : "00b575cad039c15f7f3dffcfc007b4b0f743c871ecc76a504a32672fd84526d861"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000424a0bc4d16dbbd40d2fd81a7c3f8d8ec741607d5bb406a0611cc60d0e683bd46b575cad039c15f7f3dffcfc007b4b0f743c871ecc76a504a32672fd84526d861",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJKC8TRbbvUDS/YGnw/jY7HQWB9W7\nQGoGEcxg0OaDvUa1dcrQOcFffz3/z8AHtLD3Q8hx7MdqUEoyZy/YRSbYYQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 381,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022013d22b06d6b8f5d97e0c64962b4a3bae30f668ca6217ef5b35d799f159e23ebe",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04d24dd06745cafb39186d22a92aa0e58169a79ab69488628a9da5ed3ef747269b7e9209d98faeb95355948adae61d5291c6015d3ee9513486d886fb05cbd25c6a",
+        "wx" : "00d24dd06745cafb39186d22a92aa0e58169a79ab69488628a9da5ed3ef747269b",
+        "wy" : "7e9209d98faeb95355948adae61d5291c6015d3ee9513486d886fb05cbd25c6a"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d24dd06745cafb39186d22a92aa0e58169a79ab69488628a9da5ed3ef747269b7e9209d98faeb95355948adae61d5291c6015d3ee9513486d886fb05cbd25c6a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0k3QZ0XK+zkYbSKpKqDlgWmnmraU\niGKKnaXtPvdHJpt+kgnZj665U1WUitrmHVKRxgFdPulRNIbYhvsFy9Jcag==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 382,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002204523ce342e4994bb8968bf6613f60c06c86111f15a3a389309e72cd447d5dd99",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "048200f148e7eab1581bcd1e23946f8a9b8191d9641f9560341721f9d3fec3d63ece795669e0481e035de8623d716a6984d0a4809d6c65519443ee55260f7f3dcb",
+        "wx" : "008200f148e7eab1581bcd1e23946f8a9b8191d9641f9560341721f9d3fec3d63e",
+        "wy" : "00ce795669e0481e035de8623d716a6984d0a4809d6c65519443ee55260f7f3dcb"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048200f148e7eab1581bcd1e23946f8a9b8191d9641f9560341721f9d3fec3d63ece795669e0481e035de8623d716a6984d0a4809d6c65519443ee55260f7f3dcb",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEggDxSOfqsVgbzR4jlG+Km4GR2WQf\nlWA0FyH50/7D1j7OeVZp4EgeA13oYj1xammE0KSAnWxlUZRD7lUmD389yw==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 383,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022037d765be3c9c78189ad30edb5097a4db670de11686d01420e37039d4677f4809",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04a8a69c5ed33b150ce8d37ac197070ed894c05d47258a80c9041d92486622024de85997c9666b60a393568efede8f4ca0167c1e10f626e62fc1b8c8e9c6ba6ed7",
+        "wx" : "00a8a69c5ed33b150ce8d37ac197070ed894c05d47258a80c9041d92486622024d",
+        "wy" : "00e85997c9666b60a393568efede8f4ca0167c1e10f626e62fc1b8c8e9c6ba6ed7"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a8a69c5ed33b150ce8d37ac197070ed894c05d47258a80c9041d92486622024de85997c9666b60a393568efede8f4ca0167c1e10f626e62fc1b8c8e9c6ba6ed7",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqKacXtM7FQzo03rBlwcO2JTAXUcl\nioDJBB2SSGYiAk3oWZfJZmtgo5NWjv7ej0ygFnweEPYm5i/BuMjpxrpu1w==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 384,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022044237823b54e0c74c2bf5f759d9ac5f8cb897d537ffa92effd4f0bb6c9acd860",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04ed0587e75b3b9a1dd0794f41d1729fcd432b2436cbf51c230d8bc7273273181735a57f09c7873d3964aa8102c9e25fa53070cd924cb7e3a459174740b8b71c34",
+        "wx" : "00ed0587e75b3b9a1dd0794f41d1729fcd432b2436cbf51c230d8bc72732731817",
+        "wy" : "35a57f09c7873d3964aa8102c9e25fa53070cd924cb7e3a459174740b8b71c34"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ed0587e75b3b9a1dd0794f41d1729fcd432b2436cbf51c230d8bc7273273181735a57f09c7873d3964aa8102c9e25fa53070cd924cb7e3a459174740b8b71c34",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE7QWH51s7mh3QeU9B0XKfzUMrJDbL\n9RwjDYvHJzJzGBc1pX8Jx4c9OWSqgQLJ4l+lMHDNkky346RZF0dAuLccNA==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 385,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220266d30a485385906054ca86d46f5f2b17e7f4646a3092092ad92877126538111",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04077091d99004a99ee08224e59a46a70495e6fba4eff681c3ce42127e588681ef4f1c16c77dfa440dde18245c9de76243d8f2fd9dea3f2782d6c04974d02f25dc",
+        "wx" : "077091d99004a99ee08224e59a46a70495e6fba4eff681c3ce42127e588681ef",
+        "wy" : "4f1c16c77dfa440dde18245c9de76243d8f2fd9dea3f2782d6c04974d02f25dc"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004077091d99004a99ee08224e59a46a70495e6fba4eff681c3ce42127e588681ef4f1c16c77dfa440dde18245c9de76243d8f2fd9dea3f2782d6c04974d02f25dc",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEB3CR2ZAEqZ7ggiTlmkanBJXm+6Tv\n9oHDzkISfliGge9PHBbHffpEDd4YJFyd52JD2PL9neo/J4LWwEl00C8l3A==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 386,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220538c7b3798e84d0ce90340165806348971ed44db8f0c674f5f215968390f92ee",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04616a8b8e57d82c11678f5827911024cd23a16cb52a65f230fb554a7b110c35a5bb466660be5cab3e4b587c12b45bd998bd56c7d66c2f94d03a1a6d2028d8a154",
+        "wx" : "616a8b8e57d82c11678f5827911024cd23a16cb52a65f230fb554a7b110c35a5",
+        "wy" : "00bb466660be5cab3e4b587c12b45bd998bd56c7d66c2f94d03a1a6d2028d8a154"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004616a8b8e57d82c11678f5827911024cd23a16cb52a65f230fb554a7b110c35a5bb466660be5cab3e4b587c12b45bd998bd56c7d66c2f94d03a1a6d2028d8a154",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEYWqLjlfYLBFnj1gnkRAkzSOhbLUq\nZfIw+1VKexEMNaW7RmZgvlyrPktYfBK0W9mYvVbH1mwvlNA6Gm0gKNihVA==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 387,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002206fef0ef15d1688e15e704c4e6bb8bb7f40d52d3af5c661bb78c4ed9b408699b3",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0471dc92b2b1baa7612c4a53427a0d2dfe548fa9cf829bb6b248f736a5eb30b513f91c7dff1144cb36057c2b859f35bd666a7961833b06de0f45159fbae208e326",
+        "wx" : "71dc92b2b1baa7612c4a53427a0d2dfe548fa9cf829bb6b248f736a5eb30b513",
+        "wy" : "00f91c7dff1144cb36057c2b859f35bd666a7961833b06de0f45159fbae208e326"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000471dc92b2b1baa7612c4a53427a0d2dfe548fa9cf829bb6b248f736a5eb30b513f91c7dff1144cb36057c2b859f35bd666a7961833b06de0f45159fbae208e326",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcdySsrG6p2EsSlNCeg0t/lSPqc+C\nm7aySPc2peswtRP5HH3/EUTLNgV8K4WfNb1manlhgzsG3g9FFZ+64gjjJg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 388,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002206f44275e9aeb1331efcb8d58f35c0252791427e403ad84daad51d247cc2a64c6",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04662f43ae614bd9c90ff3fcded25cf0ef186b6967a47aa6aa7ae7f396594df931f5f94a525edd50d3738f7a28d03d7a2a70095c8f89de9bb2c645fea8d8bac9e0",
+        "wx" : "662f43ae614bd9c90ff3fcded25cf0ef186b6967a47aa6aa7ae7f396594df931",
+        "wy" : "00f5f94a525edd50d3738f7a28d03d7a2a70095c8f89de9bb2c645fea8d8bac9e0"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004662f43ae614bd9c90ff3fcded25cf0ef186b6967a47aa6aa7ae7f396594df931f5f94a525edd50d3738f7a28d03d7a2a70095c8f89de9bb2c645fea8d8bac9e0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZi9DrmFL2ckP8/ze0lzw7xhraWek\neqaqeufzlllN+TH1+UpSXt1Q03OPeijQPXoqcAlcj4nem7LGRf6o2LrJ4A==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 389,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022021323755b103d2f9da6ab83eccab9ad8598bcf625652f10e7a3eeee3c3945fb3",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04dff107959bd2f7386497a5624430a0ab35e552c1a4e4dc9c298caeb96353170dcb5065d7947a676c76287ca8e430324f8a534b0ba6f21200e033c4b88852a3cc",
+        "wx" : "00dff107959bd2f7386497a5624430a0ab35e552c1a4e4dc9c298caeb96353170d",
+        "wy" : "00cb5065d7947a676c76287ca8e430324f8a534b0ba6f21200e033c4b88852a3cc"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004dff107959bd2f7386497a5624430a0ab35e552c1a4e4dc9c298caeb96353170dcb5065d7947a676c76287ca8e430324f8a534b0ba6f21200e033c4b88852a3cc",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3/EHlZvS9zhkl6ViRDCgqzXlUsGk\n5NycKYyuuWNTFw3LUGXXlHpnbHYofKjkMDJPilNLC6byEgDgM8S4iFKjzA==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 390,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002206c50acfe76de1289e7a5edb240f1c2a7879db6873d5d931f3c6ac467a6eac171",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04bd0862b0bfba85036922e06f5458754aafc3075b603a814b3ac75659bf24d7528258a607ffca2cfe05a300cb4c3c4e1963bbb1bc54d320e16969f85aad243385",
+        "wx" : "00bd0862b0bfba85036922e06f5458754aafc3075b603a814b3ac75659bf24d752",
+        "wy" : "008258a607ffca2cfe05a300cb4c3c4e1963bbb1bc54d320e16969f85aad243385"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bd0862b0bfba85036922e06f5458754aafc3075b603a814b3ac75659bf24d7528258a607ffca2cfe05a300cb4c3c4e1963bbb1bc54d320e16969f85aad243385",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvQhisL+6hQNpIuBvVFh1Sq/DB1tg\nOoFLOsdWWb8k11KCWKYH/8os/gWjAMtMPE4ZY7uxvFTTIOFpafharSQzhQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 391,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220755b7fffb0b17ad57dca50fcefb7fe297b029df25e5ccb5069e8e70c2742c2a6",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04b533d4695dd5b8c5e07757e55e6e516f7e2c88fa0239e23f60e8ec07dd70f2871b134ee58cc583278456863f33c3a85d881f7d4a39850143e29d4eaf009afe47",
+        "wx" : "00b533d4695dd5b8c5e07757e55e6e516f7e2c88fa0239e23f60e8ec07dd70f287",
+        "wy" : "1b134ee58cc583278456863f33c3a85d881f7d4a39850143e29d4eaf009afe47"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b533d4695dd5b8c5e07757e55e6e516f7e2c88fa0239e23f60e8ec07dd70f2871b134ee58cc583278456863f33c3a85d881f7d4a39850143e29d4eaf009afe47",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtTPUaV3VuMXgd1flXm5Rb34siPoC\nOeI/YOjsB91w8ocbE07ljMWDJ4RWhj8zw6hdiB99SjmFAUPinU6vAJr+Rw==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 392,
+          "comment" : "point at infinity during verify",
+          "flags" : [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304402207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a80220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04f50d371b91bfb1d7d14e1323523bc3aa8cbf2c57f9e284de628c8b4536787b86f94ad887ac94d527247cd2e7d0c8b1291c553c9730405380b14cbb209f5fa2dd",
+        "wx" : "00f50d371b91bfb1d7d14e1323523bc3aa8cbf2c57f9e284de628c8b4536787b86",
+        "wy" : "00f94ad887ac94d527247cd2e7d0c8b1291c553c9730405380b14cbb209f5fa2dd"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f50d371b91bfb1d7d14e1323523bc3aa8cbf2c57f9e284de628c8b4536787b86f94ad887ac94d527247cd2e7d0c8b1291c553c9730405380b14cbb209f5fa2dd",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9Q03G5G/sdfRThMjUjvDqoy/LFf5\n4oTeYoyLRTZ4e4b5StiHrJTVJyR80ufQyLEpHFU8lzBAU4CxTLsgn1+i3Q==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 393,
+          "comment" : "edge case for signature malleability",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304402207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a902207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a8",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0468ec6e298eafe16539156ce57a14b04a7047c221bafc3a582eaeb0d857c4d94697bed1af17850117fdb39b2324f220a5698ed16c426a27335bb385ac8ca6fb30",
+        "wx" : "68ec6e298eafe16539156ce57a14b04a7047c221bafc3a582eaeb0d857c4d946",
+        "wy" : "0097bed1af17850117fdb39b2324f220a5698ed16c426a27335bb385ac8ca6fb30"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000468ec6e298eafe16539156ce57a14b04a7047c221bafc3a582eaeb0d857c4d94697bed1af17850117fdb39b2324f220a5698ed16c426a27335bb385ac8ca6fb30",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaOxuKY6v4WU5FWzlehSwSnBHwiG6\n/DpYLq6w2FfE2UaXvtGvF4UBF/2zmyMk8iClaY7RbEJqJzNbs4WsjKb7MA==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-256",
+      "tests" : [
+        {
+          "tcId" : 394,
+          "comment" : "edge case for signature malleability",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304402207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a902207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a9",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
         "uncompressed" : "0469da0364734d2e530fece94019265fefb781a0f1b08f6c8897bdf6557927c8b866d2d3c7dcd518b23d726960f069ad71a933d86ef8abbcce8b20f71e2a847002",
         "wx" : "69da0364734d2e530fece94019265fefb781a0f1b08f6c8897bdf6557927c8b8",
         "wy" : "66d2d3c7dcd518b23d726960f069ad71a933d86ef8abbcce8b20f71e2a847002"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000469da0364734d2e530fece94019265fefb781a0f1b08f6c8897bdf6557927c8b866d2d3c7dcd518b23d726960f069ad71a933d86ef8abbcce8b20f71e2a847002",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEadoDZHNNLlMP7OlAGSZf77eBoPGw\nj2yIl732VXknyLhm0tPH3NUYsj1yaWDwaa1xqTPYbvirvM6LIPceKoRwAg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000469da0364734d2e530fece94019265fefb781a0f1b08f6c8897bdf6557927c8b866d2d3c7dcd518b23d726960f069ad71a933d86ef8abbcce8b20f71e2a847002",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEadoDZHNNLlMP7OlAGSZf77eBoPGw\nj2yIl732VXknyLhm0tPH3NUYsj1yaWDwaa1xqTPYbvirvM6LIPceKoRwAg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 291,
+          "tcId" : 395,
           "comment" : "u1 == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30450220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022100bb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca605023",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04d8adc00023a8edc02576e2b63e3e30621a471e2b2320620187bf067a1ac1ff3233e2b50ec09807accb36131fff95ed12a09a86b4ea9690aa32861576ba2362e1",
-        "wx" : "0d8adc00023a8edc02576e2b63e3e30621a471e2b2320620187bf067a1ac1ff32",
+        "wx" : "00d8adc00023a8edc02576e2b63e3e30621a471e2b2320620187bf067a1ac1ff32",
         "wy" : "33e2b50ec09807accb36131fff95ed12a09a86b4ea9690aa32861576ba2362e1"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d8adc00023a8edc02576e2b63e3e30621a471e2b2320620187bf067a1ac1ff3233e2b50ec09807accb36131fff95ed12a09a86b4ea9690aa32861576ba2362e1",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2K3AACOo7cAlduK2Pj4wYhpHHisj\nIGIBh78GehrB/zIz4rUOwJgHrMs2Ex//le0SoJqGtOqWkKoyhhV2uiNi4Q==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d8adc00023a8edc02576e2b63e3e30621a471e2b2320620187bf067a1ac1ff3233e2b50ec09807accb36131fff95ed12a09a86b4ea9690aa32861576ba2362e1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2K3AACOo7cAlduK2Pj4wYhpHHisj\nIGIBh78GehrB/zIz4rUOwJgHrMs2Ex//le0SoJqGtOqWkKoyhhV2uiNi4Q==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 292,
+          "tcId" : 396,
           "comment" : "u1 == n - 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022044a5ad0ad0636d9f12bc9e0a6bdd5e1cbcb012ea7bf091fcec15b0c43202d52e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "043623ac973ced0a56fa6d882f03a7d5c7edca02cfc7b2401fab3690dbe75ab7858db06908e64b28613da7257e737f39793da8e713ba0643b92e9bb3252be7f8fe",
         "wx" : "3623ac973ced0a56fa6d882f03a7d5c7edca02cfc7b2401fab3690dbe75ab785",
-        "wy" : "08db06908e64b28613da7257e737f39793da8e713ba0643b92e9bb3252be7f8fe"
+        "wy" : "008db06908e64b28613da7257e737f39793da8e713ba0643b92e9bb3252be7f8fe"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043623ac973ced0a56fa6d882f03a7d5c7edca02cfc7b2401fab3690dbe75ab7858db06908e64b28613da7257e737f39793da8e713ba0643b92e9bb3252be7f8fe",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENiOslzztClb6bYgvA6fVx+3KAs/H\nskAfqzaQ2+dat4WNsGkI5ksoYT2nJX5zfzl5PajnE7oGQ7kum7MlK+f4/g==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043623ac973ced0a56fa6d882f03a7d5c7edca02cfc7b2401fab3690dbe75ab7858db06908e64b28613da7257e737f39793da8e713ba0643b92e9bb3252be7f8fe",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENiOslzztClb6bYgvA6fVx+3KAs/H\nskAfqzaQ2+dat4WNsGkI5ksoYT2nJX5zfzl5PajnE7oGQ7kum7MlK+f4/g==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 293,
+          "tcId" : 397,
           "comment" : "u2 == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04cf04ea77e9622523d894b93ff52dc3027b31959503b6fa3890e5e04263f922f1e8528fb7c006b3983c8b8400e57b4ed71740c2f3975438821199bedeaecab2e9",
-        "wx" : "0cf04ea77e9622523d894b93ff52dc3027b31959503b6fa3890e5e04263f922f1",
-        "wy" : "0e8528fb7c006b3983c8b8400e57b4ed71740c2f3975438821199bedeaecab2e9"
+        "wx" : "00cf04ea77e9622523d894b93ff52dc3027b31959503b6fa3890e5e04263f922f1",
+        "wy" : "00e8528fb7c006b3983c8b8400e57b4ed71740c2f3975438821199bedeaecab2e9"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cf04ea77e9622523d894b93ff52dc3027b31959503b6fa3890e5e04263f922f1e8528fb7c006b3983c8b8400e57b4ed71740c2f3975438821199bedeaecab2e9",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzwTqd+liJSPYlLk/9S3DAnsxlZUD\ntvo4kOXgQmP5IvHoUo+3wAazmDyLhADle07XF0DC85dUOIIRmb7ersqy6Q==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cf04ea77e9622523d894b93ff52dc3027b31959503b6fa3890e5e04263f922f1e8528fb7c006b3983c8b8400e57b4ed71740c2f3975438821199bedeaecab2e9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzwTqd+liJSPYlLk/9S3DAnsxlZUD\ntvo4kOXgQmP5IvHoUo+3wAazmDyLhADle07XF0DC85dUOIIRmb7ersqy6Q==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 294,
+          "tcId" : 398,
           "comment" : "u2 == n - 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30450220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022100aaaaaaaa00000000aaaaaaaaaaaaaaaa7def51c91a0fbf034d26872ca84218e1",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04db7a2c8a1ab573e5929dc24077b508d7e683d49227996bda3e9f78dbeff773504f417f3bc9a88075c2e0aadd5a13311730cf7cc76a82f11a36eaf08a6c99a206",
-        "wx" : "0db7a2c8a1ab573e5929dc24077b508d7e683d49227996bda3e9f78dbeff77350",
+        "wx" : "00db7a2c8a1ab573e5929dc24077b508d7e683d49227996bda3e9f78dbeff77350",
         "wy" : "4f417f3bc9a88075c2e0aadd5a13311730cf7cc76a82f11a36eaf08a6c99a206"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004db7a2c8a1ab573e5929dc24077b508d7e683d49227996bda3e9f78dbeff773504f417f3bc9a88075c2e0aadd5a13311730cf7cc76a82f11a36eaf08a6c99a206",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE23osihq1c+WSncJAd7UI1+aD1JIn\nmWvaPp942+/3c1BPQX87yaiAdcLgqt1aEzEXMM98x2qC8Ro26vCKbJmiBg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004db7a2c8a1ab573e5929dc24077b508d7e683d49227996bda3e9f78dbeff773504f417f3bc9a88075c2e0aadd5a13311730cf7cc76a82f11a36eaf08a6c99a206",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE23osihq1c+WSncJAd7UI1+aD1JIn\nmWvaPp942+/3c1BPQX87yaiAdcLgqt1aEzEXMM98x2qC8Ro26vCKbJmiBg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 295,
+          "tcId" : 399,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100e91e1ba60fdedb76a46bcb51dc0b8b4b7e019f0a28721885fa5d3a8196623397",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04dead11c7a5b396862f21974dc4752fadeff994efe9bbd05ab413765ea80b6e1f1de3f0640e8ac6edcf89cff53c40e265bb94078a343736df07aa0318fc7fe1ff",
-        "wx" : "0dead11c7a5b396862f21974dc4752fadeff994efe9bbd05ab413765ea80b6e1f",
+        "wx" : "00dead11c7a5b396862f21974dc4752fadeff994efe9bbd05ab413765ea80b6e1f",
         "wy" : "1de3f0640e8ac6edcf89cff53c40e265bb94078a343736df07aa0318fc7fe1ff"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004dead11c7a5b396862f21974dc4752fadeff994efe9bbd05ab413765ea80b6e1f1de3f0640e8ac6edcf89cff53c40e265bb94078a343736df07aa0318fc7fe1ff",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3q0Rx6WzloYvIZdNxHUvre/5lO/p\nu9BatBN2XqgLbh8d4/BkDorG7c+Jz/U8QOJlu5QHijQ3Nt8HqgMY/H/h/w==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004dead11c7a5b396862f21974dc4752fadeff994efe9bbd05ab413765ea80b6e1f1de3f0640e8ac6edcf89cff53c40e265bb94078a343736df07aa0318fc7fe1ff",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3q0Rx6WzloYvIZdNxHUvre/5lO/p\nu9BatBN2XqgLbh8d4/BkDorG7c+Jz/U8QOJlu5QHijQ3Nt8HqgMY/H/h/w==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 296,
+          "tcId" : 400,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100fdea5843ffeb73af94313ba4831b53fe24f799e525b1e8e8c87b59b95b430ad9",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04d0bc472e0d7c81ebaed3a6ef96c18613bb1fea6f994326fbe80e00dfde67c7e9986c723ea4843d48389b946f64ad56c83ad70ff17ba85335667d1bb9fa619efd",
-        "wx" : "0d0bc472e0d7c81ebaed3a6ef96c18613bb1fea6f994326fbe80e00dfde67c7e9",
-        "wy" : "0986c723ea4843d48389b946f64ad56c83ad70ff17ba85335667d1bb9fa619efd"
+        "wx" : "00d0bc472e0d7c81ebaed3a6ef96c18613bb1fea6f994326fbe80e00dfde67c7e9",
+        "wy" : "00986c723ea4843d48389b946f64ad56c83ad70ff17ba85335667d1bb9fa619efd"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d0bc472e0d7c81ebaed3a6ef96c18613bb1fea6f994326fbe80e00dfde67c7e9986c723ea4843d48389b946f64ad56c83ad70ff17ba85335667d1bb9fa619efd",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0LxHLg18geuu06bvlsGGE7sf6m+Z\nQyb76A4A395nx+mYbHI+pIQ9SDiblG9krVbIOtcP8XuoUzVmfRu5+mGe/Q==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d0bc472e0d7c81ebaed3a6ef96c18613bb1fea6f994326fbe80e00dfde67c7e9986c723ea4843d48389b946f64ad56c83ad70ff17ba85335667d1bb9fa619efd",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0LxHLg18geuu06bvlsGGE7sf6m+Z\nQyb76A4A395nx+mYbHI+pIQ9SDiblG9krVbIOtcP8XuoUzVmfRu5+mGe/Q==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 297,
+          "tcId" : 401,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022003ffcabf2f1b4d2a65190db1680d62bb994e41c5251cd73b3c3dfc5e5bafc035",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04a0a44ca947d66a2acb736008b9c08d1ab2ad03776e02640f78495d458dd51c326337fe5cf8c4604b1f1c409dc2d872d4294a4762420df43a30a2392e40426add",
-        "wx" : "0a0a44ca947d66a2acb736008b9c08d1ab2ad03776e02640f78495d458dd51c32",
+        "wx" : "00a0a44ca947d66a2acb736008b9c08d1ab2ad03776e02640f78495d458dd51c32",
         "wy" : "6337fe5cf8c4604b1f1c409dc2d872d4294a4762420df43a30a2392e40426add"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a0a44ca947d66a2acb736008b9c08d1ab2ad03776e02640f78495d458dd51c326337fe5cf8c4604b1f1c409dc2d872d4294a4762420df43a30a2392e40426add",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoKRMqUfWairLc2AIucCNGrKtA3du\nAmQPeEldRY3VHDJjN/5c+MRgSx8cQJ3C2HLUKUpHYkIN9DowojkuQEJq3Q==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a0a44ca947d66a2acb736008b9c08d1ab2ad03776e02640f78495d458dd51c326337fe5cf8c4604b1f1c409dc2d872d4294a4762420df43a30a2392e40426add",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEoKRMqUfWairLc2AIucCNGrKtA3du\nAmQPeEldRY3VHDJjN/5c+MRgSx8cQJ3C2HLUKUpHYkIN9DowojkuQEJq3Q==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 298,
+          "tcId" : 402,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02204dfbc401f971cd304b33dfdb17d0fed0fe4c1a88ae648e0d2847f74977534989",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04c9c2115290d008b45fb65fad0f602389298c25420b775019d42b62c3ce8a96b73877d25a8080dc02d987ca730f0405c2c9dbefac46f9e601cc3f06e9713973fd",
-        "wx" : "0c9c2115290d008b45fb65fad0f602389298c25420b775019d42b62c3ce8a96b7",
+        "wx" : "00c9c2115290d008b45fb65fad0f602389298c25420b775019d42b62c3ce8a96b7",
         "wy" : "3877d25a8080dc02d987ca730f0405c2c9dbefac46f9e601cc3f06e9713973fd"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c9c2115290d008b45fb65fad0f602389298c25420b775019d42b62c3ce8a96b73877d25a8080dc02d987ca730f0405c2c9dbefac46f9e601cc3f06e9713973fd",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEycIRUpDQCLRftl+tD2AjiSmMJUIL\nd1AZ1Ctiw86Klrc4d9JagIDcAtmHynMPBAXCydvvrEb55gHMPwbpcTlz/Q==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c9c2115290d008b45fb65fad0f602389298c25420b775019d42b62c3ce8a96b73877d25a8080dc02d987ca730f0405c2c9dbefac46f9e601cc3f06e9713973fd",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEycIRUpDQCLRftl+tD2AjiSmMJUIL\nd1AZ1Ctiw86Klrc4d9JagIDcAtmHynMPBAXCydvvrEb55gHMPwbpcTlz/Q==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 299,
+          "tcId" : 403,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bc4024761cd2ffd43dfdb17d0fed112b988977055cd3a8e54971eba9cda5ca71",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "045eca1ef4c287dddc66b8bccf1b88e8a24c0018962f3c5e7efa83bc1a5ff6033e5e79c4cb2c245b8c45abdce8a8e4da758d92a607c32cd407ecaef22f1c934a71",
         "wx" : "5eca1ef4c287dddc66b8bccf1b88e8a24c0018962f3c5e7efa83bc1a5ff6033e",
         "wy" : "5e79c4cb2c245b8c45abdce8a8e4da758d92a607c32cd407ecaef22f1c934a71"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045eca1ef4c287dddc66b8bccf1b88e8a24c0018962f3c5e7efa83bc1a5ff6033e5e79c4cb2c245b8c45abdce8a8e4da758d92a607c32cd407ecaef22f1c934a71",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXsoe9MKH3dxmuLzPG4jookwAGJYv\nPF5++oO8Gl/2Az5eecTLLCRbjEWr3Oio5Np1jZKmB8Ms1AfsrvIvHJNKcQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045eca1ef4c287dddc66b8bccf1b88e8a24c0018962f3c5e7efa83bc1a5ff6033e5e79c4cb2c245b8c45abdce8a8e4da758d92a607c32cd407ecaef22f1c934a71",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXsoe9MKH3dxmuLzPG4jookwAGJYv\nPF5++oO8Gl/2Az5eecTLLCRbjEWr3Oio5Np1jZKmB8Ms1AfsrvIvHJNKcQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 300,
+          "tcId" : 404,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0220788048ed39a5ffa77bfb62fa1fda2257742bf35d128fb3459f2a0c909ee86f91",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "045caaa030e7fdf0e4936bc7ab5a96353e0a01e4130c3f8bf22d473e317029a47adeb6adc462f7058f2a20d371e9702254e9b201642005b3ceda926b42b178bef9",
         "wx" : "5caaa030e7fdf0e4936bc7ab5a96353e0a01e4130c3f8bf22d473e317029a47a",
-        "wy" : "0deb6adc462f7058f2a20d371e9702254e9b201642005b3ceda926b42b178bef9"
+        "wy" : "00deb6adc462f7058f2a20d371e9702254e9b201642005b3ceda926b42b178bef9"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045caaa030e7fdf0e4936bc7ab5a96353e0a01e4130c3f8bf22d473e317029a47adeb6adc462f7058f2a20d371e9702254e9b201642005b3ceda926b42b178bef9",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXKqgMOf98OSTa8erWpY1PgoB5BMM\nP4vyLUc+MXAppHretq3EYvcFjyog03HpcCJU6bIBZCAFs87akmtCsXi++Q==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045caaa030e7fdf0e4936bc7ab5a96353e0a01e4130c3f8bf22d473e317029a47adeb6adc462f7058f2a20d371e9702254e9b201642005b3ceda926b42b178bef9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXKqgMOf98OSTa8erWpY1PgoB5BMM\nP4vyLUc+MXAppHretq3EYvcFjyog03HpcCJU6bIBZCAFs87akmtCsXi++Q==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 301,
+          "tcId" : 405,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0220476d9131fd381bd917d0fed112bc9e0a5924b5ed5b11167edd8b23582b3cb15e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04c2fd20bac06e555bb8ac0ce69eb1ea20f83a1fc3501c8a66469b1a31f619b0986237050779f52b615bd7b8d76a25fc95ca2ed32525c75f27ffc87ac397e6cbaf",
-        "wx" : "0c2fd20bac06e555bb8ac0ce69eb1ea20f83a1fc3501c8a66469b1a31f619b098",
+        "wx" : "00c2fd20bac06e555bb8ac0ce69eb1ea20f83a1fc3501c8a66469b1a31f619b098",
         "wy" : "6237050779f52b615bd7b8d76a25fc95ca2ed32525c75f27ffc87ac397e6cbaf"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c2fd20bac06e555bb8ac0ce69eb1ea20f83a1fc3501c8a66469b1a31f619b0986237050779f52b615bd7b8d76a25fc95ca2ed32525c75f27ffc87ac397e6cbaf",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwv0gusBuVVu4rAzmnrHqIPg6H8NQ\nHIpmRpsaMfYZsJhiNwUHefUrYVvXuNdqJfyVyi7TJSXHXyf/yHrDl+bLrw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c2fd20bac06e555bb8ac0ce69eb1ea20f83a1fc3501c8a66469b1a31f619b0986237050779f52b615bd7b8d76a25fc95ca2ed32525c75f27ffc87ac397e6cbaf",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEwv0gusBuVVu4rAzmnrHqIPg6H8NQ\nHIpmRpsaMfYZsJhiNwUHefUrYVvXuNdqJfyVyi7TJSXHXyf/yHrDl+bLrw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 302,
+          "tcId" : 406,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0221008374253e3e21bd154448d0a8f640fe46fafa8b19ce78d538f6cc0a19662d3601",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "043fd6a1ca7f77fb3b0bbe726c372010068426e11ea6ae78ce17bedae4bba86ced03ce5516406bf8cfaab8745eac1cd69018ad6f50b5461872ddfc56e0db3c8ff4",
         "wx" : "3fd6a1ca7f77fb3b0bbe726c372010068426e11ea6ae78ce17bedae4bba86ced",
-        "wy" : "3ce5516406bf8cfaab8745eac1cd69018ad6f50b5461872ddfc56e0db3c8ff4"
+        "wy" : "03ce5516406bf8cfaab8745eac1cd69018ad6f50b5461872ddfc56e0db3c8ff4"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043fd6a1ca7f77fb3b0bbe726c372010068426e11ea6ae78ce17bedae4bba86ced03ce5516406bf8cfaab8745eac1cd69018ad6f50b5461872ddfc56e0db3c8ff4",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEP9ahyn93+zsLvnJsNyAQBoQm4R6m\nrnjOF77a5LuobO0DzlUWQGv4z6q4dF6sHNaQGK1vULVGGHLd/Fbg2zyP9A==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043fd6a1ca7f77fb3b0bbe726c372010068426e11ea6ae78ce17bedae4bba86ced03ce5516406bf8cfaab8745eac1cd69018ad6f50b5461872ddfc56e0db3c8ff4",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEP9ahyn93+zsLvnJsNyAQBoQm4R6m\nrnjOF77a5LuobO0DzlUWQGv4z6q4dF6sHNaQGK1vULVGGHLd/Fbg2zyP9A==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 303,
+          "tcId" : 407,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0220357cfd3be4d01d413c5b9ede36cba5452c11ee7fe14879e749ae6a2d897a52d6",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "049cb8e51e27a5ae3b624a60d6dc32734e4989db20e9bca3ede1edf7b086911114b4c104ab3c677e4b36d6556e8ad5f523410a19f2e277aa895fc57322b4427544",
-        "wx" : "09cb8e51e27a5ae3b624a60d6dc32734e4989db20e9bca3ede1edf7b086911114",
-        "wy" : "0b4c104ab3c677e4b36d6556e8ad5f523410a19f2e277aa895fc57322b4427544"
+        "wx" : "009cb8e51e27a5ae3b624a60d6dc32734e4989db20e9bca3ede1edf7b086911114",
+        "wy" : "00b4c104ab3c677e4b36d6556e8ad5f523410a19f2e277aa895fc57322b4427544"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049cb8e51e27a5ae3b624a60d6dc32734e4989db20e9bca3ede1edf7b086911114b4c104ab3c677e4b36d6556e8ad5f523410a19f2e277aa895fc57322b4427544",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnLjlHielrjtiSmDW3DJzTkmJ2yDp\nvKPt4e33sIaRERS0wQSrPGd+SzbWVW6K1fUjQQoZ8uJ3qolfxXMitEJ1RA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049cb8e51e27a5ae3b624a60d6dc32734e4989db20e9bca3ede1edf7b086911114b4c104ab3c677e4b36d6556e8ad5f523410a19f2e277aa895fc57322b4427544",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnLjlHielrjtiSmDW3DJzTkmJ2yDp\nvKPt4e33sIaRERS0wQSrPGd+SzbWVW6K1fUjQQoZ8uJ3qolfxXMitEJ1RA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 304,
+          "tcId" : 408,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022029798c5c0ee287d4a5e8e6b799fd86b8df5225298e6ffc807cd2f2bc27a0a6d8",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04a3e52c156dcaf10502620b7955bc2b40bc78ef3d569e1223c262512d8f49602a4a2039f31c1097024ad3cc86e57321de032355463486164cf192944977df147f",
-        "wx" : "0a3e52c156dcaf10502620b7955bc2b40bc78ef3d569e1223c262512d8f49602a",
+        "wx" : "00a3e52c156dcaf10502620b7955bc2b40bc78ef3d569e1223c262512d8f49602a",
         "wy" : "4a2039f31c1097024ad3cc86e57321de032355463486164cf192944977df147f"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a3e52c156dcaf10502620b7955bc2b40bc78ef3d569e1223c262512d8f49602a4a2039f31c1097024ad3cc86e57321de032355463486164cf192944977df147f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEo+UsFW3K8QUCYgt5VbwrQLx47z1W\nnhIjwmJRLY9JYCpKIDnzHBCXAkrTzIblcyHeAyNVRjSGFkzxkpRJd98Ufw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a3e52c156dcaf10502620b7955bc2b40bc78ef3d569e1223c262512d8f49602a4a2039f31c1097024ad3cc86e57321de032355463486164cf192944977df147f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEo+UsFW3K8QUCYgt5VbwrQLx47z1W\nnhIjwmJRLY9JYCpKIDnzHBCXAkrTzIblcyHeAyNVRjSGFkzxkpRJd98Ufw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 305,
+          "tcId" : 409,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02200b70f22c781092452dca1a5711fa3a5a1f72add1bf52c2ff7cae4820b30078dd",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04f19b78928720d5bee8e670fb90010fb15c37bf91b58a5157c3f3c059b2655e88cf701ec962fb4a11dcf273f5dc357e58468560c7cfeb942d074abd4329260509",
-        "wx" : "0f19b78928720d5bee8e670fb90010fb15c37bf91b58a5157c3f3c059b2655e88",
-        "wy" : "0cf701ec962fb4a11dcf273f5dc357e58468560c7cfeb942d074abd4329260509"
+        "wx" : "00f19b78928720d5bee8e670fb90010fb15c37bf91b58a5157c3f3c059b2655e88",
+        "wy" : "00cf701ec962fb4a11dcf273f5dc357e58468560c7cfeb942d074abd4329260509"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f19b78928720d5bee8e670fb90010fb15c37bf91b58a5157c3f3c059b2655e88cf701ec962fb4a11dcf273f5dc357e58468560c7cfeb942d074abd4329260509",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8Zt4kocg1b7o5nD7kAEPsVw3v5G1\nilFXw/PAWbJlXojPcB7JYvtKEdzyc/XcNX5YRoVgx8/rlC0HSr1DKSYFCQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f19b78928720d5bee8e670fb90010fb15c37bf91b58a5157c3f3c059b2655e88cf701ec962fb4a11dcf273f5dc357e58468560c7cfeb942d074abd4329260509",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8Zt4kocg1b7o5nD7kAEPsVw3v5G1\nilFXw/PAWbJlXojPcB7JYvtKEdzyc/XcNX5YRoVgx8/rlC0HSr1DKSYFCQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 306,
+          "tcId" : 410,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022016e1e458f021248a5b9434ae23f474b43ee55ba37ea585fef95c90416600f1ba",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0483a744459ecdfb01a5cf52b27a05bb7337482d242f235d7b4cb89345545c90a8c05d49337b9649813287de9ffe90355fd905df5f3c32945828121f37cc50de6e",
-        "wx" : "083a744459ecdfb01a5cf52b27a05bb7337482d242f235d7b4cb89345545c90a8",
-        "wy" : "0c05d49337b9649813287de9ffe90355fd905df5f3c32945828121f37cc50de6e"
+        "wx" : "0083a744459ecdfb01a5cf52b27a05bb7337482d242f235d7b4cb89345545c90a8",
+        "wy" : "00c05d49337b9649813287de9ffe90355fd905df5f3c32945828121f37cc50de6e"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000483a744459ecdfb01a5cf52b27a05bb7337482d242f235d7b4cb89345545c90a8c05d49337b9649813287de9ffe90355fd905df5f3c32945828121f37cc50de6e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEg6dERZ7N+wGlz1KyegW7czdILSQv\nI117TLiTRVRckKjAXUkze5ZJgTKH3p/+kDVf2QXfXzwylFgoEh83zFDebg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000483a744459ecdfb01a5cf52b27a05bb7337482d242f235d7b4cb89345545c90a8c05d49337b9649813287de9ffe90355fd905df5f3c32945828121f37cc50de6e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEg6dERZ7N+wGlz1KyegW7czdILSQv\nI117TLiTRVRckKjAXUkze5ZJgTKH3p/+kDVf2QXfXzwylFgoEh83zFDebg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 307,
+          "tcId" : 411,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02202252d6856831b6cf895e4f0535eeaf0e5e5809753df848fe760ad86219016a97",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04dd13c6b34c56982ddae124f039dfd23f4b19bbe88cee8e528ae51e5d6f3a21d7bfad4c2e6f263fe5eb59ca974d039fc0e4c3345692fb5320bdae4bd3b42a45ff",
-        "wx" : "0dd13c6b34c56982ddae124f039dfd23f4b19bbe88cee8e528ae51e5d6f3a21d7",
-        "wy" : "0bfad4c2e6f263fe5eb59ca974d039fc0e4c3345692fb5320bdae4bd3b42a45ff"
+        "wx" : "00dd13c6b34c56982ddae124f039dfd23f4b19bbe88cee8e528ae51e5d6f3a21d7",
+        "wy" : "00bfad4c2e6f263fe5eb59ca974d039fc0e4c3345692fb5320bdae4bd3b42a45ff"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004dd13c6b34c56982ddae124f039dfd23f4b19bbe88cee8e528ae51e5d6f3a21d7bfad4c2e6f263fe5eb59ca974d039fc0e4c3345692fb5320bdae4bd3b42a45ff",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3RPGs0xWmC3a4STwOd/SP0sZu+iM\n7o5SiuUeXW86Ide/rUwubyY/5etZypdNA5/A5MM0VpL7UyC9rkvTtCpF/w==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004dd13c6b34c56982ddae124f039dfd23f4b19bbe88cee8e528ae51e5d6f3a21d7bfad4c2e6f263fe5eb59ca974d039fc0e4c3345692fb5320bdae4bd3b42a45ff",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3RPGs0xWmC3a4STwOd/SP0sZu+iM\n7o5SiuUeXW86Ide/rUwubyY/5etZypdNA5/A5MM0VpL7UyC9rkvTtCpF/w==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 308,
+          "tcId" : 412,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02210081ffe55f178da695b28c86d8b406b15dab1a9e39661a3ae017fbe390ac0972c3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0467e6f659cdde869a2f65f094e94e5b4dfad636bbf95192feeed01b0f3deb7460a37e0a51f258b7aeb51dfe592f5cfd5685bbe58712c8d9233c62886437c38ba0",
         "wx" : "67e6f659cdde869a2f65f094e94e5b4dfad636bbf95192feeed01b0f3deb7460",
-        "wy" : "0a37e0a51f258b7aeb51dfe592f5cfd5685bbe58712c8d9233c62886437c38ba0"
+        "wy" : "00a37e0a51f258b7aeb51dfe592f5cfd5685bbe58712c8d9233c62886437c38ba0"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000467e6f659cdde869a2f65f094e94e5b4dfad636bbf95192feeed01b0f3deb7460a37e0a51f258b7aeb51dfe592f5cfd5685bbe58712c8d9233c62886437c38ba0",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZ+b2Wc3ehpovZfCU6U5bTfrWNrv5\nUZL+7tAbDz3rdGCjfgpR8li3rrUd/lkvXP1WhbvlhxLI2SM8YohkN8OLoA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000467e6f659cdde869a2f65f094e94e5b4dfad636bbf95192feeed01b0f3deb7460a37e0a51f258b7aeb51dfe592f5cfd5685bbe58712c8d9233c62886437c38ba0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEZ+b2Wc3ehpovZfCU6U5bTfrWNrv5\nUZL+7tAbDz3rdGCjfgpR8li3rrUd/lkvXP1WhbvlhxLI2SM8YohkN8OLoA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 309,
+          "tcId" : 413,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02207fffffffaaaaaaaaffffffffffffffffe9a2538f37b28a2c513dee40fecbb71a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "042eb6412505aec05c6545f029932087e490d05511e8ec1f599617bb367f9ecaaf805f51efcc4803403f9b1ae0124890f06a43fedcddb31830f6669af292895cb0",
         "wx" : "2eb6412505aec05c6545f029932087e490d05511e8ec1f599617bb367f9ecaaf",
-        "wy" : "0805f51efcc4803403f9b1ae0124890f06a43fedcddb31830f6669af292895cb0"
+        "wy" : "00805f51efcc4803403f9b1ae0124890f06a43fedcddb31830f6669af292895cb0"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042eb6412505aec05c6545f029932087e490d05511e8ec1f599617bb367f9ecaaf805f51efcc4803403f9b1ae0124890f06a43fedcddb31830f6669af292895cb0",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELrZBJQWuwFxlRfApkyCH5JDQVRHo\n7B9Zlhe7Nn+eyq+AX1HvzEgDQD+bGuASSJDwakP+3N2zGDD2ZprykolcsA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042eb6412505aec05c6545f029932087e490d05511e8ec1f599617bb367f9ecaaf805f51efcc4803403f9b1ae0124890f06a43fedcddb31830f6669af292895cb0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELrZBJQWuwFxlRfApkyCH5JDQVRHo\n7B9Zlhe7Nn+eyq+AX1HvzEgDQD+bGuASSJDwakP+3N2zGDD2ZprykolcsA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 310,
+          "tcId" : 414,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100b62f26b5f2a2b26f6de86d42ad8a13da3ab3cccd0459b201de009e526adf21f2",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0484db645868eab35e3a9fd80e056e2e855435e3a6b68d75a50a854625fe0d7f356d2589ac655edc9a11ef3e075eddda9abf92e72171570ef7bf43a2ee39338cfe",
-        "wx" : "084db645868eab35e3a9fd80e056e2e855435e3a6b68d75a50a854625fe0d7f35",
+        "wx" : "0084db645868eab35e3a9fd80e056e2e855435e3a6b68d75a50a854625fe0d7f35",
         "wy" : "6d2589ac655edc9a11ef3e075eddda9abf92e72171570ef7bf43a2ee39338cfe"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000484db645868eab35e3a9fd80e056e2e855435e3a6b68d75a50a854625fe0d7f356d2589ac655edc9a11ef3e075eddda9abf92e72171570ef7bf43a2ee39338cfe",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhNtkWGjqs146n9gOBW4uhVQ146a2\njXWlCoVGJf4NfzVtJYmsZV7cmhHvPgde3dqav5LnIXFXDve/Q6LuOTOM/g==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000484db645868eab35e3a9fd80e056e2e855435e3a6b68d75a50a854625fe0d7f356d2589ac655edc9a11ef3e075eddda9abf92e72171570ef7bf43a2ee39338cfe",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhNtkWGjqs146n9gOBW4uhVQ146a2\njXWlCoVGJf4NfzVtJYmsZV7cmhHvPgde3dqav5LnIXFXDve/Q6LuOTOM/g==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 311,
+          "tcId" : 415,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bb1d9ac949dd748cd02bbbe749bd351cd57b38bb61403d700686aa7b4c90851e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0491b9e47c56278662d75c0983b22ca8ea6aa5059b7a2ff7637eb2975e386ad66349aa8ff283d0f77c18d6d11dc062165fd13c3c0310679c1408302a16854ecfbd",
-        "wx" : "091b9e47c56278662d75c0983b22ca8ea6aa5059b7a2ff7637eb2975e386ad663",
+        "wx" : "0091b9e47c56278662d75c0983b22ca8ea6aa5059b7a2ff7637eb2975e386ad663",
         "wy" : "49aa8ff283d0f77c18d6d11dc062165fd13c3c0310679c1408302a16854ecfbd"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000491b9e47c56278662d75c0983b22ca8ea6aa5059b7a2ff7637eb2975e386ad66349aa8ff283d0f77c18d6d11dc062165fd13c3c0310679c1408302a16854ecfbd",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkbnkfFYnhmLXXAmDsiyo6mqlBZt6\nL/djfrKXXjhq1mNJqo/yg9D3fBjW0R3AYhZf0Tw8AxBnnBQIMCoWhU7PvQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000491b9e47c56278662d75c0983b22ca8ea6aa5059b7a2ff7637eb2975e386ad66349aa8ff283d0f77c18d6d11dc062165fd13c3c0310679c1408302a16854ecfbd",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkbnkfFYnhmLXXAmDsiyo6mqlBZt6\nL/djfrKXXjhq1mNJqo/yg9D3fBjW0R3AYhZf0Tw8AxBnnBQIMCoWhU7PvQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 312,
+          "tcId" : 416,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022066755a00638cdaec1c732513ca0234ece52545dac11f816e818f725b4f60aaf2",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04f3ec2f13caf04d0192b47fb4c5311fb6d4dc6b0a9e802e5327f7ec5ee8e4834df97e3e468b7d0db867d6ecfe81e2b0f9531df87efdb47c1338ac321fefe5a432",
-        "wx" : "0f3ec2f13caf04d0192b47fb4c5311fb6d4dc6b0a9e802e5327f7ec5ee8e4834d",
-        "wy" : "0f97e3e468b7d0db867d6ecfe81e2b0f9531df87efdb47c1338ac321fefe5a432"
+        "wx" : "00f3ec2f13caf04d0192b47fb4c5311fb6d4dc6b0a9e802e5327f7ec5ee8e4834d",
+        "wy" : "00f97e3e468b7d0db867d6ecfe81e2b0f9531df87efdb47c1338ac321fefe5a432"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f3ec2f13caf04d0192b47fb4c5311fb6d4dc6b0a9e802e5327f7ec5ee8e4834df97e3e468b7d0db867d6ecfe81e2b0f9531df87efdb47c1338ac321fefe5a432",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8+wvE8rwTQGStH+0xTEfttTcawqe\ngC5TJ/fsXujkg035fj5Gi30NuGfW7P6B4rD5Ux34fv20fBM4rDIf7+WkMg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f3ec2f13caf04d0192b47fb4c5311fb6d4dc6b0a9e802e5327f7ec5ee8e4834df97e3e468b7d0db867d6ecfe81e2b0f9531df87efdb47c1338ac321fefe5a432",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8+wvE8rwTQGStH+0xTEfttTcawqe\ngC5TJ/fsXujkg035fj5Gi30NuGfW7P6B4rD5Ux34fv20fBM4rDIf7+WkMg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 313,
+          "tcId" : 417,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022055a00c9fcdaebb6032513ca0234ecfffe98ebe492fdf02e48ca48e982beb3669",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04d92b200aefcab6ac7dafd9acaf2fa10b3180235b8f46b4503e4693c670fccc885ef2f3aebf5b317475336256768f7c19efb7352d27e4cccadc85b6b8ab922c72",
-        "wx" : "0d92b200aefcab6ac7dafd9acaf2fa10b3180235b8f46b4503e4693c670fccc88",
+        "wx" : "00d92b200aefcab6ac7dafd9acaf2fa10b3180235b8f46b4503e4693c670fccc88",
         "wy" : "5ef2f3aebf5b317475336256768f7c19efb7352d27e4cccadc85b6b8ab922c72"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d92b200aefcab6ac7dafd9acaf2fa10b3180235b8f46b4503e4693c670fccc885ef2f3aebf5b317475336256768f7c19efb7352d27e4cccadc85b6b8ab922c72",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2SsgCu/Ktqx9r9msry+hCzGAI1uP\nRrRQPkaTxnD8zIhe8vOuv1sxdHUzYlZ2j3wZ77c1LSfkzMrchba4q5Iscg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d92b200aefcab6ac7dafd9acaf2fa10b3180235b8f46b4503e4693c670fccc885ef2f3aebf5b317475336256768f7c19efb7352d27e4cccadc85b6b8ab922c72",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2SsgCu/Ktqx9r9msry+hCzGAI1uP\nRrRQPkaTxnD8zIhe8vOuv1sxdHUzYlZ2j3wZ77c1LSfkzMrchba4q5Iscg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 314,
+          "tcId" : 418,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100ab40193f9b5d76c064a27940469d9fffd31d7c925fbe05c919491d3057d66cd2",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "040a88361eb92ecca2625b38e5f98bbabb96bf179b3d76fc48140a3bcd881523cde6bdf56033f84a5054035597375d90866aa2c96b86a41ccf6edebf47298ad489",
         "wx" : "0a88361eb92ecca2625b38e5f98bbabb96bf179b3d76fc48140a3bcd881523cd",
-        "wy" : "0e6bdf56033f84a5054035597375d90866aa2c96b86a41ccf6edebf47298ad489"
+        "wy" : "00e6bdf56033f84a5054035597375d90866aa2c96b86a41ccf6edebf47298ad489"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040a88361eb92ecca2625b38e5f98bbabb96bf179b3d76fc48140a3bcd881523cde6bdf56033f84a5054035597375d90866aa2c96b86a41ccf6edebf47298ad489",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECog2HrkuzKJiWzjl+Yu6u5a/F5s9\ndvxIFAo7zYgVI83mvfVgM/hKUFQDVZc3XZCGaqLJa4akHM9u3r9HKYrUiQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040a88361eb92ecca2625b38e5f98bbabb96bf179b3d76fc48140a3bcd881523cde6bdf56033f84a5054035597375d90866aa2c96b86a41ccf6edebf47298ad489",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECog2HrkuzKJiWzjl+Yu6u5a/F5s9\ndvxIFAo7zYgVI83mvfVgM/hKUFQDVZc3XZCGaqLJa4akHM9u3r9HKYrUiQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 315,
+          "tcId" : 419,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100ca0234ebb5fdcb13ca0234ecffffffffcb0dadbbc7f549f8a26b4408d0dc8600",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04d0fb17ccd8fafe827e0c1afc5d8d80366e2b20e7f14a563a2ba50469d84375e868612569d39e2bb9f554355564646de99ac602cc6349cf8c1e236a7de7637d93",
-        "wx" : "0d0fb17ccd8fafe827e0c1afc5d8d80366e2b20e7f14a563a2ba50469d84375e8",
+        "wx" : "00d0fb17ccd8fafe827e0c1afc5d8d80366e2b20e7f14a563a2ba50469d84375e8",
         "wy" : "68612569d39e2bb9f554355564646de99ac602cc6349cf8c1e236a7de7637d93"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d0fb17ccd8fafe827e0c1afc5d8d80366e2b20e7f14a563a2ba50469d84375e868612569d39e2bb9f554355564646de99ac602cc6349cf8c1e236a7de7637d93",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0PsXzNj6/oJ+DBr8XY2ANm4rIOfx\nSlY6K6UEadhDdehoYSVp054rufVUNVVkZG3pmsYCzGNJz4weI2p952N9kw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d0fb17ccd8fafe827e0c1afc5d8d80366e2b20e7f14a563a2ba50469d84375e868612569d39e2bb9f554355564646de99ac602cc6349cf8c1e236a7de7637d93",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE0PsXzNj6/oJ+DBr8XY2ANm4rIOfx\nSlY6K6UEadhDdehoYSVp054rufVUNVVkZG3pmsYCzGNJz4weI2p952N9kw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 316,
+          "tcId" : 420,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bfffffff3ea3677e082b9310572620ae19933a9e65b285598711c77298815ad3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04836f33bbc1dc0d3d3abbcef0d91f11e2ac4181076c9af0a22b1e4309d3edb2769ab443ff6f901e30c773867582997c2bec2b0cb8120d760236f3a95bbe881f75",
-        "wx" : "0836f33bbc1dc0d3d3abbcef0d91f11e2ac4181076c9af0a22b1e4309d3edb276",
-        "wy" : "09ab443ff6f901e30c773867582997c2bec2b0cb8120d760236f3a95bbe881f75"
+        "wx" : "00836f33bbc1dc0d3d3abbcef0d91f11e2ac4181076c9af0a22b1e4309d3edb276",
+        "wy" : "009ab443ff6f901e30c773867582997c2bec2b0cb8120d760236f3a95bbe881f75"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004836f33bbc1dc0d3d3abbcef0d91f11e2ac4181076c9af0a22b1e4309d3edb2769ab443ff6f901e30c773867582997c2bec2b0cb8120d760236f3a95bbe881f75",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEg28zu8HcDT06u87w2R8R4qxBgQds\nmvCiKx5DCdPtsnaatEP/b5AeMMdzhnWCmXwr7CsMuBINdgI286lbvogfdQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004836f33bbc1dc0d3d3abbcef0d91f11e2ac4181076c9af0a22b1e4309d3edb2769ab443ff6f901e30c773867582997c2bec2b0cb8120d760236f3a95bbe881f75",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEg28zu8HcDT06u87w2R8R4qxBgQds\nmvCiKx5DCdPtsnaatEP/b5AeMMdzhnWCmXwr7CsMuBINdgI286lbvogfdQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 317,
+          "tcId" : 421,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0220266666663bbbbbbbe6666666666666665b37902e023fab7c8f055d86e5cc41f4",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0492f99fbe973ed4a299719baee4b432741237034dec8d72ba5103cb33e55feeb8033dd0e91134c734174889f3ebcf1b7a1ac05767289280ee7a794cebd6e69697",
-        "wx" : "092f99fbe973ed4a299719baee4b432741237034dec8d72ba5103cb33e55feeb8",
-        "wy" : "33dd0e91134c734174889f3ebcf1b7a1ac05767289280ee7a794cebd6e69697"
+        "wx" : "0092f99fbe973ed4a299719baee4b432741237034dec8d72ba5103cb33e55feeb8",
+        "wy" : "033dd0e91134c734174889f3ebcf1b7a1ac05767289280ee7a794cebd6e69697"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000492f99fbe973ed4a299719baee4b432741237034dec8d72ba5103cb33e55feeb8033dd0e91134c734174889f3ebcf1b7a1ac05767289280ee7a794cebd6e69697",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkvmfvpc+1KKZcZuu5LQydBI3A03s\njXK6UQPLM+Vf7rgDPdDpETTHNBdIifPrzxt6GsBXZyiSgO56eUzr1uaWlw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000492f99fbe973ed4a299719baee4b432741237034dec8d72ba5103cb33e55feeb8033dd0e91134c734174889f3ebcf1b7a1ac05767289280ee7a794cebd6e69697",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEkvmfvpc+1KKZcZuu5LQydBI3A03s\njXK6UQPLM+Vf7rgDPdDpETTHNBdIifPrzxt6GsBXZyiSgO56eUzr1uaWlw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 318,
+          "tcId" : 422,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bfffffff36db6db7a492492492492492146c573f4c6dfc8d08a443e258970b09",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04d35ba58da30197d378e618ec0fa7e2e2d12cffd73ebbb2049d130bba434af09eff83986e6875e41ea432b7585a49b3a6c77cbb3c47919f8e82874c794635c1d2",
-        "wx" : "0d35ba58da30197d378e618ec0fa7e2e2d12cffd73ebbb2049d130bba434af09e",
-        "wy" : "0ff83986e6875e41ea432b7585a49b3a6c77cbb3c47919f8e82874c794635c1d2"
+        "wx" : "00d35ba58da30197d378e618ec0fa7e2e2d12cffd73ebbb2049d130bba434af09e",
+        "wy" : "00ff83986e6875e41ea432b7585a49b3a6c77cbb3c47919f8e82874c794635c1d2"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d35ba58da30197d378e618ec0fa7e2e2d12cffd73ebbb2049d130bba434af09eff83986e6875e41ea432b7585a49b3a6c77cbb3c47919f8e82874c794635c1d2",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE01uljaMBl9N45hjsD6fi4tEs/9c+\nu7IEnRMLukNK8J7/g5huaHXkHqQyt1haSbOmx3y7PEeRn46Ch0x5RjXB0g==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d35ba58da30197d378e618ec0fa7e2e2d12cffd73ebbb2049d130bba434af09eff83986e6875e41ea432b7585a49b3a6c77cbb3c47919f8e82874c794635c1d2",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE01uljaMBl9N45hjsD6fi4tEs/9c+\nu7IEnRMLukNK8J7/g5huaHXkHqQyt1haSbOmx3y7PEeRn46Ch0x5RjXB0g==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 319,
+          "tcId" : 423,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bfffffff2aaaaaab7fffffffffffffffc815d0e60b3e596ecb1ad3a27cfd49c4",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "048651ce490f1b46d73f3ff475149be29136697334a519d7ddab0725c8d0793224e11c65bd8ca92dc8bc9ae82911f0b52751ce21dd9003ae60900bd825f590cc28",
-        "wx" : "08651ce490f1b46d73f3ff475149be29136697334a519d7ddab0725c8d0793224",
-        "wy" : "0e11c65bd8ca92dc8bc9ae82911f0b52751ce21dd9003ae60900bd825f590cc28"
+        "wx" : "008651ce490f1b46d73f3ff475149be29136697334a519d7ddab0725c8d0793224",
+        "wy" : "00e11c65bd8ca92dc8bc9ae82911f0b52751ce21dd9003ae60900bd825f590cc28"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048651ce490f1b46d73f3ff475149be29136697334a519d7ddab0725c8d0793224e11c65bd8ca92dc8bc9ae82911f0b52751ce21dd9003ae60900bd825f590cc28",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhlHOSQ8bRtc/P/R1FJvikTZpczSl\nGdfdqwclyNB5MiThHGW9jKktyLya6CkR8LUnUc4h3ZADrmCQC9gl9ZDMKA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048651ce490f1b46d73f3ff475149be29136697334a519d7ddab0725c8d0793224e11c65bd8ca92dc8bc9ae82911f0b52751ce21dd9003ae60900bd825f590cc28",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhlHOSQ8bRtc/P/R1FJvikTZpczSl\nGdfdqwclyNB5MiThHGW9jKktyLya6CkR8LUnUc4h3ZADrmCQC9gl9ZDMKA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 320,
+          "tcId" : 424,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02207fffffff55555555ffffffffffffffffd344a71e6f651458a27bdc81fd976e37",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "046d8e1b12c831a0da8795650ff95f101ed921d9e2f72b15b1cdaca9826b9cfc6def6d63e2bc5c089570394a4bc9f892d5e6c7a6a637b20469a58c106ad486bf37",
         "wx" : "6d8e1b12c831a0da8795650ff95f101ed921d9e2f72b15b1cdaca9826b9cfc6d",
-        "wy" : "0ef6d63e2bc5c089570394a4bc9f892d5e6c7a6a637b20469a58c106ad486bf37"
+        "wy" : "00ef6d63e2bc5c089570394a4bc9f892d5e6c7a6a637b20469a58c106ad486bf37"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046d8e1b12c831a0da8795650ff95f101ed921d9e2f72b15b1cdaca9826b9cfc6def6d63e2bc5c089570394a4bc9f892d5e6c7a6a637b20469a58c106ad486bf37",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbY4bEsgxoNqHlWUP+V8QHtkh2eL3\nKxWxzaypgmuc/G3vbWPivFwIlXA5SkvJ+JLV5sempjeyBGmljBBq1Ia/Nw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046d8e1b12c831a0da8795650ff95f101ed921d9e2f72b15b1cdaca9826b9cfc6def6d63e2bc5c089570394a4bc9f892d5e6c7a6a637b20469a58c106ad486bf37",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEbY4bEsgxoNqHlWUP+V8QHtkh2eL3\nKxWxzaypgmuc/G3vbWPivFwIlXA5SkvJ+JLV5sempjeyBGmljBBq1Ia/Nw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 321,
+          "tcId" : 425,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02203fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192aa",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "040ae580bae933b4ef2997cbdbb0922328ca9a410f627a0f7dff24cb4d920e15428911e7f8cc365a8a88eb81421a361ccc2b99e309d8dcd9a98ba83c3949d893e3",
         "wx" : "0ae580bae933b4ef2997cbdbb0922328ca9a410f627a0f7dff24cb4d920e1542",
-        "wy" : "08911e7f8cc365a8a88eb81421a361ccc2b99e309d8dcd9a98ba83c3949d893e3"
+        "wy" : "008911e7f8cc365a8a88eb81421a361ccc2b99e309d8dcd9a98ba83c3949d893e3"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040ae580bae933b4ef2997cbdbb0922328ca9a410f627a0f7dff24cb4d920e15428911e7f8cc365a8a88eb81421a361ccc2b99e309d8dcd9a98ba83c3949d893e3",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECuWAuukztO8pl8vbsJIjKMqaQQ9i\neg99/yTLTZIOFUKJEef4zDZaiojrgUIaNhzMK5njCdjc2amLqDw5SdiT4w==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040ae580bae933b4ef2997cbdbb0922328ca9a410f627a0f7dff24cb4d920e15428911e7f8cc365a8a88eb81421a361ccc2b99e309d8dcd9a98ba83c3949d893e3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECuWAuukztO8pl8vbsJIjKMqaQQ9i\neg99/yTLTZIOFUKJEef4zDZaiojrgUIaNhzMK5njCdjc2amLqDw5SdiT4w==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 322,
+          "tcId" : 426,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02205d8ecd64a4eeba466815ddf3a4de9a8e6abd9c5db0a01eb80343553da648428f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "045b812fd521aafa69835a849cce6fbdeb6983b442d2444fe70e134c027fc46963838a40f2a36092e9004e92d8d940cf5638550ce672ce8b8d4e15eba5499249e9",
         "wx" : "5b812fd521aafa69835a849cce6fbdeb6983b442d2444fe70e134c027fc46963",
-        "wy" : "0838a40f2a36092e9004e92d8d940cf5638550ce672ce8b8d4e15eba5499249e9"
+        "wy" : "00838a40f2a36092e9004e92d8d940cf5638550ce672ce8b8d4e15eba5499249e9"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045b812fd521aafa69835a849cce6fbdeb6983b442d2444fe70e134c027fc46963838a40f2a36092e9004e92d8d940cf5638550ce672ce8b8d4e15eba5499249e9",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEW4Ev1SGq+mmDWoSczm+962mDtELS\nRE/nDhNMAn/EaWODikDyo2CS6QBOktjZQM9WOFUM5nLOi41OFeulSZJJ6Q==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045b812fd521aafa69835a849cce6fbdeb6983b442d2444fe70e134c027fc46963838a40f2a36092e9004e92d8d940cf5638550ce672ce8b8d4e15eba5499249e9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEW4Ev1SGq+mmDWoSczm+962mDtELS\nRE/nDhNMAn/EaWODikDyo2CS6QBOktjZQM9WOFUM5nLOi41OFeulSZJJ6Q==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 323,
+          "tcId" : 427,
           "comment" : "point duplication during verification",
-          "msg" : "313233343030",
-          "sig" : "304502206f2347cab7dd76858fe0555ac3bc99048c4aacafdfb6bcbe05ea6c42c4934569022100bb726660235793aa9957a61e76e00c2c435109cf9a15dd624d53f4301047856b",
-          "result" : "valid",
           "flags" : [
             "PointDuplication"
-          ]
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502206f2347cab7dd76858fe0555ac3bc99048c4aacafdfb6bcbe05ea6c42c4934569022100bb726660235793aa9957a61e76e00c2c435109cf9a15dd624d53f4301047856b",
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "045b812fd521aafa69835a849cce6fbdeb6983b442d2444fe70e134c027fc469637c75bf0c5c9f6d17ffb16d2726bf30a9c7aaf31a8d317472b1ea145ab66db616",
         "wx" : "5b812fd521aafa69835a849cce6fbdeb6983b442d2444fe70e134c027fc46963",
         "wy" : "7c75bf0c5c9f6d17ffb16d2726bf30a9c7aaf31a8d317472b1ea145ab66db616"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045b812fd521aafa69835a849cce6fbdeb6983b442d2444fe70e134c027fc469637c75bf0c5c9f6d17ffb16d2726bf30a9c7aaf31a8d317472b1ea145ab66db616",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEW4Ev1SGq+mmDWoSczm+962mDtELS\nRE/nDhNMAn/EaWN8db8MXJ9tF/+xbScmvzCpx6rzGo0xdHKx6hRatm22Fg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045b812fd521aafa69835a849cce6fbdeb6983b442d2444fe70e134c027fc469637c75bf0c5c9f6d17ffb16d2726bf30a9c7aaf31a8d317472b1ea145ab66db616",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEW4Ev1SGq+mmDWoSczm+962mDtELS\nRE/nDhNMAn/EaWN8db8MXJ9tF/+xbScmvzCpx6rzGo0xdHKx6hRatm22Fg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 324,
+          "tcId" : 428,
           "comment" : "duplication bug",
-          "msg" : "313233343030",
-          "sig" : "304502206f2347cab7dd76858fe0555ac3bc99048c4aacafdfb6bcbe05ea6c42c4934569022100bb726660235793aa9957a61e76e00c2c435109cf9a15dd624d53f4301047856b",
-          "result" : "invalid",
           "flags" : [
             "PointDuplication"
-          ]
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502206f2347cab7dd76858fe0555ac3bc99048c4aacafdfb6bcbe05ea6c42c4934569022100bb726660235793aa9957a61e76e00c2c435109cf9a15dd624d53f4301047856b",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "046adda82b90261b0f319faa0d878665a6b6da497f09c903176222c34acfef72a647e6f50dcc40ad5d9b59f7602bb222fad71a41bf5e1f9df4959a364c62e488d9",
         "wx" : "6adda82b90261b0f319faa0d878665a6b6da497f09c903176222c34acfef72a6",
         "wy" : "47e6f50dcc40ad5d9b59f7602bb222fad71a41bf5e1f9df4959a364c62e488d9"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046adda82b90261b0f319faa0d878665a6b6da497f09c903176222c34acfef72a647e6f50dcc40ad5d9b59f7602bb222fad71a41bf5e1f9df4959a364c62e488d9",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEat2oK5AmGw8xn6oNh4ZlprbaSX8J\nyQMXYiLDSs/vcqZH5vUNzECtXZtZ92ArsiL61xpBv14fnfSVmjZMYuSI2Q==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046adda82b90261b0f319faa0d878665a6b6da497f09c903176222c34acfef72a647e6f50dcc40ad5d9b59f7602bb222fad71a41bf5e1f9df4959a364c62e488d9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEat2oK5AmGw8xn6oNh4ZlprbaSX8J\nyQMXYiLDSs/vcqZH5vUNzECtXZtZ92ArsiL61xpBv14fnfSVmjZMYuSI2Q==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 325,
+          "tcId" : 429,
           "comment" : "point with x-coordinate 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30250201010220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "042fca0d0a47914de77ed56e7eccc3276a601120c6df0069c825c8f6a01c9f382065f3450a1d17c6b24989a39beb1c7decfca8384fbdc294418e5d807b3c6ed7de",
         "wx" : "2fca0d0a47914de77ed56e7eccc3276a601120c6df0069c825c8f6a01c9f3820",
         "wy" : "65f3450a1d17c6b24989a39beb1c7decfca8384fbdc294418e5d807b3c6ed7de"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042fca0d0a47914de77ed56e7eccc3276a601120c6df0069c825c8f6a01c9f382065f3450a1d17c6b24989a39beb1c7decfca8384fbdc294418e5d807b3c6ed7de",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEL8oNCkeRTed+1W5+zMMnamARIMbf\nAGnIJcj2oByfOCBl80UKHRfGskmJo5vrHH3s/Kg4T73ClEGOXYB7PG7X3g==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042fca0d0a47914de77ed56e7eccc3276a601120c6df0069c825c8f6a01c9f382065f3450a1d17c6b24989a39beb1c7decfca8384fbdc294418e5d807b3c6ed7de",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEL8oNCkeRTed+1W5+zMMnamARIMbf\nAGnIJcj2oByfOCBl80UKHRfGskmJo5vrHH3s/Kg4T73ClEGOXYB7PG7X3g==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 326,
+          "tcId" : 430,
           "comment" : "point with x-coordinate 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3045022101000000000000000000000000000000000000000000000000000000000000000002203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aa9",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04dd86d3b5f4a13e8511083b78002081c53ff467f11ebd98a51a633db76665d25045d5c8200c89f2fa10d849349226d21d8dfaed6ff8d5cb3e1b7e17474ebc18f7",
-        "wx" : "0dd86d3b5f4a13e8511083b78002081c53ff467f11ebd98a51a633db76665d250",
+        "wx" : "00dd86d3b5f4a13e8511083b78002081c53ff467f11ebd98a51a633db76665d250",
         "wy" : "45d5c8200c89f2fa10d849349226d21d8dfaed6ff8d5cb3e1b7e17474ebc18f7"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004dd86d3b5f4a13e8511083b78002081c53ff467f11ebd98a51a633db76665d25045d5c8200c89f2fa10d849349226d21d8dfaed6ff8d5cb3e1b7e17474ebc18f7",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3YbTtfShPoURCDt4ACCBxT/0Z/Ee\nvZilGmM9t2Zl0lBF1cggDIny+hDYSTSSJtIdjfrtb/jVyz4bfhdHTrwY9w==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004dd86d3b5f4a13e8511083b78002081c53ff467f11ebd98a51a633db76665d25045d5c8200c89f2fa10d849349226d21d8dfaed6ff8d5cb3e1b7e17474ebc18f7",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3YbTtfShPoURCDt4ACCBxT/0Z/Ee\nvZilGmM9t2Zl0lBF1cggDIny+hDYSTSSJtIdjfrtb/jVyz4bfhdHTrwY9w==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 327,
+          "tcId" : 431,
           "comment" : "comparison with point at infinity ",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aa9",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "044fea55b32cb32aca0c12c4cd0abfb4e64b0f5a516e578c016591a93f5a0fbcc5d7d3fd10b2be668c547b212f6bb14c88f0fecd38a8a4b2c785ed3be62ce4b280",
         "wx" : "4fea55b32cb32aca0c12c4cd0abfb4e64b0f5a516e578c016591a93f5a0fbcc5",
-        "wy" : "0d7d3fd10b2be668c547b212f6bb14c88f0fecd38a8a4b2c785ed3be62ce4b280"
+        "wy" : "00d7d3fd10b2be668c547b212f6bb14c88f0fecd38a8a4b2c785ed3be62ce4b280"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044fea55b32cb32aca0c12c4cd0abfb4e64b0f5a516e578c016591a93f5a0fbcc5d7d3fd10b2be668c547b212f6bb14c88f0fecd38a8a4b2c785ed3be62ce4b280",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAET+pVsyyzKsoMEsTNCr+05ksPWlFu\nV4wBZZGpP1oPvMXX0/0Qsr5mjFR7IS9rsUyI8P7NOKiksseF7TvmLOSygA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044fea55b32cb32aca0c12c4cd0abfb4e64b0f5a516e578c016591a93f5a0fbcc5d7d3fd10b2be668c547b212f6bb14c88f0fecd38a8a4b2c785ed3be62ce4b280",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAET+pVsyyzKsoMEsTNCr+05ksPWlFu\nV4wBZZGpP1oPvMXX0/0Qsr5mjFR7IS9rsUyI8P7NOKiksseF7TvmLOSygA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 328,
+          "tcId" : 432,
           "comment" : "extreme value for k and edgecase s",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc476699780220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04c6a771527024227792170a6f8eee735bf32b7f98af669ead299802e32d7c3107bc3b4b5e65ab887bbd343572b3e5619261fe3a073e2ffd78412f726867db589e",
-        "wx" : "0c6a771527024227792170a6f8eee735bf32b7f98af669ead299802e32d7c3107",
-        "wy" : "0bc3b4b5e65ab887bbd343572b3e5619261fe3a073e2ffd78412f726867db589e"
+        "wx" : "00c6a771527024227792170a6f8eee735bf32b7f98af669ead299802e32d7c3107",
+        "wy" : "00bc3b4b5e65ab887bbd343572b3e5619261fe3a073e2ffd78412f726867db589e"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c6a771527024227792170a6f8eee735bf32b7f98af669ead299802e32d7c3107bc3b4b5e65ab887bbd343572b3e5619261fe3a073e2ffd78412f726867db589e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExqdxUnAkIneSFwpvju5zW/Mrf5iv\nZp6tKZgC4y18MQe8O0teZauIe700NXKz5WGSYf46Bz4v/XhBL3JoZ9tYng==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004c6a771527024227792170a6f8eee735bf32b7f98af669ead299802e32d7c3107bc3b4b5e65ab887bbd343572b3e5619261fe3a073e2ffd78412f726867db589e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAExqdxUnAkIneSFwpvju5zW/Mrf5iv\nZp6tKZgC4y18MQe8O0teZauIe700NXKz5WGSYf46Bz4v/XhBL3JoZ9tYng==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 329,
+          "tcId" : 433,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022100b6db6db6249249254924924924924924625bd7a09bec4ca81bcdd9f8fd6b63cc",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04851c2bbad08e54ec7a9af99f49f03644d6ec6d59b207fec98de85a7d15b956efcee9960283045075684b410be8d0f7494b91aa2379f60727319f10ddeb0fe9d6",
-        "wx" : "0851c2bbad08e54ec7a9af99f49f03644d6ec6d59b207fec98de85a7d15b956ef",
-        "wy" : "0cee9960283045075684b410be8d0f7494b91aa2379f60727319f10ddeb0fe9d6"
+        "wx" : "00851c2bbad08e54ec7a9af99f49f03644d6ec6d59b207fec98de85a7d15b956ef",
+        "wy" : "00cee9960283045075684b410be8d0f7494b91aa2379f60727319f10ddeb0fe9d6"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004851c2bbad08e54ec7a9af99f49f03644d6ec6d59b207fec98de85a7d15b956efcee9960283045075684b410be8d0f7494b91aa2379f60727319f10ddeb0fe9d6",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhRwrutCOVOx6mvmfSfA2RNbsbVmy\nB/7JjehafRW5Vu/O6ZYCgwRQdWhLQQvo0PdJS5GqI3n2BycxnxDd6w/p1g==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004851c2bbad08e54ec7a9af99f49f03644d6ec6d59b207fec98de85a7d15b956efcee9960283045075684b410be8d0f7494b91aa2379f60727319f10ddeb0fe9d6",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEhRwrutCOVOx6mvmfSfA2RNbsbVmy\nB/7JjehafRW5Vu/O6ZYCgwRQdWhLQQvo0PdJS5GqI3n2BycxnxDd6w/p1g==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 330,
+          "tcId" : 434,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022100cccccccc00000000cccccccccccccccc971f2ef152794b9d8fc7d568c9e8eaa7",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04f6417c8a670584e388676949e53da7fc55911ff68318d1bf3061205acb19c48f8f2b743df34ad0f72674acb7505929784779cd9ac916c3669ead43026ab6d43f",
-        "wx" : "0f6417c8a670584e388676949e53da7fc55911ff68318d1bf3061205acb19c48f",
-        "wy" : "08f2b743df34ad0f72674acb7505929784779cd9ac916c3669ead43026ab6d43f"
+        "wx" : "00f6417c8a670584e388676949e53da7fc55911ff68318d1bf3061205acb19c48f",
+        "wy" : "008f2b743df34ad0f72674acb7505929784779cd9ac916c3669ead43026ab6d43f"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f6417c8a670584e388676949e53da7fc55911ff68318d1bf3061205acb19c48f8f2b743df34ad0f72674acb7505929784779cd9ac916c3669ead43026ab6d43f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9kF8imcFhOOIZ2lJ5T2n/FWRH/aD\nGNG/MGEgWssZxI+PK3Q980rQ9yZ0rLdQWSl4R3nNmskWw2aerUMCarbUPw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f6417c8a670584e388676949e53da7fc55911ff68318d1bf3061205acb19c48f8f2b743df34ad0f72674acb7505929784779cd9ac916c3669ead43026ab6d43f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9kF8imcFhOOIZ2lJ5T2n/FWRH/aD\nGNG/MGEgWssZxI+PK3Q980rQ9yZ0rLdQWSl4R3nNmskWw2aerUMCarbUPw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 331,
+          "tcId" : 435,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc4766997802203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aaa",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04501421277be45a5eefec6c639930d636032565af420cf3373f557faa7f8a06438673d6cb6076e1cfcdc7dfe7384c8e5cac08d74501f2ae6e89cad195d0aa1371",
         "wx" : "501421277be45a5eefec6c639930d636032565af420cf3373f557faa7f8a0643",
-        "wy" : "08673d6cb6076e1cfcdc7dfe7384c8e5cac08d74501f2ae6e89cad195d0aa1371"
+        "wy" : "008673d6cb6076e1cfcdc7dfe7384c8e5cac08d74501f2ae6e89cad195d0aa1371"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004501421277be45a5eefec6c639930d636032565af420cf3373f557faa7f8a06438673d6cb6076e1cfcdc7dfe7384c8e5cac08d74501f2ae6e89cad195d0aa1371",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUBQhJ3vkWl7v7GxjmTDWNgMlZa9C\nDPM3P1V/qn+KBkOGc9bLYHbhz83H3+c4TI5crAjXRQHyrm6JytGV0KoTcQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004501421277be45a5eefec6c639930d636032565af420cf3373f557faa7f8a06438673d6cb6076e1cfcdc7dfe7384c8e5cac08d74501f2ae6e89cad195d0aa1371",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEUBQhJ3vkWl7v7GxjmTDWNgMlZa9C\nDPM3P1V/qn+KBkOGc9bLYHbhz83H3+c4TI5crAjXRQHyrm6JytGV0KoTcQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 332,
+          "tcId" : 436,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022049249248db6db6dbb6db6db6db6db6db5a8b230d0b2b51dcd7ebf0c9fef7c185",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "040d935bf9ffc115a527735f729ca8a4ca23ee01a4894adf0e3415ac84e808bb343195a3762fea29ed38912bd9ea6c4fde70c3050893a4375850ce61d82eba33c5",
         "wx" : "0d935bf9ffc115a527735f729ca8a4ca23ee01a4894adf0e3415ac84e808bb34",
         "wy" : "3195a3762fea29ed38912bd9ea6c4fde70c3050893a4375850ce61d82eba33c5"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040d935bf9ffc115a527735f729ca8a4ca23ee01a4894adf0e3415ac84e808bb343195a3762fea29ed38912bd9ea6c4fde70c3050893a4375850ce61d82eba33c5",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDZNb+f/BFaUnc19ynKikyiPuAaSJ\nSt8ONBWshOgIuzQxlaN2L+op7TiRK9nqbE/ecMMFCJOkN1hQzmHYLrozxQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040d935bf9ffc115a527735f729ca8a4ca23ee01a4894adf0e3415ac84e808bb343195a3762fea29ed38912bd9ea6c4fde70c3050893a4375850ce61d82eba33c5",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDZNb+f/BFaUnc19ynKikyiPuAaSJ\nSt8ONBWshOgIuzQxlaN2L+op7TiRK9nqbE/ecMMFCJOkN1hQzmHYLrozxQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 333,
+          "tcId" : 437,
           "comment" : "extreme value for k",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022016a4502e2781e11ac82cbc9d1edd8c981584d13e18411e2f6e0478c34416e3bb",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "045e59f50708646be8a589355014308e60b668fb670196206c41e748e64e4dca215de37fee5c97bcaf7144d5b459982f52eeeafbdf03aacbafef38e213624a01de",
         "wx" : "5e59f50708646be8a589355014308e60b668fb670196206c41e748e64e4dca21",
         "wy" : "5de37fee5c97bcaf7144d5b459982f52eeeafbdf03aacbafef38e213624a01de"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045e59f50708646be8a589355014308e60b668fb670196206c41e748e64e4dca215de37fee5c97bcaf7144d5b459982f52eeeafbdf03aacbafef38e213624a01de",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXln1Bwhka+iliTVQFDCOYLZo+2cB\nliBsQedI5k5NyiFd43/uXJe8r3FE1bRZmC9S7ur73wOqy6/vOOITYkoB3g==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045e59f50708646be8a589355014308e60b668fb670196206c41e748e64e4dca215de37fee5c97bcaf7144d5b459982f52eeeafbdf03aacbafef38e213624a01de",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXln1Bwhka+iliTVQFDCOYLZo+2cB\nliBsQedI5k5NyiFd43/uXJe8r3FE1bRZmC9S7ur73wOqy6/vOOITYkoB3g==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 334,
+          "tcId" : 438,
           "comment" : "extreme value for k and edgecase s",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2960220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04169fb797325843faff2f7a5b5445da9e2fd6226f7ef90ef0bfe924104b02db8e7bbb8de662c7b9b1cf9b22f7a2e582bd46d581d68878efb2b861b131d8a1d667",
         "wx" : "169fb797325843faff2f7a5b5445da9e2fd6226f7ef90ef0bfe924104b02db8e",
         "wy" : "7bbb8de662c7b9b1cf9b22f7a2e582bd46d581d68878efb2b861b131d8a1d667"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004169fb797325843faff2f7a5b5445da9e2fd6226f7ef90ef0bfe924104b02db8e7bbb8de662c7b9b1cf9b22f7a2e582bd46d581d68878efb2b861b131d8a1d667",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFp+3lzJYQ/r/L3pbVEXani/WIm9+\n+Q7wv+kkEEsC2457u43mYse5sc+bIvei5YK9RtWB1oh477K4YbEx2KHWZw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004169fb797325843faff2f7a5b5445da9e2fd6226f7ef90ef0bfe924104b02db8e7bbb8de662c7b9b1cf9b22f7a2e582bd46d581d68878efb2b861b131d8a1d667",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFp+3lzJYQ/r/L3pbVEXani/WIm9+\n+Q7wv+kkEEsC2457u43mYse5sc+bIvei5YK9RtWB1oh477K4YbEx2KHWZw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 335,
+          "tcId" : 439,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022100b6db6db6249249254924924924924924625bd7a09bec4ca81bcdd9f8fd6b63cc",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04271cd89c000143096b62d4e9e4ca885aef2f7023d18affdaf8b7b548981487540a1c6e954e32108435b55fa385b0f76481a609b9149ccb4b02b2ca47fe8e4da5",
         "wx" : "271cd89c000143096b62d4e9e4ca885aef2f7023d18affdaf8b7b54898148754",
         "wy" : "0a1c6e954e32108435b55fa385b0f76481a609b9149ccb4b02b2ca47fe8e4da5"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004271cd89c000143096b62d4e9e4ca885aef2f7023d18affdaf8b7b548981487540a1c6e954e32108435b55fa385b0f76481a609b9149ccb4b02b2ca47fe8e4da5",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJxzYnAABQwlrYtTp5MqIWu8vcCPR\niv/a+Le1SJgUh1QKHG6VTjIQhDW1X6OFsPdkgaYJuRScy0sCsspH/o5NpQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004271cd89c000143096b62d4e9e4ca885aef2f7023d18affdaf8b7b548981487540a1c6e954e32108435b55fa385b0f76481a609b9149ccb4b02b2ca47fe8e4da5",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJxzYnAABQwlrYtTp5MqIWu8vcCPR\niv/a+Le1SJgUh1QKHG6VTjIQhDW1X6OFsPdkgaYJuRScy0sCsspH/o5NpQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 336,
+          "tcId" : 440,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022100cccccccc00000000cccccccccccccccc971f2ef152794b9d8fc7d568c9e8eaa7",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "043d0bc7ed8f09d2cb7ddb46ebc1ed799ab1563a9ab84bf524587a220afe499c12e22dc3b3c103824a4f378d96adb0a408abf19ce7d68aa6244f78cb216fa3f8df",
         "wx" : "3d0bc7ed8f09d2cb7ddb46ebc1ed799ab1563a9ab84bf524587a220afe499c12",
-        "wy" : "0e22dc3b3c103824a4f378d96adb0a408abf19ce7d68aa6244f78cb216fa3f8df"
+        "wy" : "00e22dc3b3c103824a4f378d96adb0a408abf19ce7d68aa6244f78cb216fa3f8df"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043d0bc7ed8f09d2cb7ddb46ebc1ed799ab1563a9ab84bf524587a220afe499c12e22dc3b3c103824a4f378d96adb0a408abf19ce7d68aa6244f78cb216fa3f8df",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPQvH7Y8J0st920brwe15mrFWOpq4\nS/UkWHoiCv5JnBLiLcOzwQOCSk83jZatsKQIq/Gc59aKpiRPeMshb6P43w==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043d0bc7ed8f09d2cb7ddb46ebc1ed799ab1563a9ab84bf524587a220afe499c12e22dc3b3c103824a4f378d96adb0a408abf19ce7d68aa6244f78cb216fa3f8df",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPQvH7Y8J0st920brwe15mrFWOpq4\nS/UkWHoiCv5JnBLiLcOzwQOCSk83jZatsKQIq/Gc59aKpiRPeMshb6P43w==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 337,
+          "tcId" : 441,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c29602203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aaa",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04a6c885ade1a4c566f9bb010d066974abb281797fa701288c721bcbd23663a9b72e424b690957168d193a6096fc77a2b004a9c7d467e007e1f2058458f98af316",
-        "wx" : "0a6c885ade1a4c566f9bb010d066974abb281797fa701288c721bcbd23663a9b7",
+        "wx" : "00a6c885ade1a4c566f9bb010d066974abb281797fa701288c721bcbd23663a9b7",
         "wy" : "2e424b690957168d193a6096fc77a2b004a9c7d467e007e1f2058458f98af316"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a6c885ade1a4c566f9bb010d066974abb281797fa701288c721bcbd23663a9b72e424b690957168d193a6096fc77a2b004a9c7d467e007e1f2058458f98af316",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpsiFreGkxWb5uwENBml0q7KBeX+n\nASiMchvL0jZjqbcuQktpCVcWjRk6YJb8d6KwBKnH1GfgB+HyBYRY+YrzFg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a6c885ade1a4c566f9bb010d066974abb281797fa701288c721bcbd23663a9b72e424b690957168d193a6096fc77a2b004a9c7d467e007e1f2058458f98af316",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEpsiFreGkxWb5uwENBml0q7KBeX+n\nASiMchvL0jZjqbcuQktpCVcWjRk6YJb8d6KwBKnH1GfgB+HyBYRY+YrzFg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 338,
+          "tcId" : 442,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022049249248db6db6dbb6db6db6db6db6db5a8b230d0b2b51dcd7ebf0c9fef7c185",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "048d3c2c2c3b765ba8289e6ac3812572a25bf75df62d87ab7330c3bdbad9ebfa5c4c6845442d66935b238578d43aec54f7caa1621d1af241d4632e0b780c423f5d",
-        "wx" : "08d3c2c2c3b765ba8289e6ac3812572a25bf75df62d87ab7330c3bdbad9ebfa5c",
+        "wx" : "008d3c2c2c3b765ba8289e6ac3812572a25bf75df62d87ab7330c3bdbad9ebfa5c",
         "wy" : "4c6845442d66935b238578d43aec54f7caa1621d1af241d4632e0b780c423f5d"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048d3c2c2c3b765ba8289e6ac3812572a25bf75df62d87ab7330c3bdbad9ebfa5c4c6845442d66935b238578d43aec54f7caa1621d1af241d4632e0b780c423f5d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjTwsLDt2W6gonmrDgSVyolv3XfYt\nh6tzMMO9utnr+lxMaEVELWaTWyOFeNQ67FT3yqFiHRryQdRjLgt4DEI/XQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048d3c2c2c3b765ba8289e6ac3812572a25bf75df62d87ab7330c3bdbad9ebfa5c4c6845442d66935b238578d43aec54f7caa1621d1af241d4632e0b780c423f5d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjTwsLDt2W6gonmrDgSVyolv3XfYt\nh6tzMMO9utnr+lxMaEVELWaTWyOFeNQ67FT3yqFiHRryQdRjLgt4DEI/XQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 339,
+          "tcId" : 443,
           "comment" : "extreme value for k",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022016a4502e2781e11ac82cbc9d1edd8c981584d13e18411e2f6e0478c34416e3bb",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
         "wx" : "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
         "wy" : "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaxfR8uEsQkf4vOblY6RA8ncDfYEt\n6zOg9KE5RdiYwpZP40Li/hp/m47n60p8D54WK84zV2sxXs7LtkBoN79R9Q==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaxfR8uEsQkf4vOblY6RA8ncDfYEt\n6zOg9KE5RdiYwpZP40Li/hp/m47n60p8D54WK84zV2sxXs7LtkBoN79R9Q==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 340,
-          "comment" : "testing point duplication",
+          "tcId" : 444,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "3045022100bb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca6050230220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 341,
-          "comment" : "testing point duplication",
+          "tcId" : 445,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "3044022044a5ad0ad0636d9f12bc9e0a6bdd5e1cbcb012ea7bf091fcec15b0c43202d52e0220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a",
         "wx" : "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
-        "wy" : "0b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a"
+        "wy" : "00b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaxfR8uEsQkf4vOblY6RA8ncDfYEt\n6zOg9KE5RdiYwpawHL0cAeWAZXEYFLWD8GHp1DHMqZTOoTE0Sb+XyECuCg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaxfR8uEsQkf4vOblY6RA8ncDfYEt\n6zOg9KE5RdiYwpawHL0cAeWAZXEYFLWD8GHp1DHMqZTOoTE0Sb+XyECuCg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 342,
-          "comment" : "testing point duplication",
+          "tcId" : 446,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "3045022100bb5a52f42f9c9261ed4361f59422a1e30036e7c32b270c8807a419feca6050230220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 343,
-          "comment" : "testing point duplication",
+          "tcId" : 447,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "3044022044a5ad0ad0636d9f12bc9e0a6bdd5e1cbcb012ea7bf091fcec15b0c43202d52e0220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "0404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
-        "wx" : "4aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad5",
-        "wy" : "087d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d"
-      },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKrsc2NXJvIT+4qeZNo7hjLkFJWp\nRNAEW1IuunJA+tWH2TFXmKqjpboBd1eHztBeqve04J/IHW0apUboNl1SXQ==\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-256",
-      "type" : "ECDSAVer",
-      "tests" : [
-        {
-          "tcId" : 344,
-          "comment" : "pseudorandom signature",
-          "msg" : "",
-          "sig" : "3045022100b292a619339f6e567a305c951c0dcbcc42d16e47f219f9e98e76e09d8770b34a02200177e60492c5a8242f76f07bfe3661bde59ec2a17ce5bd2dab2abebdf89a62e2",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 345,
-          "comment" : "pseudorandom signature",
-          "msg" : "4d7367",
-          "sig" : "30450220530bd6b0c9af2d69ba897f6b5fb59695cfbf33afe66dbadcf5b8d2a2a6538e23022100d85e489cb7a161fd55ededcedbf4cc0c0987e3e3f0f242cae934c72caa3f43e9",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 346,
-          "comment" : "pseudorandom signature",
-          "msg" : "313233343030",
-          "sig" : "3046022100a8ea150cb80125d7381c4c1f1da8e9de2711f9917060406a73d7904519e51388022100f3ab9fa68bd47973a73b2d40480c2ba50c22c9d76ec217257288293285449b86",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 347,
-          "comment" : "pseudorandom signature",
-          "msg" : "0000000000000000000000000000000000000000",
-          "sig" : "3045022100986e65933ef2ed4ee5aada139f52b70539aaf63f00a91f29c69178490d57fb7102203dafedfb8da6189d372308cbf1489bbbdabf0c0217d1c0ff0f701aaa7a694b9c",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp256r1",
-        "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "044f337ccfd67726a805e4f1600ae2849df3807eca117380239fbd816900000000ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685",
         "wx" : "4f337ccfd67726a805e4f1600ae2849df3807eca117380239fbd816900000000",
-        "wy" : "0ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685"
+        "wy" : "00ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044f337ccfd67726a805e4f1600ae2849df3807eca117380239fbd816900000000ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETzN8z9Z3JqgF5PFgCuKEnfOAfsoR\nc4Ajn72BaQAAAADtneoSTMjDlkFkEemIww9CfrUEr0OjFGzV336mBmbWhQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044f337ccfd67726a805e4f1600ae2849df3807eca117380239fbd816900000000ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETzN8z9Z3JqgF5PFgCuKEnfOAfsoR\nc4Ajn72BaQAAAADtneoSTMjDlkFkEemIww9CfrUEr0OjFGzV336mBmbWhQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 348,
+          "tcId" : 448,
           "comment" : "x-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3046022100d434e262a49eab7781e353a3565e482550dd0fd5defa013c7f29745eff3569f10221009b0c0a93f267fb6052fd8077be769c2b98953195d7bc10de844218305c6ba17a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 349,
+          "tcId" : 449,
           "comment" : "x-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304402200fe774355c04d060f76d79fd7a772e421463489221bf0a33add0be9b1979110b0220500dcba1c69a8fbd43fa4f57f743ce124ca8b91a1f325f3fac6181175df55737",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 350,
+          "tcId" : 450,
           "comment" : "x-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3045022100bb40bf217bed3fb3950c7d39f03d36dc8e3b2cd79693f125bfd06595ee1135e30220541bf3532351ebb032710bdb6a1bf1bfc89a1e291ac692b3fa4780745bb55677",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f49726500493584fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000",
         "wx" : "3cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f497265004935",
-        "wy" : "084fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000"
+        "wy" : "0084fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f49726500493584fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPPA9YU2JOc/UmaB4c/rCgWGPBrj/\nh+gBXD9JcmUASTWE+hdNeRxyvyzjiAqJYN0qfHoTOKgvhanlnNvegAAAAA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f49726500493584fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPPA9YU2JOc/UmaB4c/rCgWGPBrj/\nh+gBXD9JcmUASTWE+hdNeRxyvyzjiAqJYN0qfHoTOKgvhanlnNvegAAAAA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 351,
+          "tcId" : 451,
           "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30440220664eb7ee6db84a34df3c86ea31389a5405badd5ca99231ff556d3e75a233e73a022059f3c752e52eca46137642490a51560ce0badc678754b8f72e51a2901426a1bd",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 352,
+          "tcId" : 452,
           "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304502204cd0429bbabd2827009d6fcd843d4ce39c3e42e2d1631fd001985a79d1fd8b430221009638bf12dd682f60be7ef1d0e0d98f08b7bca77a1a2b869ae466189d2acdabe3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 353,
+          "tcId" : 453,
           "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3046022100e56c6ea2d1b017091c44d8b6cb62b9f460e3ce9aed5e5fd41e8added97c56c04022100a308ec31f281e955be20b457e463440b4fcf2b80258078207fc1378180f89b55",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f4972650049357b05e8b186e38d41d31c77f5769f22d58385ecc857d07a561a6324217fffffff",
         "wx" : "3cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f497265004935",
         "wy" : "7b05e8b186e38d41d31c77f5769f22d58385ecc857d07a561a6324217fffffff"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f4972650049357b05e8b186e38d41d31c77f5769f22d58385ecc857d07a561a6324217fffffff",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPPA9YU2JOc/UmaB4c/rCgWGPBrj/\nh+gBXD9JcmUASTV7BeixhuONQdMcd/V2nyLVg4XsyFfQelYaYyQhf////w==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f4972650049357b05e8b186e38d41d31c77f5769f22d58385ecc857d07a561a6324217fffffff",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPPA9YU2JOc/UmaB4c/rCgWGPBrj/\nh+gBXD9JcmUASTV7BeixhuONQdMcd/V2nyLVg4XsyFfQelYaYyQhf////w==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 354,
+          "tcId" : 454,
           "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304402201158a08d291500b4cabed3346d891eee57c176356a2624fb011f8fbbf34668300220228a8c486a736006e082325b85290c5bc91f378b75d487dda46798c18f285519",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 355,
+          "tcId" : 455,
           "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3045022100b1db9289649f59410ea36b0c0fc8d6aa2687b29176939dd23e0dde56d309fa9d02203e1535e4280559015b0dbd987366dcf43a6d1af5c23c7d584e1c3f48a1251336",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 356,
+          "tcId" : 456,
           "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3046022100b7b16e762286cb96446aa8d4e6e7578b0a341a79f2dd1a220ac6f0ca4e24ed86022100ddc60a700a139b04661c547d07bbb0721780146df799ccf55e55234ecb8f12bc",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "042829c31faa2e400e344ed94bca3fcd0545956ebcfe8ad0f6dfa5ff8effffffffa01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e",
         "wx" : "2829c31faa2e400e344ed94bca3fcd0545956ebcfe8ad0f6dfa5ff8effffffff",
-        "wy" : "0a01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e"
+        "wy" : "00a01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042829c31faa2e400e344ed94bca3fcd0545956ebcfe8ad0f6dfa5ff8effffffffa01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKCnDH6ouQA40TtlLyj/NBUWVbrz+\nitD236X/jv////+gGq+vAA5SWFhVr6dnat4oQRMJkFLfV+frO9N+vrkiLg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042829c31faa2e400e344ed94bca3fcd0545956ebcfe8ad0f6dfa5ff8effffffffa01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKCnDH6ouQA40TtlLyj/NBUWVbrz+\nitD236X/jv////+gGq+vAA5SWFhVr6dnat4oQRMJkFLfV+frO9N+vrkiLg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 357,
+          "tcId" : 457,
           "comment" : "x-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3045022100d82a7c2717261187c8e00d8df963ff35d796edad36bc6e6bd1c91c670d9105b402203dcabddaf8fcaa61f4603e7cbac0f3c0351ecd5988efb23f680d07debd139929",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 358,
+          "tcId" : 458,
           "comment" : "x-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304402205eb9c8845de68eb13d5befe719f462d77787802baff30ce96a5cba063254af7802202c026ae9be2e2a5e7ca0ff9bbd92fb6e44972186228ee9a62b87ddbe2ef66fb5",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 359,
+          "tcId" : 459,
           "comment" : "x-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304602210096843dd03c22abd2f3b782b170239f90f277921becc117d0404a8e4e36230c28022100f2be378f526f74a543f67165976de9ed9a31214eb4d7e6db19e1ede123dd991d",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f55a8abcba2dda8474311ee54149b973cae0c0fb89557ad0bf78e6529a1663bd73",
-        "wx" : "0fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f5",
+        "wx" : "00fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f5",
         "wy" : "5a8abcba2dda8474311ee54149b973cae0c0fb89557ad0bf78e6529a1663bd73"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f55a8abcba2dda8474311ee54149b973cae0c0fb89557ad0bf78e6529a1663bd73",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE////+UgIHmoEWN2PnnOPJmX/kFmt\naqwHCDGMTKmnpPVairy6LdqEdDEe5UFJuXPK4MD7iVV60L945lKaFmO9cw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f55a8abcba2dda8474311ee54149b973cae0c0fb89557ad0bf78e6529a1663bd73",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE////+UgIHmoEWN2PnnOPJmX/kFmt\naqwHCDGMTKmnpPVairy6LdqEdDEe5UFJuXPK4MD7iVV60L945lKaFmO9cw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 360,
+          "tcId" : 460,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30440220766456dce1857c906f9996af729339464d27e9d98edc2d0e3b760297067421f60220402385ecadae0d8081dccaf5d19037ec4e55376eced699e93646bfbbf19d0b41",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 361,
+          "tcId" : 461,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3046022100c605c4b2edeab20419e6518a11b2dbc2b97ed8b07cced0b19c34f777de7b9fd9022100edf0f612c5f46e03c719647bc8af1b29b2cde2eda700fb1cff5e159d47326dba",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 362,
+          "tcId" : 462,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3046022100d48b68e6cabfe03cf6141c9ac54141f210e64485d9929ad7b732bfe3b7eb8a84022100feedae50c61bd00e19dc26f9b7e2265e4508c389109ad2f208f0772315b6c941",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400000003fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e1099872070e8e87c555fa13659cca5d7fadcfcb0023ea889548ca48af2ba7e71",
-        "wx" : "3fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e",
+        "wx" : "03fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e",
         "wy" : "1099872070e8e87c555fa13659cca5d7fadcfcb0023ea889548ca48af2ba7e71"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000003fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e1099872070e8e87c555fa13659cca5d7fadcfcb0023ea889548ca48af2ba7e71",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAAAAA/oV+WOUnV8DpvXH+G+eABXu\nsjrrv/EXOTe6dI4QmYcgcOjofFVfoTZZzKXX+tz8sAI+qIlUjKSK8rp+cQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000003fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e1099872070e8e87c555fa13659cca5d7fadcfcb0023ea889548ca48af2ba7e71",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAAAAA/oV+WOUnV8DpvXH+G+eABXu\nsjrrv/EXOTe6dI4QmYcgcOjofFVfoTZZzKXX+tz8sAI+qIlUjKSK8rp+cQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 363,
+          "tcId" : 463,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3046022100b7c81457d4aeb6aa65957098569f0479710ad7f6595d5874c35a93d12a5dd4c7022100b7961a0b652878c2d568069a432ca18a1a9199f2ca574dad4b9e3a05c0a1cdb3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 364,
+          "tcId" : 464,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304402206b01332ddb6edfa9a30a1321d5858e1ee3cf97e263e669f8de5e9652e76ff3f702205939545fced457309a6a04ace2bd0f70139c8f7d86b02cb1cc58f9e69e96cd5a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 365,
+          "tcId" : 465,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3046022100efdb884720eaeadc349f9fc356b6c0344101cd2fd8436b7d0e6a4fb93f106361022100f24bee6ad5dc05f7613975473aadf3aacba9e77de7d69b6ce48cb60d8113385d",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015000000001352bb4a0fa2ea4cceb9ab63dd684ade5a1127bcf300a698a7193bc2",
-        "wx" : "0bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015",
+        "wx" : "00bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015",
         "wy" : "1352bb4a0fa2ea4cceb9ab63dd684ade5a1127bcf300a698a7193bc2"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015000000001352bb4a0fa2ea4cceb9ab63dd684ade5a1127bcf300a698a7193bc2",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvLspFMefBF6qbsu8YSgWs75dLWeW\ncH2BJen4UcGK8BUAAAAAE1K7Sg+i6kzOuatj3WhK3loRJ7zzAKaYpxk7wg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015000000001352bb4a0fa2ea4cceb9ab63dd684ade5a1127bcf300a698a7193bc2",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvLspFMefBF6qbsu8YSgWs75dLWeW\ncH2BJen4UcGK8BUAAAAAE1K7Sg+i6kzOuatj3WhK3loRJ7zzAKaYpxk7wg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 366,
+          "tcId" : 466,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3044022031230428405560dcb88fb5a646836aea9b23a23dd973dcbe8014c87b8b20eb0702200f9344d6e812ce166646747694a41b0aaf97374e19f3c5fb8bd7ae3d9bd0beff",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 367,
+          "tcId" : 467,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3046022100caa797da65b320ab0d5c470cda0b36b294359c7db9841d679174db34c4855743022100cf543a62f23e212745391aaf7505f345123d2685ee3b941d3de6d9b36242e5a0",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 368,
+          "tcId" : 468,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304502207e5f0ab5d900d3d3d7867657e5d6d36519bc54084536e7d21c336ed8001859450221009450c07f201faec94b82dfb322e5ac676688294aad35aa72e727ff0b19b646aa",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d",
-        "wx" : "0bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015",
-        "wy" : "0fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d"
+        "wx" : "00bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015",
+        "wy" : "00fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvLspFMefBF6qbsu8YSgWs75dLWeW\ncH2BJen4UcGK8BX////+7K1EtvBdFbMxRlScIpe1IqXu2EMM/1lnWObEPQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvLspFMefBF6qbsu8YSgWs75dLWeW\ncH2BJen4UcGK8BX////+7K1EtvBdFbMxRlScIpe1IqXu2EMM/1lnWObEPQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-256",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 369,
+          "tcId" : 469,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3046022100d7d70c581ae9e3f66dc6a480bf037ae23f8a1e4a2136fe4b03aa69f0ca25b35602210089c460f8a5a5c2bbba962c8a3ee833a413e85658e62a59e2af41d9127cc47224",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 370,
+          "tcId" : 470,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30440220341c1b9ff3c83dd5e0dfa0bf68bcdf4bb7aa20c625975e5eeee34bb396266b34022072b69f061b750fd5121b22b11366fad549c634e77765a017902a67099e0a4469",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 371,
+          "tcId" : 471,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3045022070bebe684cdcb5ca72a42f0d873879359bd1781a591809947628d313a3814f67022100aec03aca8f5587a4d535fa31027bbe9cc0e464b1c3577f4c2dcde6b2094798a9",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     }

--- a/Tests/Test Vectors/ecdsa_secp256r1_sha512_test.json
+++ b/Tests/Test Vectors/ecdsa_secp256r1_sha512_test.json
@@ -1,4948 +1,7204 @@
 {
   "algorithm" : "ECDSA",
-  "generatorVersion" : "0.4.12",
+  "schema" : "ecdsa_verify_schema.json",
+  "generatorVersion" : "0.9rc5",
+  "numberOfTests" : 541,
+  "header" : [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of ASN encoded ECDSA signatures."
+  ],
   "notes" : {
-    "BER" : "This is a signature with correct values for (r, s) but using some alternative BER encoding instead of DER encoding. Implementations should not accept such signatures to limit signature malleability.",
-    "EdgeCase" : "Edge case values such as r=1 and s=0 can lead to forgeries if the ECDSA implementation does not check boundaries and computes s^(-1)==0.",
-    "MissingZero" : "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
-    "PointDuplication" : "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission."
+    "ArithmeticError" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "cves" : [
+        "CVE-2017-18146"
+      ]
+    },
+    "BerEncodedSignature" : {
+      "bugType" : "BER_ENCODING",
+      "description" : "ECDSA signatures are usually DER encoded. This signature contains valid values for r and s, but it uses alternative BER encoding.",
+      "effect" : "Accepting alternative BER encodings may be benign in some cases, or be an issue if protocol requires signature malleability.",
+      "cves" : [
+        "CVE-2020-14966",
+        "CVE-2020-13822",
+        "CVE-2019-14859",
+        "CVE-2016-1000342"
+      ]
+    },
+    "EdgeCasePublicKey" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidEncoding" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "ECDSA signatures are encoded using ASN.1. This test vector contains an incorrectly encoded signature. The test vector itself was generated from a valid signature by modifying its encoding.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature" : {
+      "bugType" : "AUTH_BYPASS",
+      "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "cves" : [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "InvalidTypesInSignature" : {
+      "bugType" : "AUTH_BYPASS",
+      "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "cves" : [
+        "CVE-2022-21449"
+      ]
+    },
+    "MissingZero" : {
+      "bugType" : "LEGACY",
+      "description" : "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
+      "effect" : "While signatures are more malleable if such signatures are accepted, this typically leads to no vulnerability, since a badly encoded signature can be reencoded correctly."
+    },
+    "ModifiedInteger" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModifiedSignature" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an invalid signature that was generated from a valid signature by modifying it.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect" : "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves" : [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves" : [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SmallRandS" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect" : "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves" : [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "Untruncatedhash" : {
+      "bugType" : "MISSING_STEP",
+      "description" : "If the size of the digest is longer than the size of the underlying order of the multiplicative subgroup then the hash digest must be truncated during signature generation and verification. This test vector contains a signature where this step has been omitted."
+    },
+    "ValidSignature" : {
+      "bugType" : "BASIC",
+      "description" : "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
   },
-  "numberOfTests" : 440,
-  "header" : [],
   "testGroups" : [
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
-        "wx" : "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838",
-        "wy" : "0c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
+        "uncompressed" : "0404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+        "wx" : "04aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad5",
+        "wy" : "0087d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKSexBRK64+3c/kZ4KBKLrSkDJpkZ\n9whgacjE32xzKDjHeHlk6qwA5ZIfsUmKYPRgZ2az2WhQAVWNGpdOc0FRPg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKrsc2NXJvIT+4qeZNo7hjLkFJWp\nRNAEW1IuunJA+tWH2TFXmKqjpboBd1eHztBeqve04J/IHW0apUboNl1SXQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
           "tcId" : 1,
-          "comment" : "signature malleability",
-          "msg" : "313233343030",
-          "sig" : "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002205f85a63a5be977ad714cea16b10035f07cadf7513ae8cca86f35b7692aafd69f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
+          "msg" : "",
+          "sig" : "30440220093f3825c0cf820cced816a3a67446c85606a6d529e43857643fccc11e1f705f0220769782888c63058630f97a5891c8700e82979e4f233586bfc5042fa73cb70a4e",
+          "result" : "valid"
         },
         {
           "tcId" : 2,
-          "comment" : "Legacy:ASN encoding of s misses leading 0",
-          "msg" : "313233343030",
-          "sig" : "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00220a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "acceptable",
+          "comment" : "pseudorandom signature",
           "flags" : [
-            "MissingZero"
-          ]
+            "ValidSignature"
+          ],
+          "msg" : "4d7367",
+          "sig" : "3046022100e8564e3e515a09f9f35258442b99e162d27e10975fcb7963d3c26319dc093f84022100c3af01ed0fd0148749ca323364846c862fc6f4beb682b7ead3b2d89b9da8bad4",
+          "result" : "valid"
         },
         {
           "tcId" : 3,
-          "comment" : "valid",
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "valid",
-          "flags" : []
+          "sig" : "304502201412254f8c1dd2742a00ddee5192e7baa288741026871f3057ad9f983b5ab114022100bcdf878fa156f37040922698ad6fb6928601ddc26c40448ea660e67c25eda090",
+          "result" : "valid"
         },
         {
           "tcId" : 4,
-          "comment" : "long form encoding of length",
-          "msg" : "313233343030",
-          "sig" : "30814502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
+          "comment" : "pseudorandom signature",
           "flags" : [
-            "BER"
-          ]
-        },
+            "ValidSignature"
+          ],
+          "msg" : "0000000000000000000000000000000000000000",
+          "sig" : "30450221009e0676048381839bb0a4703a0ae38facfe1e2c61bd25950c896aa975cd6ec86902206ea0cedf96f11fff0e746941183492f4d17272c92449afd20e34041a6894ee82",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+        "wx" : "2927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838",
+        "wy" : "00c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042927b10512bae3eddcfe467828128bad2903269919f7086069c8c4df6c732838c7787964eaac00e5921fb1498a60f4606766b3d9685001558d1a974e7341513e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKSexBRK64+3c/kZ4KBKLrSkDJpkZ\n9whgacjE32xzKDjHeHlk6qwA5ZIfsUmKYPRgZ2az2WhQAVWNGpdOc0FRPg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
         {
           "tcId" : 5,
-          "comment" : "long form encoding of length",
-          "msg" : "313233343030",
-          "sig" : "30460281202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
+          "comment" : "signature malleability",
           "flags" : [
-            "BER"
-          ]
+            "ValidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002205f85a63a5be977ad714cea16b10035f07cadf7513ae8cca86f35b7692aafd69f",
+          "result" : "valid"
         },
         {
           "tcId" : 6,
-          "comment" : "long form encoding of length",
-          "msg" : "313233343030",
-          "sig" : "304602202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002812100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
+          "comment" : "Legacy: ASN encoding of s misses leading 0",
           "flags" : [
-            "BER"
-          ]
+            "MissingZero"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00220a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 7,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "3082004502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
+          "comment" : "valid",
           "flags" : [
-            "BER"
-          ]
+            "ValidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "valid"
         },
         {
           "tcId" : 8,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "3047028200202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
+          "comment" : "length of sequence [r, s] uses long form encoding",
           "flags" : [
-            "BER"
-          ]
+            "BerEncodedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30814502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 9,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00282002100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
+          "comment" : "length of sequence [r, s] contains a leading 0",
           "flags" : [
-            "BER"
-          ]
+            "BerEncodedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3082004502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 10,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] uses 70 instead of 69",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
           "sig" : "304602202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
           "tcId" : 11,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] uses 68 instead of 69",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
           "sig" : "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
           "tcId" : 12,
-          "comment" : "wrong length",
+          "comment" : "uint32 overflow in length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502212478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3085010000004502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 13,
-          "comment" : "wrong length",
+          "comment" : "uint64 overflow in length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3045021f2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308901000000000000004502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 14,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022200a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30847fffffff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 15,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30848000000002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 16,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3085010000004502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3084ffffffff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 17,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**40 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304a028501000000202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3085ffffffffff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 18,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304a02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00285010000002100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3088ffffffffffffffff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 19,
-          "comment" : "uint64 overflow in length",
+          "comment" : "incorrect length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308901000000000000004502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30ff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 20,
-          "comment" : "uint64 overflow in length",
+          "comment" : "replaced sequence [r, s] by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304e02890100000000000000202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 21,
-          "comment" : "uint64 overflow in length",
+          "comment" : "removing sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304e02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0028901000000000000002100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "",
+          "result" : "invalid"
         },
         {
           "tcId" : 22,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "lonely sequence tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30847fffffff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30",
+          "result" : "invalid"
         },
         {
           "tcId" : 23,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "appending 0's to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304902847fffffff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result" : "invalid"
         },
         {
           "tcId" : 24,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "prepending 0's to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002847fffffff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3047000002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 25,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "appending unused 0's to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3084ffffffff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result" : "invalid"
         },
         {
           "tcId" : 26,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "appending null value to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30490284ffffffff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20500",
+          "result" : "invalid"
         },
         {
           "tcId" : 27,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "prepending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00284ffffffff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304a498177304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 28,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "prepending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3085ffffffffff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30492500304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 29,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "appending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304a0285ffffffffff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3047304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20004deadbeef",
+          "result" : "invalid"
         },
         {
           "tcId" : 30,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304a02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00285ffffffffff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304daa00bb00cd00304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 31,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3088ffffffffffffffff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304d2228aa00bb00cd0002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 32,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304d0288ffffffffffffffff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304d02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02229aa00bb00cd00022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 33,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "truncated length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304d02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00288ffffffffffffffff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3081",
+          "result" : "invalid"
         },
         {
           "tcId" : 34,
-          "comment" : "incorrect length",
+          "comment" : "including undefined tags to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30ff02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304baa02aabb304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 35,
-          "comment" : "incorrect length",
+          "comment" : "using composition with indefinite length for sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502ff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result" : "invalid"
         },
         {
           "tcId" : 36,
-          "comment" : "incorrect length",
+          "comment" : "using composition with wrong tag for sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002ff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080314502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result" : "invalid"
         },
         {
           "tcId" : 37,
-          "comment" : "indefinite length without termination",
+          "comment" : "Replacing sequence [r, s] with NULL",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 38,
-          "comment" : "indefinite length without termination",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502802478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "2e4502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 39,
-          "comment" : "indefinite length without termination",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0028000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "2f4502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 40,
-          "comment" : "removing sequence",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "314502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 41,
-          "comment" : "lonely sequence tag",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "324502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 42,
-          "comment" : "appending 0's to sequence",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "ff4502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 43,
-          "comment" : "prepending 0's to sequence",
+          "comment" : "dropping value of sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3047000002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 44,
-          "comment" : "appending unused 0's to sequence",
+          "comment" : "using composition for sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30493001023044202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 45,
-          "comment" : "appending null value to sequence",
+          "comment" : "truncated sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34e",
+          "result" : "invalid"
         },
         {
           "tcId" : 46,
-          "comment" : "including garbage",
+          "comment" : "truncated sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304a498177304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3044202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 47,
-          "comment" : "including garbage",
+          "comment" : "sequence [r, s] of size 4166 to check for overflows",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30492500304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3082104602202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 48,
-          "comment" : "including garbage",
+          "comment" : "indefinite length",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3047304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20004deadbeef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result" : "invalid"
         },
         {
           "tcId" : 49,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with truncated delimiter",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304a222549817702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb200",
+          "result" : "invalid"
         },
         {
           "tcId" : 50,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with additional element",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30492224250002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb205000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 51,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with truncated element",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304d222202202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00004deadbeef022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2060811220000",
+          "result" : "invalid"
         },
         {
           "tcId" : 52,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with garbage",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304a02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02226498177022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000fe02beef",
+          "result" : "invalid"
         },
         {
           "tcId" : 53,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with nonempty EOC",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c022252500022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20002beef",
+          "result" : "invalid"
         },
         {
           "tcId" : 54,
-          "comment" : "including garbage",
+          "comment" : "prepend empty sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304d02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02223022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20004deadbeef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3047300002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 55,
-          "comment" : "including undefined tags",
+          "comment" : "append empty sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304daa00bb00cd00304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb23000",
+          "result" : "invalid"
         },
         {
           "tcId" : 56,
-          "comment" : "including undefined tags",
+          "comment" : "append zero",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304baa02aabb304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304802202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 57,
-          "comment" : "including undefined tags",
+          "comment" : "append garbage with high tag number",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304d2228aa00bb00cd0002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304802202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2bf7f00",
+          "result" : "invalid"
         },
         {
           "tcId" : 58,
-          "comment" : "including undefined tags",
+          "comment" : "append null with explicit tag",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304b2226aa02aabb02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2a0020500",
+          "result" : "invalid"
         },
         {
           "tcId" : 59,
-          "comment" : "including undefined tags",
+          "comment" : "append null with implicit tag",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304d02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02229aa00bb00cd00022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2a000",
+          "result" : "invalid"
         },
         {
           "tcId" : 60,
-          "comment" : "including undefined tags",
+          "comment" : "sequence of sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304b02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02227aa02aabb022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3047304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 61,
-          "comment" : "truncated length of sequence",
+          "comment" : "truncated sequence: removed last 1 elements",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3081",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "302202202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0",
+          "result" : "invalid"
         },
         {
           "tcId" : 62,
-          "comment" : "using composition with indefinite length",
+          "comment" : "repeating element in sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306802202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 63,
-          "comment" : "using composition with indefinite length",
+          "comment" : "flipped bit 0 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3049228002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00000022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30432478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c1022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 64,
-          "comment" : "using composition with indefinite length",
+          "comment" : "flipped bit 32 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02280022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30432478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42a98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 65,
-          "comment" : "using composition with wrong tag",
+          "comment" : "flipped bit 48 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080314502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30432478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c67f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 66,
-          "comment" : "using composition with wrong tag",
+          "comment" : "flipped bit 64 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3049228003202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00000022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30432478f1d049f6d857ac900a7af1772226a4c59b345fbb90603c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 67,
-          "comment" : "using composition with wrong tag",
+          "comment" : "length of r uses long form encoding",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02280032100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30460281202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 68,
-          "comment" : "Replacing sequence with NULL",
+          "comment" : "length of r contains a leading 0",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "0500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3047028200202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 69,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r uses 33 instead of 32",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "2e4502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502212478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 70,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r uses 31 instead of 32",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "2f4502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3045021f2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 71,
-          "comment" : "changing tag value of sequence",
+          "comment" : "uint32 overflow in length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "314502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304a028501000000202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 72,
-          "comment" : "changing tag value of sequence",
+          "comment" : "uint64 overflow in length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "324502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304e02890100000000000000202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 73,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "ff4502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902847fffffff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 74,
-          "comment" : "dropping value of sequence",
+          "comment" : "length of r = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30490284800000002478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 75,
-          "comment" : "using composition for sequence",
+          "comment" : "length of r = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30493001023044202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30490284ffffffff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 76,
-          "comment" : "truncate sequence",
+          "comment" : "length of r = 2**40 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34e",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304a0285ffffffffff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 77,
-          "comment" : "truncate sequence",
+          "comment" : "length of r = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3044202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304d0288ffffffffffffffff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 78,
-          "comment" : "indefinite length",
-          "msg" : "313233343030",
-          "sig" : "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
-          "result" : "invalid",
+          "comment" : "incorrect length of r",
           "flags" : [
-            "BER"
-          ]
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502ff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 79,
-          "comment" : "indefinite length with truncated delimiter",
+          "comment" : "replaced r by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb200",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502802478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 80,
-          "comment" : "indefinite length with additional element",
+          "comment" : "removing r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb205000000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3023022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 81,
-          "comment" : "indefinite length with truncated element",
+          "comment" : "lonely integer tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2060811220000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "302402022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 82,
-          "comment" : "indefinite length with garbage",
+          "comment" : "lonely integer tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000fe02beef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "302302202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002",
+          "result" : "invalid"
         },
         {
           "tcId" : 83,
-          "comment" : "indefinite length with nonempty EOC",
+          "comment" : "appending 0's to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20002beef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702222478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00000022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 84,
-          "comment" : "prepend empty sequence",
+          "comment" : "prepending 0's to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3047300002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3047022200002478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 85,
-          "comment" : "append empty sequence",
+          "comment" : "appending unused 0's to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb23000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00000022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 86,
-          "comment" : "sequence of sequence",
+          "comment" : "appending null value to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3047304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702222478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00500022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 87,
-          "comment" : "truncated sequence",
+          "comment" : "prepending garbage to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "302202202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304a222549817702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 88,
-          "comment" : "repeat element in sequence",
+          "comment" : "prepending garbage to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306802202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30492224250002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 89,
-          "comment" : "removing integer",
+          "comment" : "appending garbage to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3023022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304d222202202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00004deadbeef022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 90,
-          "comment" : "lonely integer tag",
+          "comment" : "truncated length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "302402022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30250281022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 91,
-          "comment" : "lonely integer tag",
+          "comment" : "including undefined tags to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "302302202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304b2226aa02aabb02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 92,
-          "comment" : "appending 0's to integer",
+          "comment" : "using composition with indefinite length for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702222478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00000022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3049228002202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00000022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 93,
-          "comment" : "appending 0's to integer",
+          "comment" : "using composition with wrong tag for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022300a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3049228003202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00000022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 94,
-          "comment" : "prepending 0's to integer",
-          "msg" : "313233343030",
-          "sig" : "3047022200002478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
+          "comment" : "Replacing r with NULL",
           "flags" : [
-            "BER"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30250500022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 95,
-          "comment" : "prepending 0's to integer",
-          "msg" : "313233343030",
-          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00223000000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
+          "comment" : "changing tag value of r",
           "flags" : [
-            "BER"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304500202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 96,
-          "comment" : "appending unused 0's to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00000022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304501202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 97,
-          "comment" : "appending null value to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702222478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00500022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304503202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 98,
-          "comment" : "appending null value to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022300a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304504202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 99,
-          "comment" : "truncated length of integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30250281022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3045ff202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 100,
-          "comment" : "truncated length of integer",
+          "comment" : "dropping value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "302402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00281",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30250200022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 101,
-          "comment" : "Replacing integer with NULL",
+          "comment" : "using composition for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30250500022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30492224020124021f78f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 102,
-          "comment" : "Replacing integer with NULL",
+          "comment" : "modifying first byte of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "302402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202678f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 103,
-          "comment" : "changing tag value of integer",
+          "comment" : "modifying last byte of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304500202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f98140022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 104,
-          "comment" : "changing tag value of integer",
+          "comment" : "truncated r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304501202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3044021f2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 105,
-          "comment" : "changing tag value of integer",
+          "comment" : "truncated r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304503202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3044021f78f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 106,
-          "comment" : "changing tag value of integer",
+          "comment" : "r of size 4129 to check for overflows",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304504202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30821048028210212478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 107,
-          "comment" : "changing tag value of integer",
+          "comment" : "leading ff in r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3045ff202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30460221ff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 108,
-          "comment" : "changing tag value of integer",
+          "comment" : "replaced r by infinity",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0002100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3026090180022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 109,
-          "comment" : "changing tag value of integer",
+          "comment" : "replacing r with zero",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0012100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3026020100022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 110,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 0 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0032100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304302202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb3",
+          "result" : "invalid"
         },
         {
           "tcId" : 111,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 32 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0042100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304302202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841358d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 112,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 48 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0ff2100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304302202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84851359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 113,
-          "comment" : "dropping value of integer",
+          "comment" : "flipped bit 64 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30250200022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304302202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dd84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 114,
-          "comment" : "dropping value of integer",
+          "comment" : "length of s uses long form encoding",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "302402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00200",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304602202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002812100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 115,
-          "comment" : "using composition for integer",
+          "comment" : "length of s contains a leading 0",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30492224020124021f78f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00282002100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 116,
-          "comment" : "using composition for integer",
+          "comment" : "length of s uses 34 instead of 33",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c022250201000220a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022200a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 117,
-          "comment" : "modify first byte of integer",
+          "comment" : "length of s uses 32 instead of 33",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202678f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 118,
-          "comment" : "modify first byte of integer",
+          "comment" : "uint32 overflow in length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022102a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304a02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00285010000002100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 119,
-          "comment" : "modify last byte of integer",
+          "comment" : "uint64 overflow in length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f98140022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304e02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0028901000000000000002100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 120,
-          "comment" : "modify last byte of integer",
+          "comment" : "length of s = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34e32",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002847fffffff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 121,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3044021f2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002848000000000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 122,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3044021f78f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00284ffffffff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 123,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**40 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34e",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304a02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00285ffffffffff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 124,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00220a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304d02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00288ffffffffffffffff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 125,
-          "comment" : "leading ff in integer",
+          "comment" : "incorrect length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30460221ff2478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002ff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 126,
-          "comment" : "leading ff in integer",
+          "comment" : "replaced s by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304602202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00222ff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0028000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 127,
-          "comment" : "infinity",
+          "comment" : "appending 0's to s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3026090180022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022300a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result" : "invalid"
         },
         {
           "tcId" : 128,
-          "comment" : "infinity",
+          "comment" : "prepending 0's to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "302502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0090180",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00223000000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 129,
-          "comment" : "replacing integer with zero",
+          "comment" : "appending null value to s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3026020100022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304702202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022300a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20500",
+          "result" : "invalid"
         },
         {
           "tcId" : 130,
-          "comment" : "replacing integer with zero",
+          "comment" : "prepending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "302502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0020100",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304a02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02226498177022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 131,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "prepending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30460221012478f1cf49f6d858ac900a7af177222661ac95e206d32ee63020beee955ca711022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c022252500022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 132,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "appending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30460221ff2478f1d149f6d856ac900a7af1772226e7dea086b8a3f1dc48ad29689c965c6f022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304d02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02223022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20004deadbeef",
+          "result" : "invalid"
         },
         {
           "tcId" : 133,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "truncated length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30450220db870e2fb60927a8536ff5850e88ddd95b3a64cba0446f9ec3990bd467067e40022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "302402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00281",
+          "result" : "invalid"
         },
         {
           "tcId" : 134,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "including undefined tags to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3046022100db870e2eb60927a9536ff5850e88ddd918215f79475c0e23b752d6976369a391022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304b02202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02227aa02aabb022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 135,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "using composition with indefinite length for s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30460221fedb870e30b60927a7536ff5850e88ddd99e536a1df92cd119cfdf41116aa358ef022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02280022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result" : "invalid"
         },
         {
           "tcId" : 136,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "using composition with wrong tag for s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30460221012478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c02280032100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000",
+          "result" : "invalid"
         },
         {
           "tcId" : 137,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "Replacing s with NULL",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3046022100db870e2fb60927a8536ff5850e88ddd95b3a64cba0446f9ec3990bd467067e40022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "302402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00500",
+          "result" : "invalid"
         },
         {
           "tcId" : 138,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022101a07a59c3a41688548eb315e94effca0efd1ffe0a13467061783dde1cce167403",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0002100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 139,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00220a07a59c5a41688528eb315e94effca0f835208aec517335790ca4896d5502961",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0012100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 140,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00221ff5f85a63b5be977ac714cea16b10035f0bfc6fca393d12e237b7beca62e4cb14e",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0032100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 141,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00221fe5f85a63c5be977ab714cea16b10035f102e001f5ecb98f9e87c221e331e98bfd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0042100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 142,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022101a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0ff2100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 143,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "dropping value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c002205f85a63b5be977ac714cea16b10035f0bfc6fca393d12e237b7beca62e4cb14e",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "302402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00200",
+          "result" : "invalid"
         },
         {
           "tcId" : 144,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020100020100",
-          "result" : "invalid",
+          "comment" : "using composition for s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304902202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c022250201000220a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 145,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020100020101",
-          "result" : "invalid",
+          "comment" : "modifying first byte of s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022102a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 146,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201000201ff",
-          "result" : "invalid",
+          "comment" : "modifying last byte of s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34e32",
+          "result" : "invalid"
         },
         {
           "tcId" : 147,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "truncated s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304402202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34e",
+          "result" : "invalid"
         },
         {
           "tcId" : 148,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "s of size 4130 to check for overflows",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3082104802202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00282102200a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb20000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 149,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "leading ff in s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304602202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c00222ff00a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 150,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020100022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "replaced s by infinity",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0090180",
+          "result" : "invalid"
         },
         {
           "tcId" : 151,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020100022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "replacing s with zero",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302502202478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 152,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3008020100090380fe01",
-          "result" : "invalid",
+          "comment" : "replaced r by r + n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30460221012478f1cf49f6d858ac900a7af177222661ac95e206d32ee63020beee955ca711022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 153,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020101020100",
-          "result" : "invalid",
+          "comment" : "replaced r by r - n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30460221ff2478f1d149f6d856ac900a7af1772226e7dea086b8a3f1dc48ad29689c965c6f022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 154,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020101020101",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 256 * n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047022201002478f0d049f6d957ac900a7af17721e38bc048db775a1554f631b727fc1ed2c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 155,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201010201ff",
-          "result" : "invalid",
+          "comment" : "replaced r by -r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30450220db870e2fb60927a8536ff5850e88ddd95b3a64cba0446f9ec3990bd467067e40022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 156,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "replaced r by n - r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100db870e2eb60927a9536ff5850e88ddd918215f79475c0e23b752d6976369a391022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 157,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "replaced r by -n - r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30460221fedb870e30b60927a7536ff5850e88ddd99e536a1df92cd119cfdf41116aa358ef022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 158,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 2**256",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30460221012478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 159,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 2**320",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304e02290100000000000000002478f1d049f6d857ac900a7af1772226a4c59b345fbb90613c66f42b98f981c0022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 160,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026020101022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "replaced s by s + n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022101a07a59c3a41688548eb315e94effca0efd1ffe0a13467061783dde1cce167403022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 161,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3008020101090380fe01",
-          "result" : "invalid",
+          "comment" : "replaced s by s - n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30450220a07a59c5a41688528eb315e94effca0f835208aec517335790ca4896d5502961022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 162,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff020100",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 256 * n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304702220100a07a58c4a41689538eb315e94effc9cc2733b10383cd56d03e4ed65634d89fb2022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 163,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff020101",
-          "result" : "invalid",
+          "comment" : "replaced s by -s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30460221ff5f85a63b5be977ac714cea16b10035f0bfc6fca393d12e237b7beca62e4cb14e022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 164,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff0201ff",
-          "result" : "invalid",
+          "comment" : "replaced s by -n - s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30460221fe5f85a63c5be977ab714cea16b10035f102e001f5ecb98f9e87c221e331e98bfd022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 165,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 2**256",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022101a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 166,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "replaced s by s - 2**256",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30450220a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 167,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 2**320",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304e0229010000000000000000a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2022100a07a59c4a41688538eb315e94effca0f4039035c6c2ed1dc84841359d1b34eb2",
+          "result" : "invalid"
         },
         {
           "tcId" : 168,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30260201ff022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 169,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30260201ff022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 170,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30080201ff090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201000201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 171,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 172,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 173,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020100022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 174,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020100022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 175,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020100022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 176,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 177,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 178,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201010201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 179,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3028022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 180,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 181,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020101022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 182,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325500201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020101022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 183,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026020101022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 184,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 185,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 186,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff0201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 187,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 188,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3028022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 189,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260201ff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 190,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260201ff022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 191,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325520201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260201ff022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 192,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 193,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 194,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 195,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 196,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 197,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3028022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 198,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 199,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 200,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 201,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 202,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325500201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 203,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 204,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 205,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 206,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3028022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 207,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000001000000000000000000000001000000000000000000000000020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 208,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000001000000000000000000000001000000000000000000000000020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 209,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3026022100ffffffff000000010000000000000000000000010000000000000000000000000201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 210,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325520201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 211,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 212,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 213,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 214,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000001000000000000000000000001000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 215,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3028022100ffffffff00000001000000000000000000000001000000000000000000000000090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 216,
-          "comment" : "Edge case for Shamir multiplication",
-          "msg" : "3932323038",
-          "sig" : "3044022064a1aab5000d0e804f3e2fc02bdee9be8ff312334e2ba16d11547c97711c898e02203c623e7f7598376825fa8bc09e727c75794cbb4ee8716ae15c31cd1cbe9ca3ee",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=0",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 217,
-          "comment" : "special case hash",
-          "msg" : "33393439313934313732",
-          "sig" : "304402203a4f61f7f8c4546e3580f7848411786fee1229a07a6ecf5fb84870869188215d022018c5ce44354e2274eadb8fea319f8d6f60944532dbaae86bfd8105f253041bcb",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 218,
-          "comment" : "special case hash",
-          "msg" : "35333637363431383737",
-          "sig" : "304502203fa9975fb2b08b7b6e33f3843099da3f43f1dcfe9b171a60cafd5489ca9c5328022100985a86825a0cc728f5d9dac2a513b49127a06100f0fc4b8b1f200903e0df9ed2",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=-1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 219,
-          "comment" : "special case hash",
-          "msg" : "35363731343831303935",
-          "sig" : "304402204d66e7ee5edd02ab96db25954050079ef8de1d0f02f34d4d75112eaf3f73124002206292d1563140013c589be40e599862bdd6bda2103809928928a119b43851a2ce",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 220,
-          "comment" : "special case hash",
-          "msg" : "3131323037313732393039",
-          "sig" : "3046022100a9228305f7b486f568eb65d44e49ba007e3f14b8f23c689c952e4ced1e6cf91e022100b73c74d28bd1268002bed784a6b06c40a90ee5938ea6d08f272d027e0f96a72c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n - 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 221,
-          "comment" : "special case hash",
-          "msg" : "3131323938303334323336",
-          "sig" : "304402203fa39842bfab6c38afa7963c60beb09484d4579fc75ef09efff44e91bc62ca8302205612add1924f0285ace5b158828e2b32ab2b6e7f10ee68dca1cc54591fee1fec",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 222,
-          "comment" : "special case hash",
-          "msg" : "39383736303239363833",
-          "sig" : "3045022006c04b02edfeecd8620f035ea4f449bd924593e86e5288a6f22d1923b0e2e8a9022100f666718e6fefb515bb9339d29cc0e58cfba89d605ca0066bca87f6a3f08ebcfa",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=p",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 223,
-          "comment" : "special case hash",
-          "msg" : "3230323034323936353139",
-          "sig" : "304402201ddd953c32a5f84109cd4d9ec8c364dd318376ff5d228211a367483077d638800220563dba4845de762baf04910618d587e0dd0c97dd1c9785c24ffdf2f8a660abf2",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=p + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 224,
-          "comment" : "special case hash",
-          "msg" : "31343531363639313830",
-          "sig" : "30460221009fe4ec4831ef4945f100d5d35a2e6312411ca5df6c900ca60690f2985d553482022100c674ad5e1bead2f767c9248e444452a4a8530dd47246cbbc968da865bdf212b6",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=0",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000001000000000000000000000000020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 225,
-          "comment" : "special case hash",
-          "msg" : "31303933363835393531",
-          "sig" : "3046022100e8703d6b16a79fc2ab3653cece29d06f65dd6f2c230cb08ee30c5517407d75db0221008cfeb87b8e95ddacd638b37d315393c5005f3ab8bba0cc1cd1a050829b775bfb",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000001000000000000000000000000020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 226,
-          "comment" : "special case hash",
-          "msg" : "36323139353630323031",
-          "sig" : "3046022100def608caf1f277d71403009f209c1d7eef11aaa7920397fbf429b8146181aece022100f3b8f2aa5b3df9a8b37313ea66ad5b74673f3e8614ff471b1eb6773217511fb0",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=-1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff000000010000000000000000000000010000000000000000000000000201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 227,
-          "comment" : "special case hash",
-          "msg" : "35363832343734333033",
-          "sig" : "304402204f5d08e8d936ce831d02d6b23fb8fce0e0750101af3ab9c3b28636b95a5e24ad02206f034480553bcecac221f8be8288163c55492e2e56a88f4d0341b61436a0a6c0",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551",
+          "result" : "invalid"
         },
         {
           "tcId" : 228,
-          "comment" : "special case hash",
-          "msg" : "33373336353331373836",
-          "sig" : "3045022100bdd822bfe3733d9f4b88764fe091db2e8f8af366e4c44d876bf82e62bd48c7ee02207fbf7750c5dc849a2c55dbdd067806f869652a7b3a57baa4733781d3128f02de",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n - 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632550",
+          "result" : "invalid"
         },
         {
           "tcId" : 229,
-          "comment" : "special case hash",
-          "msg" : "34373935393033373932",
-          "sig" : "304402201c4fc02961b7f4245566b410bf08f447502ea4f75b15690344681efa2edf7b4b02207d63eef119dc88bc4a1b2c43ac21cd53892443661f8c3a97d558bf888c29f769",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632552",
+          "result" : "invalid"
         },
         {
           "tcId" : 230,
-          "comment" : "special case hash",
-          "msg" : "39333939363131303037",
-          "sig" : "304402206406f2d249ab1264e175476ca3300efd049fcad569dff40b922082b41cc7b7ce0220461872b803383f785077714a9566c4d652e87b2cad90dd4f4cc84bc55004c530",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=p",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 231,
-          "comment" : "special case hash",
-          "msg" : "31303837343931313835",
-          "sig" : "30450220415c924b9ba1902b340058117d90623602d48b8280583fb231dc93823b83a153022100f18be8cdc2063a26ab030504d3397dc6e9c6b6c56f4e3a59832c0e4643c0263c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=p + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000001000000000000000000000000022100ffffffff00000001000000000000000000000001000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 232,
-          "comment" : "special case hash",
-          "msg" : "33323336363738353030",
-          "sig" : "3045022100d12e96c7d2f177b7cf6d8a1ede060a2b174dc993d43f5fe60f75604824b64fef02200c97d87035fcca0a5f47fe6461bb30cbaf05b37e4211ec3fcd51fc71a12239ca",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008020100090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 233,
-          "comment" : "special case hash",
-          "msg" : "31343438393937373033",
-          "sig" : "304502207df72a64c7e982c88f83b3a22802690098147e0e42ef4371ef069910858c0646022100adbaa7b10c6a3f995ed5f83d7bda4ba626b355f34a72bf92ff788300b70e72d0",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 234,
-          "comment" : "special case hash",
-          "msg" : "35373134363332383037",
-          "sig" : "30440220047c4306f8d30e425ae70e0bee9e0b94faa4ef18a9c6d7f2c95de0fe6e2a323702207a4d0d0a596bd9ea3fe9850e9c8c77322594344623c0b46ac2a8c95948aefd98",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 235,
-          "comment" : "special case hash",
-          "msg" : "323236343837343932",
-          "sig" : "3044022057d603a367e23af39c95dd418c0176da8b211d50b1be82bf5ef621a2640204f702205dc3f285ad015c4d71157bd11e5b8df6a89e4b267393b08b5ad5013bdae544b1",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 236,
-          "comment" : "special case hash",
-          "msg" : "35333533343439343739",
-          "sig" : "3044022011df6741021ec8cc567584aea16817c540859c4e5011551c00b097fcfc2337e50220668551919d43206ac0571fc5ad3ac0efb489bea599e7bf99fe4c7468d6c2c5e0",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201000500",
+          "result" : "invalid"
         },
         {
           "tcId" : 237,
-          "comment" : "special case hash",
-          "msg" : "34373837333033383830",
-          "sig" : "304402207451ffede471bd370406533436fc42a89daa0af4903d087cbc062fe7e54dbf700220590895398f22b48ce72cbf7c3d3ee1dd7fb0ee645edb0b1b1de35f370e5bf5ee",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201000c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 238,
-          "comment" : "special case hash",
-          "msg" : "32323332313935383233",
-          "sig" : "3045022100fc4c4d81da6f687a6426263193c1a680b67734a1b180647b8c76407cc4f0a9c6022056f775d372c9bee685374085be676c9cf31cf1f978a5e6ccb04e4a0761159cc7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201000c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 239,
-          "comment" : "special case hash",
-          "msg" : "3130373339333931393137",
-          "sig" : "3045022100feb978ca33c46ffba47eb63bb40de7833e43d5654575b54de1fea3d1de3c8ad50220108078ba997bfa064521baf342c97b0c64bd25240c8fd0fd7533ae2d03081b70",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201003000",
+          "result" : "invalid"
         },
         {
           "tcId" : 240,
-          "comment" : "special case hash",
-          "msg" : "31383831303237333135",
-          "sig" : "3046022100cc61729698467ba53da199ff481fe7433f194fc96367907e8dc5e1d9f42b1e2102210083dd9ef156e7c1f9c09b3bf86a4f1c88e5dd20cd74d997858e600797dbe74ad2",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201003003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 241,
-          "comment" : "special case hash",
-          "msg" : "36303631363933393037",
-          "sig" : "3045022100d47f616303ff0eb813eac32e760ba30ad445e0af7dc57e70756104823f6a895f0220047f2217b399c46a426b936a124980a6011f0896f51dbe07632828a72d7173f1",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008020101090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 242,
-          "comment" : "special case hash",
-          "msg" : "38383935323237303934",
-          "sig" : "3046022100cff73dfa2bac67ce1340b25c885abb3e7979ef7f840f15d5f19e86640cdd40a3022100c7d1210802796c4f251049ee08a2c29f5c71064033d17010c65bf2e94499381e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 243,
-          "comment" : "special case hash",
-          "msg" : "31353830323334303934",
-          "sig" : "3044022010acaf9c485ab1220355b95be269f124e12eb252f2224b0fc50785eb2ee3df45022032443b557efc6896347fa778e1fcf33cbb769c9a7da896b20d93fea7c2791ea4",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 244,
-          "comment" : "special case hash",
-          "msg" : "33393635393931353132",
-          "sig" : "3046022100f919da0651abc2bff994a879d2778fa5195d57400e003e8dd6adb3fc7a0cc4cc0221009b945d06bd119665b278a59bd24fdd2350817d0be87997bee57b70c479d64a2d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 245,
-          "comment" : "special case hash",
-          "msg" : "32323838373332313938",
-          "sig" : "3045022100cc38e7a018f6d70b2d9b49120cc9b4a169f2f72238821a86b81f553b6225d24e0220276efd8bf06ccce07c7aae35eaac3bd1c374dcf0cf0588d5e0e4171936688636",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201010500",
+          "result" : "invalid"
         },
         {
           "tcId" : 246,
-          "comment" : "special case hash",
-          "msg" : "32323330383837333139",
-          "sig" : "3045022100ff85ad66621991c318b85cef73c576cb2a8d43c568c1aafc85b40ef2a9a6b41c0220732a79e6837ebf8434fea6e7fefa948f506ae455c1a3eb36a030185a23037d96",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201010c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 247,
-          "comment" : "special case hash",
-          "msg" : "313239303536393337",
-          "sig" : "3044022033f016e51eef9b1136380cb8b84c6b38b107e24c6731bd07cb1c7f4a29f33a83022036b177bb8be94c8be67ff3a41fcc4d22b5c9eb377da713eb014ae01c64ca6dd7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201010c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 248,
-          "comment" : "special case hash",
-          "msg" : "32373438363536343338",
-          "sig" : "3045022100929413ee91f27454d74e91370a10a86fc98ac7305c8ab4ca59752bda3a7bfc370220483b47a26a0d7d2e6bd37d351d9ee37c5ec2a4686d884d78b6beb7f6b08c50f9",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201013000",
+          "result" : "invalid"
         },
         {
           "tcId" : 249,
-          "comment" : "special case hash",
-          "msg" : "37353833353032363034",
-          "sig" : "30450220578202c7d0abac93ca43dde3cb44414e5601c1eb557604cb9adb4bde0a12633b022100fb9a7412e307aee95ef4b53540571a21559414e5306794ab5182cfb229dab3e9",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201013003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 250,
-          "comment" : "special case hash",
-          "msg" : "32333237373534323739",
-          "sig" : "3045022046d45ad0bb75b8639d0e91d8450fc31887c211328a5784fc83b4cb7f5b962c1b022100d6751d13ede2079b7aa1d822bdb32d7f3cf00273a1ff03df90c0ec7c62a47568",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201ff090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 251,
-          "comment" : "special case hash",
-          "msg" : "373735353038353834",
-          "sig" : "3046022100abe84c941783d5ced284fea56341ecc68d6bdd3196d318fbd074641f8c885bd5022100bdea3c44d48e01aa40935c1c9723ff733199563440f26b4ecf0b444b0418d9f5",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 252,
-          "comment" : "special case hash",
-          "msg" : "3137393832363438333832",
-          "sig" : "3045022005277cdbf491e336fe81be24e393a161a4fb89112c9ffed1ee6649c406713408022100ab6934332e68e108bb0484d21c457dcf381a620c3a4712fdbfeb658a3fafd60c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 253,
-          "comment" : "special case hash",
-          "msg" : "32333936373737333635",
-          "sig" : "30450220293825737c8c14430ed10dbadd7da337275f9b61d1d26377f778ffaa00c139de022100cdddec267a8678c96829bf6c1d6f38322e119937cfd2fee01e9dc9525f43ed6b",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 254,
-          "comment" : "special case hash",
-          "msg" : "35393938313035383031",
-          "sig" : "304402202041fdd6111c45dfd29e750e082dcdadc9a584a8a2be46580fb0ba3b3dc658620220421824fe987e4172a0f8bbcb7bcd9e1b073b7742ed9f9df98f2a1a37cd374ce3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 255,
-          "comment" : "special case hash",
-          "msg" : "3136363737383237303537",
-          "sig" : "30450220267941db660e046ab14e795669e002b852f7788447c53ebef46a2056978b5574022100d00183bcaf75bc11e37653f952f6a6537151c3aa0a1b9e4e41b004a29185395b",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff0c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 256,
-          "comment" : "special case hash",
-          "msg" : "323036323134333632",
-          "sig" : "304402205dcd7f6814739d47f80a363b9414e6cbfb5f0846223888510abd5b3903d7ae09022043418f138bb3c857c0ad750ca8389ebcf3719cb389634ac54a91de9f18fd7238",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff0c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 257,
-          "comment" : "special case hash",
-          "msg" : "36383432343936303435",
-          "sig" : "304502205e0e8cc0280409a0ce252da02b2424d2de3a52b406c3778932dbc60cb86c356702210093d25e929c5b00e950d89585ec6c01b6589ae0ec0af8a79c04df9e5b27b58bc5",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 258,
-          "comment" : "special case hash",
-          "msg" : "33323639383937333231",
-          "sig" : "304502204fcf9c9d9ffbf4e0b98268c087071bffe0673bb8dcb32aa667f8a639c364ea47022100820db0730bee8227fc831643fcb8e2ef9c0f7059ce42da45cf74828effa8d772",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201ff3003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 259,
-          "comment" : "special case hash",
-          "msg" : "31333837333234363932",
-          "sig" : "3046022100c60cd2e08248d58d1639b123633643c63f89aff611f998937ccb08c9113bcdca022100ac4bb470ce0164616dada7a173364ed3f9d16fd32c686136f904c99266fda17e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3028022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 260,
-          "comment" : "special case hash",
-          "msg" : "34313138383837353336",
-          "sig" : "304502207cfdaf6f22c1c7668d7b6f56f8a7be3fdeeb17a7863539555bbfa899dd70c5f1022100cee151adc71e68483b95a7857a862ae0c5a6eee478d93d40ccc7d40a31dcbd90",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 261,
-          "comment" : "special case hash",
-          "msg" : "393838363036353435",
-          "sig" : "304402202270be7ee033a706b59746eab34816be7e15c8784061d5281060707a0abe0a7d022056a163341ee95e7e3c04294a57f5f7d24bf3c3c6f13ef2f161077c47bd27665d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 262,
-          "comment" : "special case hash",
-          "msg" : "32343739313135383435",
-          "sig" : "3044022016b5d2bfcaba21167a69f7433d0c476b21ded37d84dc74ca401a3ecddb2752a8022062852cf97d89adfb0ebbe6f398ee641bfea8a2271580aac8a3d8326d8c6e0ef9",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632551010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 263,
-          "comment" : "special case hash",
-          "msg" : "35303736383837333637",
-          "sig" : "3046022100d907eefa664115848b90c3d5baa0236f08eafaf81c0d52bb9d0f8acb57490847022100fd91bc45a76e31cdc58c4bfb3df27f6470d20b19f0fba6a77b6c8846650ed8a6",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3025022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510500",
+          "result" : "invalid"
         },
         {
           "tcId" : 264,
-          "comment" : "special case hash",
-          "msg" : "393838353036393637",
-          "sig" : "30450220048337b34f427e8774b3bf7c8ff4b1ae65d132ac8af94829bb2d32944579bb31022100bd6f8eab82213ccf80764644204bb6bf16c668729cdd31dd8596286c15686e8e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3025022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 265,
-          "comment" : "special case hash",
-          "msg" : "32373231333036313331",
-          "sig" : "3046022100b2bc46b7c44293557ab7ebeb0264924277193f87a25d94c924df1518ba7c7260022100abf1f6238ff696aaafaf4f0cbbe152c3d771c5bfc43f36d7e5f5235819d02c1a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325510c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 266,
-          "comment" : "special case hash",
-          "msg" : "33323034313031363535",
-          "sig" : "3045022040d4b38a61232e654ffd08b91e18609851f4189f7bf8a425ad59d9cbb1b54c990221009e775a7bd0d934c3ed886037f5d3b356f60eda41191690566e99677d7aaf64f3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3025022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325513000",
+          "result" : "invalid"
         },
         {
           "tcId" : 267,
-          "comment" : "special case hash",
-          "msg" : "33313530363830393530",
-          "sig" : "3046022100ac8f64d7df8d9fea005744e3ac4af70aa3a38e5a0f3d069d85806a4f29710339022100c014e96decfef3857cc174f2c46ad0882bef0c4c8a17ce09441961e4ae8d2df3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3028022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6325513003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 268,
-          "comment" : "special case hash",
-          "msg" : "31373237343630313033",
-          "sig" : "3044022041b3766f41a673a01e2c0cab5ceedbcec8d82530a393f884d72aa4e6685dea0a0220073a55dca2da577cafb40e12dd20bf8529a13a6acdf9a1c7d4b2048d60876cb3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3028022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 269,
-          "comment" : "special case hash",
-          "msg" : "3134353731343631323235",
-          "sig" : "304502201942755aa8128382cd8e35a4350c22cc45ba5704d99e8a240970df11956ad866022100f64cf1e0816cf7ac5044f73ba938e142ef3305cb09becb80a0a5b9ad7ba3eb07",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 270,
-          "comment" : "special case hash",
-          "msg" : "34313739353136303930",
-          "sig" : "3045022051aba4ff1c7ddf17e0632ab71684d8de6dc700219ef346cb28ce9dafc3565b3b022100b6aaebe1af0ad01f07a68bf1cf57f9d6040b43c14b7eb8238542760e32ce3b0c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 271,
-          "comment" : "special case hash",
-          "msg" : "35383932373133303534",
-          "sig" : "304502210091efbfcc731650e9f004c38b71db146c17bf871c82c4e87716f7ff2f7f9e51d00220089ea631a7c5f05311c521d21ba798b5174881f0fd8095fb3a77515913efb6e0",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 272,
-          "comment" : "special case hash",
-          "msg" : "33383936313832323937",
-          "sig" : "304502204a7e47bd281ea09b9e3a32934c7a969e1f788f978b41585989f4689e804663fb022100e65f6bd702403cbbed7f8ad0045f331d4a96fbf8c43f71f11615b7d1b9153b7f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3025022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 273,
-          "comment" : "special case hash",
-          "msg" : "38323833333436373332",
-          "sig" : "3046022100c795f5da86e10a604d4f94bf7cac381c73edad1461d66929e53aa57ca294e89f022100bae784ab6c7b58332ee05e7d54169edf55ce45f030e71ae8df63969fb327a10c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3025022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 274,
-          "comment" : "special case hash",
-          "msg" : "33333636393734383931",
-          "sig" : "3046022100ea68b24843b225f505e01c0e608b20b4d93e8faf6b9cf70cf8f9134a80e7b668022100a3abc044b4728f80fe414bdc66f032b262356720547bec7729fad94151c6adc7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3026022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff0c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 275,
-          "comment" : "special case hash",
-          "msg" : "32313939313533323239",
-          "sig" : "3046022100bfe7502140c57a24a77edc3d9b3c4bc11d21bdb0b196977b7f2b13ac973ad697022100947a01da9731849d72b67ef7bc40b012480fd389895aad1f6b1cdbeab3b93b8d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3025022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 276,
-          "comment" : "special case hash",
-          "msg" : "35363030333136383232",
-          "sig" : "304402203434ee1142740a0ab8623b97fc8dc2567eda45dadf6039b45c448819e840cf3002203c0fac0487841997202c29f3bf2df540b115b29dc619160d52203d4a1fd4b9f7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3028022100ffffffff00000001000000000000000000000000ffffffffffffffffffffffff3003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 277,
-          "comment" : "special case hash",
-          "msg" : "383639363531363935",
-          "sig" : "304502205338500e23ba96a0adc6ef84932e25fbad7435d9f70eb7f476c6912de12e33c8022100a002f5583ea8c0d7fb17136d0ee0415acf629879ce6b01ac52e3ecd7772a3704",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0.25, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300a090380fe01090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 278,
-          "comment" : "special case hash",
-          "msg" : "36353833393236333732",
-          "sig" : "304402204ff2d4e31f4180de6901d2d20341d12387c9c55f4cf003a742f049b84af6fe0502200312f38771414555fa5ed2817dcc629a8c7cf69d306300e87bc167278ec3ef37",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=nan, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006090142090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 279,
-          "comment" : "special case hash",
-          "msg" : "3133323035303135373235",
-          "sig" : "3044022051d665bad5f2d6306c6bbfe1f27555887670061d4df36ec9f4ce6cdfaf9ea7ac02202905e43f6207ee93df35a2e9fb9bc8098c448ae98a14e4ad1ebaea5d56b6e493",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=True, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010101010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 280,
-          "comment" : "special case hash",
-          "msg" : "35303835333330373931",
-          "sig" : "3046022100b804e0235f135aba7b7531b6831f26cc9fb77d3f83854957431be20706b813690221009d317fd08e4e0467617db819cde1d7d4d74da489b2bce4db055ea01eccfafcf2",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=False, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010100010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 281,
-          "comment" : "special case hash",
-          "msg" : "37383636383133313139",
-          "sig" : "30450221008ab50ef3660ccb6af34c78e795ded6b256ffca5c94f249f3d907fb65235ef680022049d5aaeae5a6d0c15b286e428b5e720cf37a822ede445baa143ffae69aba91b8",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=Null, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300405000500",
+          "result" : "invalid"
         },
         {
           "tcId" : 282,
-          "comment" : "special case hash",
-          "msg" : "32303832353339343239",
-          "sig" : "30440220571b9c46a47c5cc53a574c196c3fb07f3510c0f4443b9f2fe781252c24d343de022068a9aebd50ff165c89b5b9cb6c1754191958f360b4d2851a481a3e1106ee7809",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30040c000c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 283,
-          "comment" : "special case hash",
-          "msg" : "3130303635393536363937",
-          "sig" : "304502204cb7817b04dc73be60d3711803bc10687a6e3f4ab79c4c1a4e9d63a73174d4eb022100ce398d2d6602d2af58a64042f830bf774aee18209d6fb5c743b6a6e437826b98",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=\"0\", s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060c01300c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 284,
-          "comment" : "special case hash",
-          "msg" : "33303234313831363034",
-          "sig" : "30450220684399c6cd6ebb1c5d5efb0d78dce40ebd48d9d944eb6548c9ce68d7fdc82229022100cf25c8e427fae359bfe60fa02964f4c9b8d6db54612e05c78c341f0a8c52d0b5",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empty list, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300430003000",
+          "result" : "invalid"
         },
         {
           "tcId" : 285,
-          "comment" : "special case hash",
-          "msg" : "37373637383532383734",
-          "sig" : "3045022020b7b36d5bc76fa182ca27152a99a956e6a0880000694296e31af98a7312d04b022100eeeabc5521f9856e920eb7d29ed7e4042f178ff706dff8eeb24b429e3b63402a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=list containing 0, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300a30030201003003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 286,
-          "comment" : "special case hash",
-          "msg" : "353434313939393734",
-          "sig" : "304402206b65c95e8e121d2e6ee506cfd62cb88e0bfb3589da40876898ef66c43982aca9022009642c05ad619b4402fd297eb57e29cca5c2eb6823931ba82de32d7c652ba73e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0.25, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008090380fe01020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 287,
-          "comment" : "special case hash",
-          "msg" : "35383433343830333931",
-          "sig" : "3044022067c74cbf5ea4b777bf521ace099f4f094d8f58900e15e67e1b4bd399056629ed02203d2884655c49b8b5f64e802a054e7bf09b0fc80ca18ebf927b82e58bb4a00400",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=nan, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006090142020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 288,
-          "comment" : "special case hash",
-          "msg" : "373138383932363239",
-          "sig" : "3045022079a5e40da5cf34c4c39adf7dfc5d454995a250314ebd212b5c8e3f4e6f875feb022100b268920e403ba17828ff271938a6558a5b2dd000229f8edb4a9d9f9b6ac1b472",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=True, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010101020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 289,
-          "comment" : "special case hash",
-          "msg" : "31373433323233343433",
-          "sig" : "3045022100c8b13006c3a51a322fff9321761b01de134f526be582b22e19693c443fc9fe46022034e7f60179c6162ab980fcd58f173b0e6c30b524d35c67921677522dcef843a1",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=False, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010100020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 290,
-          "comment" : "special case hash",
-          "msg" : "32343036303035393336",
-          "sig" : "304502203513db745489a487c88a6cedf8795b640f8f71578397bdabd6cc586c25bd66ad02210099a72cd3f0ca6c799149283ca0af37f86b88200d0c905bd3c9f1b859e55b1659",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=Null, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050500020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 291,
-          "comment" : "special case hash",
-          "msg" : "31363134303336393838",
-          "sig" : "304402203a6386afb08f7ff8140b5a270f764e8706ef2830fb177446f7b4eeb8a25aac6402204b70854b38c29245b2b980eba10ea936c68a38c1da5255ce2386db23afc7c06a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050c00020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 292,
-          "comment" : "special case hash",
-          "msg" : "32303935343235363835",
-          "sig" : "3046022100b8fc54a8a6be3c55e99c06f99ccdcce7af5c18a3c5829726a870cc1068458f64022100cc7237c39c8e6a4a1c8c62f5f88636549c7410798b89684c502c3adfe5fb7ad2",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=\"0\", s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060c0130020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 293,
-          "comment" : "special case hash",
-          "msg" : "31303038303938393833",
-          "sig" : "3045022047b460851e5607f2021626635c565a63f78f558795e1b330d09115970dbbb8ab022100a6a9f4f213e08d3c736d3e1c44a35140cb107619f265a5b13608ed729fd6d894",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empty list, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30053000020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 294,
-          "comment" : "special case hash",
-          "msg" : "31353734313437393237",
-          "sig" : "30450221008cfda4f7a65864ebbea3144863da9b075c07b5b42cb4569643ddfd70dd753b190220595784b1ab217874b82b9585521f8090b9f6322884ab7a620464f51cf846c5b7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=list containing 0, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30083003020100020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 295,
-          "comment" : "special case hash",
-          "msg" : "32383636373731353232",
-          "sig" : "304402204cd6a45bd7c8bf0edbdf073dbf1f746234cbbca31ec20b526b077c9f480096e702207cf97ae0d33f50b73a5d7adf8aa4eeeb6ff10f89a8794efe1d874e23299c1b3d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Edge case for Shamir multiplication",
+          "flags" : [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg" : "3932323038",
+          "sig" : "3044022064a1aab5000d0e804f3e2fc02bdee9be8ff312334e2ba16d11547c97711c898e02203c623e7f7598376825fa8bc09e727c75794cbb4ee8716ae15c31cd1cbe9ca3ee",
+          "result" : "valid"
         },
         {
           "tcId" : 296,
           "comment" : "special case hash",
-          "msg" : "31363934323830373837",
-          "sig" : "304402202e233f4df8ffebeaec64842b23cce161c80d303b016eca562429b227ae2b58ec022046b6b56adec82f82b54daa6a5fca286740a1704828052072a5f0bc8c7b884242",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33393439313934313732",
+          "sig" : "304402203a4f61f7f8c4546e3580f7848411786fee1229a07a6ecf5fb84870869188215d022018c5ce44354e2274eadb8fea319f8d6f60944532dbaae86bfd8105f253041bcb",
+          "result" : "valid"
         },
         {
           "tcId" : 297,
           "comment" : "special case hash",
-          "msg" : "39393231363932353638",
-          "sig" : "30440220549f658d4a3f98233a2c93bd5b1a52d64af10815ae60becb4139cac822b579c3022027bdddf0dbcf374a2aec8accc47a8ac897f8d1823dda8eb2052590970b39ce2a",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35333637363431383737",
+          "sig" : "304502203fa9975fb2b08b7b6e33f3843099da3f43f1dcfe9b171a60cafd5489ca9c5328022100985a86825a0cc728f5d9dac2a513b49127a06100f0fc4b8b1f200903e0df9ed2",
+          "result" : "valid"
         },
         {
           "tcId" : 298,
           "comment" : "special case hash",
-          "msg" : "3131363039343339373938",
-          "sig" : "30450221009fabcc1e5fd965226902f594559e231369e584453974e74f49d7d762e134fb9d0220293cccc510793bac45ce5da2bb6c9e906437f59435ca206655f74b625df07c7c",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35363731343831303935",
+          "sig" : "304402204d66e7ee5edd02ab96db25954050079ef8de1d0f02f34d4d75112eaf3f73124002206292d1563140013c589be40e599862bdd6bda2103809928928a119b43851a2ce",
+          "result" : "valid"
         },
         {
           "tcId" : 299,
           "comment" : "special case hash",
-          "msg" : "37313836313632313030",
-          "sig" : "304502202e5c140fd6f5f823addc8088ffaae967e7f4897274316769561dfb31435825d9022100eda47327d7cfae1daa344ff5582a467bd18eb9f01caeab9c6da3c0cc89df6713",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131323037313732393039",
+          "sig" : "3046022100a9228305f7b486f568eb65d44e49ba007e3f14b8f23c689c952e4ced1e6cf91e022100b73c74d28bd1268002bed784a6b06c40a90ee5938ea6d08f272d027e0f96a72c",
+          "result" : "valid"
         },
         {
           "tcId" : 300,
           "comment" : "special case hash",
-          "msg" : "33323934333437313737",
-          "sig" : "304402204c11e3b7efbe3908ad2118e54d7d34d6c6eb4570bf7fdb11a7679fe93afa254c0220712e90f421836e542dac49d10bb39db4a98b2735b6336d8a3c392f3b90e60bbe",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131323938303334323336",
+          "sig" : "304402203fa39842bfab6c38afa7963c60beb09484d4579fc75ef09efff44e91bc62ca8302205612add1924f0285ace5b158828e2b32ab2b6e7f10ee68dca1cc54591fee1fec",
+          "result" : "valid"
         },
         {
           "tcId" : 301,
           "comment" : "special case hash",
-          "msg" : "3138353134343535313230",
-          "sig" : "3045022100dfb4619303f4ff689563d2275069fac44d63ea3c3b18f4fb1ac805d7df3d12ec022068e37b846583901db256329f9cf64f40c416fba50dcb9be333a3e29c76ae32db",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "39383736303239363833",
+          "sig" : "3045022006c04b02edfeecd8620f035ea4f449bd924593e86e5288a6f22d1923b0e2e8a9022100f666718e6fefb515bb9339d29cc0e58cfba89d605ca0066bca87f6a3f08ebcfa",
+          "result" : "valid"
         },
         {
           "tcId" : 302,
           "comment" : "special case hash",
-          "msg" : "343736303433393330",
-          "sig" : "3045022100e70e8e17bd758ff0c48f91cb2c53d293f0f5ae82eb9dfe76ab98f9b064278635022021dde32cb0389cad7bdf676d9b9b7d25bb034ad25a55ea71ee7ee26a18359dd2",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3230323034323936353139",
+          "sig" : "304402201ddd953c32a5f84109cd4d9ec8c364dd318376ff5d228211a367483077d638800220563dba4845de762baf04910618d587e0dd0c97dd1c9785c24ffdf2f8a660abf2",
+          "result" : "valid"
         },
         {
           "tcId" : 303,
           "comment" : "special case hash",
-          "msg" : "32353637333738373431",
-          "sig" : "30440220421397ecae30617a5a6081ad1badf6ce9d9d4cb2afdabf1f900e7fdb7fb0af5a022057ca89dc22801c75fdbefdaeca65c675625f94de7d635062b08ed308df5762cc",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31343531363639313830",
+          "sig" : "30460221009fe4ec4831ef4945f100d5d35a2e6312411ca5df6c900ca60690f2985d553482022100c674ad5e1bead2f767c9248e444452a4a8530dd47246cbbc968da865bdf212b6",
+          "result" : "valid"
         },
         {
           "tcId" : 304,
           "comment" : "special case hash",
-          "msg" : "35373339393334393935",
-          "sig" : "304502200610c08076909bb722fba105c23eac8f66b4db1d58f66a882fc90d59acdec8e0022100af59e8d570761cac589d49f11c884007f7ac1eea1a44c6f3fdad1d542187d25e",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31303933363835393531",
+          "sig" : "3046022100e8703d6b16a79fc2ab3653cece29d06f65dd6f2c230cb08ee30c5517407d75db0221008cfeb87b8e95ddacd638b37d315393c5005f3ab8bba0cc1cd1a050829b775bfb",
+          "result" : "valid"
         },
         {
           "tcId" : 305,
           "comment" : "special case hash",
-          "msg" : "33343738333636313339",
-          "sig" : "3045022059a1181cab0ee8ce94ab2b5ab4f4b13a422e38efe69f634bf947485a5b9ea49c0221009b3c913d98a4ab15f6a39f1802b8f2d28559aa1f8d03a3a88df00c89dc293a97",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36323139353630323031",
+          "sig" : "3046022100def608caf1f277d71403009f209c1d7eef11aaa7920397fbf429b8146181aece022100f3b8f2aa5b3df9a8b37313ea66ad5b74673f3e8614ff471b1eb6773217511fb0",
+          "result" : "valid"
         },
         {
           "tcId" : 306,
           "comment" : "special case hash",
-          "msg" : "363439303532363032",
-          "sig" : "30460221008cae6c4dfbf901bd66ab82541011fa15c8e90e2c18c01bd881acaa2b63cb587b022100a86acf943f29cef91d1b66a7de5547df6cdfc45dd7bef816dcb8de9f5a425d2d",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35363832343734333033",
+          "sig" : "304402204f5d08e8d936ce831d02d6b23fb8fce0e0750101af3ab9c3b28636b95a5e24ad02206f034480553bcecac221f8be8288163c55492e2e56a88f4d0341b61436a0a6c0",
+          "result" : "valid"
         },
         {
           "tcId" : 307,
           "comment" : "special case hash",
-          "msg" : "34373633383837343936",
-          "sig" : "30450221008b00c74b86474d782eac9974aea606d8f7ee78c79597e15687021f5991e86acd0220309dfe3686648eae104e87b3e9b5616a3ad479ca4f0b558ae4f1e5ab3115346a",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33373336353331373836",
+          "sig" : "3045022100bdd822bfe3733d9f4b88764fe091db2e8f8af366e4c44d876bf82e62bd48c7ee02207fbf7750c5dc849a2c55dbdd067806f869652a7b3a57baa4733781d3128f02de",
+          "result" : "valid"
         },
         {
           "tcId" : 308,
           "comment" : "special case hash",
-          "msg" : "353739303230303830",
-          "sig" : "30450220433a915504c977809634a36fcf4480e4c8069fc127d201d30dfdb1f423c95fd4022100bcb1b89aafd50a1766b09741fc6a9a96e744ae9826d839bf85ffb50a91981773",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34373935393033373932",
+          "sig" : "304402201c4fc02961b7f4245566b410bf08f447502ea4f75b15690344681efa2edf7b4b02207d63eef119dc88bc4a1b2c43ac21cd53892443661f8c3a97d558bf888c29f769",
+          "result" : "valid"
         },
         {
           "tcId" : 309,
           "comment" : "special case hash",
-          "msg" : "35333434373837383438",
-          "sig" : "304502204b69abd2b39840a545cdd4a72d384234580e2fd938b7091d0ecdb562780857db022100fdab9957119e0a4092af82f6cc29f3c8a692671ec86efb0a03c1112a0a1e0467",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "39333939363131303037",
+          "sig" : "304402206406f2d249ab1264e175476ca3300efd049fcad569dff40b922082b41cc7b7ce0220461872b803383f785077714a9566c4d652e87b2cad90dd4f4cc84bc55004c530",
+          "result" : "valid"
         },
         {
           "tcId" : 310,
           "comment" : "special case hash",
-          "msg" : "3139323636343130393230",
-          "sig" : "3045022100dab9d3686c28363ad017b4a2b36d35bf2eb80633613d44deb9501d42a3efbd3802201392a562d79f9ab19014e4f7e2f2668259f3720a76c120d4a3c3964e880f7679",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31303837343931313835",
+          "sig" : "30450220415c924b9ba1902b340058117d90623602d48b8280583fb231dc93823b83a153022100f18be8cdc2063a26ab030504d3397dc6e9c6b6c56f4e3a59832c0e4643c0263c",
+          "result" : "valid"
         },
         {
           "tcId" : 311,
           "comment" : "special case hash",
-          "msg" : "33373033393135373035",
-          "sig" : "3045022023f94e47b440ce379b74c9311232b19a64e3e7c9b90da34b0c1c3f3d7af28105022100e1425903b1479c2ce18b108a6d1ec8b7a4f0f657dedb00de3a3ceea7fdeee9be",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323336363738353030",
+          "sig" : "3045022100d12e96c7d2f177b7cf6d8a1ede060a2b174dc993d43f5fe60f75604824b64fef02200c97d87035fcca0a5f47fe6461bb30cbaf05b37e4211ec3fcd51fc71a12239ca",
+          "result" : "valid"
         },
         {
           "tcId" : 312,
           "comment" : "special case hash",
-          "msg" : "3831353435373730",
-          "sig" : "30450221009d706a8fa85d15bd0c3492c6672dfe529f4073b217b3947b5b2cfd61f87ccb7102206aaaaf369f82a0e542f72ded7d7eb90c8314ffa613a0ea81da1c8393dbae2bac",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31343438393937373033",
+          "sig" : "304502207df72a64c7e982c88f83b3a22802690098147e0e42ef4371ef069910858c0646022100adbaa7b10c6a3f995ed5f83d7bda4ba626b355f34a72bf92ff788300b70e72d0",
+          "result" : "valid"
         },
         {
           "tcId" : 313,
           "comment" : "special case hash",
-          "msg" : "313935353330333737",
-          "sig" : "3046022100ac77918c4085c8a7ce5020b00c315629aee053a445cb4661eb50f6b62a47da29022100df2aea2b9c11a6ce39d3cd9e1faf4a53057e0b1b2e48a324be9e773203fe9fbb",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35373134363332383037",
+          "sig" : "30440220047c4306f8d30e425ae70e0bee9e0b94faa4ef18a9c6d7f2c95de0fe6e2a323702207a4d0d0a596bd9ea3fe9850e9c8c77322594344623c0b46ac2a8c95948aefd98",
+          "result" : "valid"
         },
         {
           "tcId" : 314,
           "comment" : "special case hash",
-          "msg" : "31323637383130393033",
-          "sig" : "30460221009db2dbd2935f147fae7f6a95c8e2307bd8537c3d96eb732ad6d5ebdd89bc754e02210093a9ab99d2de9d08fe0a61e26c8fe1ebbf88726e4b69d551b57d15f0ae16df5a",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "323236343837343932",
+          "sig" : "3044022057d603a367e23af39c95dd418c0176da8b211d50b1be82bf5ef621a2640204f702205dc3f285ad015c4d71157bd11e5b8df6a89e4b267393b08b5ad5013bdae544b1",
+          "result" : "valid"
         },
         {
           "tcId" : 315,
           "comment" : "special case hash",
-          "msg" : "3131313830373230383135",
-          "sig" : "30440220769f70093939afbd1fa15873decfa803ca523ace8040280ba78cf833497722bc0220369875aba5e1ced5a4ca8444ec9399a38038b00e153a0ae34d9b3c9781447eea",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35333533343439343739",
+          "sig" : "3044022011df6741021ec8cc567584aea16817c540859c4e5011551c00b097fcfc2337e50220668551919d43206ac0571fc5ad3ac0efb489bea599e7bf99fe4c7468d6c2c5e0",
+          "result" : "valid"
         },
         {
           "tcId" : 316,
           "comment" : "special case hash",
-          "msg" : "38333831383639323930",
-          "sig" : "3045022026e5182b9822550ad52f46ad80781d6bef3d110a204db5e58a0746f796982200022100a9418e76029ced0cf78a571a9e59ad04086e91f70e6813981bb33c1dee891165",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34373837333033383830",
+          "sig" : "304402207451ffede471bd370406533436fc42a89daa0af4903d087cbc062fe7e54dbf700220590895398f22b48ce72cbf7c3d3ee1dd7fb0ee645edb0b1b1de35f370e5bf5ee",
+          "result" : "valid"
         },
         {
           "tcId" : 317,
           "comment" : "special case hash",
-          "msg" : "33313331323837323737",
-          "sig" : "3046022100e7bd6aefcf7b27e1f3fadbe713f9adb3d23398e88200cd2e94989c9d12e921770221009583e0de3b76f8d4b1e634a81cbc34af54e2f8599f3684ce48d372760c8204c4",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32323332313935383233",
+          "sig" : "3045022100fc4c4d81da6f687a6426263193c1a680b67734a1b180647b8c76407cc4f0a9c6022056f775d372c9bee685374085be676c9cf31cf1f978a5e6ccb04e4a0761159cc7",
+          "result" : "valid"
         },
         {
           "tcId" : 318,
           "comment" : "special case hash",
-          "msg" : "3134333331393236353338",
-          "sig" : "30450221008638ed7eaa83609a01a6af9c52ec9bfddda90442b1e6031d61cfa22e48b2e1e2022020c284d596f71c6c8df732f5a5a2006302301e1a792e2b39663d93a9760762d2",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130373339333931393137",
+          "sig" : "3045022100feb978ca33c46ffba47eb63bb40de7833e43d5654575b54de1fea3d1de3c8ad50220108078ba997bfa064521baf342c97b0c64bd25240c8fd0fd7533ae2d03081b70",
+          "result" : "valid"
         },
         {
           "tcId" : 319,
           "comment" : "special case hash",
-          "msg" : "333434393038323336",
-          "sig" : "3044022061d924307a96180b06383608ba91674e15c3ea06ff2534412b93a587dde649c1022059b84aa2115b2547edac88088ca6313e9fbe1ca6a361c7e57938f9dde3f4349c",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31383831303237333135",
+          "sig" : "3046022100cc61729698467ba53da199ff481fe7433f194fc96367907e8dc5e1d9f42b1e2102210083dd9ef156e7c1f9c09b3bf86a4f1c88e5dd20cd74d997858e600797dbe74ad2",
+          "result" : "valid"
         },
         {
           "tcId" : 320,
           "comment" : "special case hash",
-          "msg" : "36383239383335393239",
-          "sig" : "30450220424fcfc3fd63d128c2eb125e88c7fe5d283b63470a786b82783edbb8a0b7a6d7022100b11548c2cd7fce9d44e795ca51af0b2f6a5180e9c9be0314007ed9e7f4bbe5e9",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36303631363933393037",
+          "sig" : "3045022100d47f616303ff0eb813eac32e760ba30ad445e0af7dc57e70756104823f6a895f0220047f2217b399c46a426b936a124980a6011f0896f51dbe07632828a72d7173f1",
+          "result" : "valid"
         },
         {
           "tcId" : 321,
           "comment" : "special case hash",
-          "msg" : "33343435313538303233",
-          "sig" : "3045022100a5f747ae6290fa9582c6ce8d5608621d495f061551bc4531bacba586a563b184022062faf8f92291e12812835b3f1d43c967bceb885b110bd06e5a68e2d74781ae2b",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "38383935323237303934",
+          "sig" : "3046022100cff73dfa2bac67ce1340b25c885abb3e7979ef7f840f15d5f19e86640cdd40a3022100c7d1210802796c4f251049ee08a2c29f5c71064033d17010c65bf2e94499381e",
+          "result" : "valid"
         },
         {
           "tcId" : 322,
           "comment" : "special case hash",
-          "msg" : "3132363937393837363434",
-          "sig" : "3045022100b731dc0d92c2cc7a605d78233f7814699bdf1cab2df297b6844eec4015af8ea0022039b1a0cc88eb85bcdc356b3620c51f1298c60aec5306b107e900ffdba049dd6f",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31353830323334303934",
+          "sig" : "3044022010acaf9c485ab1220355b95be269f124e12eb252f2224b0fc50785eb2ee3df45022032443b557efc6896347fa778e1fcf33cbb769c9a7da896b20d93fea7c2791ea4",
+          "result" : "valid"
         },
         {
           "tcId" : 323,
           "comment" : "special case hash",
-          "msg" : "333939323432353533",
-          "sig" : "3046022100ef73c4fa322da39fb6503bab6b66b64d241056afbcd6908f84b61ccbbe890433022100f1ef85413e5764aa58a3128ccfcf388324fe5340e5edf8d0135ae76786ce415b",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33393635393931353132",
+          "sig" : "3046022100f919da0651abc2bff994a879d2778fa5195d57400e003e8dd6adb3fc7a0cc4cc0221009b945d06bd119665b278a59bd24fdd2350817d0be87997bee57b70c479d64a2d",
+          "result" : "valid"
         },
         {
           "tcId" : 324,
           "comment" : "special case hash",
-          "msg" : "31363031393737393737",
-          "sig" : "30450220694cd30e2ad0182579331474b271ee2d48723bc8415dc6513873586ce705b76b022100c5ac0c0ed5a4017d110cb45d63aa955dc7dc5ce23e7965c5397c3ff46a884636",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32323838373332313938",
+          "sig" : "3045022100cc38e7a018f6d70b2d9b49120cc9b4a169f2f72238821a86b81f553b6225d24e0220276efd8bf06ccce07c7aae35eaac3bd1c374dcf0cf0588d5e0e4171936688636",
+          "result" : "valid"
         },
         {
           "tcId" : 325,
           "comment" : "special case hash",
-          "msg" : "3130383738373535313435",
-          "sig" : "3046022100f38b2236be3024e10b894ffb1cc68d0bb8d4cf0fcd2cfc1779f8883765d3cd96022100da69cd0b74c25566d60a486edd559fc39d569fb2751445a4798df8a36891802c",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32323330383837333139",
+          "sig" : "3045022100ff85ad66621991c318b85cef73c576cb2a8d43c568c1aafc85b40ef2a9a6b41c0220732a79e6837ebf8434fea6e7fefa948f506ae455c1a3eb36a030185a23037d96",
+          "result" : "valid"
         },
         {
           "tcId" : 326,
           "comment" : "special case hash",
-          "msg" : "37303034323532393939",
-          "sig" : "3046022100a881732c205a0b4b95669c00756fd91973450109a46f17d5a9d971b5e92b9aa40221008acefdca4e06c16b47ccad1c57c05912637e107096ba230c92b97187db79e19e",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "313239303536393337",
+          "sig" : "3044022033f016e51eef9b1136380cb8b84c6b38b107e24c6731bd07cb1c7f4a29f33a83022036b177bb8be94c8be67ff3a41fcc4d22b5c9eb377da713eb014ae01c64ca6dd7",
+          "result" : "valid"
         },
         {
           "tcId" : 327,
           "comment" : "special case hash",
-          "msg" : "31353635333235323833",
-          "sig" : "3044022004452f554bae819b42effb84ef44a9f1cb7e2d75b4ba9ff9b9cfffaddde3fd1b022061a3fbc5e73c350f2e3d85a7452cd231a3f3375fc11f5fe153b185f53b09c1d0",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32373438363536343338",
+          "sig" : "3045022100929413ee91f27454d74e91370a10a86fc98ac7305c8ab4ca59752bda3a7bfc370220483b47a26a0d7d2e6bd37d351d9ee37c5ec2a4686d884d78b6beb7f6b08c50f9",
+          "result" : "valid"
         },
         {
           "tcId" : 328,
           "comment" : "special case hash",
-          "msg" : "3233383236333432333530",
-          "sig" : "3045022005814f57f58efc7cb490119e584e635e6f0ad1c19fb5dc2edafda075bb55f98e0221009dd5c6e39009d67d965903ecffe08a851775cc1248cc19c0b77798282131b8f6",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37353833353032363034",
+          "sig" : "30450220578202c7d0abac93ca43dde3cb44414e5601c1eb557604cb9adb4bde0a12633b022100fb9a7412e307aee95ef4b53540571a21559414e5306794ab5182cfb229dab3e9",
+          "result" : "valid"
         },
         {
           "tcId" : 329,
           "comment" : "special case hash",
-          "msg" : "31343437383437303635",
-          "sig" : "3045022100dc1c4a46085e198843b1f01980cd5e4a1ff6f8e8ff7014397f0afd5b247fb0a0022038a13dc723ed90b30251d742b14733a03292ff26530a1ebcaf3d10862a6eff82",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32333237373534323739",
+          "sig" : "3045022046d45ad0bb75b8639d0e91d8450fc31887c211328a5784fc83b4cb7f5b962c1b022100d6751d13ede2079b7aa1d822bdb32d7f3cf00273a1ff03df90c0ec7c62a47568",
+          "result" : "valid"
         },
         {
           "tcId" : 330,
           "comment" : "special case hash",
-          "msg" : "3134323630323035353434",
-          "sig" : "304502201067667bf525734ca7f2510e36348fd9c2c9bccf032dfd571de6d45abd49361a022100fa762568d3a19e5a1d8ea65e00202a5b16f9afae56733a01f86e35378c558da4",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "373735353038353834",
+          "sig" : "3046022100abe84c941783d5ced284fea56341ecc68d6bdd3196d318fbd074641f8c885bd5022100bdea3c44d48e01aa40935c1c9723ff733199563440f26b4ecf0b444b0418d9f5",
+          "result" : "valid"
         },
         {
           "tcId" : 331,
           "comment" : "special case hash",
-          "msg" : "31393933383335323835",
-          "sig" : "3046022100e58d69dc56bc1031644847e3e046e2ea845a515d969d07ea1aa53aea5bd92fa1022100bfe50b80f7c512f5ab521fe7e1a131045fde78d4de826c91573baaba1e35ca97",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3137393832363438333832",
+          "sig" : "3045022005277cdbf491e336fe81be24e393a161a4fb89112c9ffed1ee6649c406713408022100ab6934332e68e108bb0484d21c457dcf381a620c3a4712fdbfeb658a3fafd60c",
+          "result" : "valid"
         },
         {
           "tcId" : 332,
           "comment" : "special case hash",
-          "msg" : "34323932313533353233",
-          "sig" : "3046022100fe79c6b8c14d0f23d426e3d157f1b541f6bb91bf29957ef97c55949c9ba48a350221009da112c4a4cf4b1ff490c426f6c8ff122183964a0de56f7336ab382dc9d10285",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32333936373737333635",
+          "sig" : "30450220293825737c8c14430ed10dbadd7da337275f9b61d1d26377f778ffaa00c139de022100cdddec267a8678c96829bf6c1d6f38322e119937cfd2fee01e9dc9525f43ed6b",
+          "result" : "valid"
         },
         {
           "tcId" : 333,
           "comment" : "special case hash",
-          "msg" : "34343539393031343936",
-          "sig" : "3045022045d4ed7e9edacb5a730944ab0037fba0a136ed9d0d26b2f4d4058554f148fa6f022100f136f15fd30cfe5e5548b3f4965c16a66a7c12904686abe12da777619212ae8c",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35393938313035383031",
+          "sig" : "304402202041fdd6111c45dfd29e750e082dcdadc9a584a8a2be46580fb0ba3b3dc658620220421824fe987e4172a0f8bbcb7bcd9e1b073b7742ed9f9df98f2a1a37cd374ce3",
+          "result" : "valid"
         },
         {
           "tcId" : 334,
           "comment" : "special case hash",
-          "msg" : "31333933393731313731",
-          "sig" : "304402204fb7c1727e40bae272f6143a50001b54b536f90233157896dbf845e263f2486302206fea5c924dca17519f6e502ef67efa08d39eb5cc3381266f0216864d2bd00a62",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3136363737383237303537",
+          "sig" : "30450220267941db660e046ab14e795669e002b852f7788447c53ebef46a2056978b5574022100d00183bcaf75bc11e37653f952f6a6537151c3aa0a1b9e4e41b004a29185395b",
+          "result" : "valid"
         },
         {
           "tcId" : 335,
           "comment" : "special case hash",
-          "msg" : "32333930363936343935",
-          "sig" : "30450220779aac665dd988054b04f2e9d483ca79179b3372b58ca00fe43520f44fcb4c32022100b4eca1182cd51f0abd3ea2268dcda49a807ad4116a583102047498aa863653f5",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "323036323134333632",
+          "sig" : "304402205dcd7f6814739d47f80a363b9414e6cbfb5f0846223888510abd5b3903d7ae09022043418f138bb3c857c0ad750ca8389ebcf3719cb389634ac54a91de9f18fd7238",
+          "result" : "valid"
         },
         {
           "tcId" : 336,
           "comment" : "special case hash",
-          "msg" : "3131343436303536323634",
-          "sig" : "3046022100db7ac6f65fb1c38d80064fd11861631237a09924b4eeca4e1569fa4b7d80ad24022100a38d178d37e13e1afa07a9d03da025d594461938a62a6c6744f5c8f7d7b7bb81",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36383432343936303435",
+          "sig" : "304502205e0e8cc0280409a0ce252da02b2424d2de3a52b406c3778932dbc60cb86c356702210093d25e929c5b00e950d89585ec6c01b6589ae0ec0af8a79c04df9e5b27b58bc5",
+          "result" : "valid"
         },
         {
           "tcId" : 337,
           "comment" : "special case hash",
-          "msg" : "363835303034373530",
-          "sig" : "3046022100c90043b4aadf795d870ac223f33acdbd1948c31afff059054dc99528c6503fa6022100829f67b312bb134f6954a23c611a7f7b5b2a69efced9c48db589ac0b4d3da827",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323639383937333231",
+          "sig" : "304502204fcf9c9d9ffbf4e0b98268c087071bffe0673bb8dcb32aa667f8a639c364ea47022100820db0730bee8227fc831643fcb8e2ef9c0f7059ce42da45cf74828effa8d772",
+          "result" : "valid"
         },
         {
           "tcId" : 338,
           "comment" : "special case hash",
-          "msg" : "3232323035333630363139",
-          "sig" : "3045022100fa16c0125b6615b90e81f7499804308a90179bf3fcff6a4b2695271c68b23ded02200d6cda5ce041dc5a5f319ad9c0de4927d0cf5e89e37b79216194413d42976d54",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31333837333234363932",
+          "sig" : "3046022100c60cd2e08248d58d1639b123633643c63f89aff611f998937ccb08c9113bcdca022100ac4bb470ce0164616dada7a173364ed3f9d16fd32c686136f904c99266fda17e",
+          "result" : "valid"
         },
         {
           "tcId" : 339,
           "comment" : "special case hash",
-          "msg" : "36323135363635313234",
-          "sig" : "304502201a4b5bd0f806549f46a3e71bfe412d6d89206017640ded66f3d0b2d9b26bec45022100aac5f74e3130264e01428570ee82ee47e245d160ed812ae252dedffd82e1ec2c",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp256r1",
-        "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "04b6e08b1bcc89e7fb0b84d7497e310553495be4877eccc4b3d6d79f7c68a0573431760fa1bcea4972759174ac1103bc6011985ccee251918d0573fbcb78969116",
-        "wx" : "0b6e08b1bcc89e7fb0b84d7497e310553495be4877eccc4b3d6d79f7c68a05734",
-        "wy" : "31760fa1bcea4972759174ac1103bc6011985ccee251918d0573fbcb78969116"
-      },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b6e08b1bcc89e7fb0b84d7497e310553495be4877eccc4b3d6d79f7c68a0573431760fa1bcea4972759174ac1103bc6011985ccee251918d0573fbcb78969116",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtuCLG8yJ5/sLhNdJfjEFU0lb5Id+\nzMSz1teffGigVzQxdg+hvOpJcnWRdKwRA7xgEZhczuJRkY0Fc/vLeJaRFg==\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-512",
-      "type" : "ECDSAVer",
-      "tests" : [
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34313138383837353336",
+          "sig" : "304502207cfdaf6f22c1c7668d7b6f56f8a7be3fdeeb17a7863539555bbfa899dd70c5f1022100cee151adc71e68483b95a7857a862ae0c5a6eee478d93d40ccc7d40a31dcbd90",
+          "result" : "valid"
+        },
         {
           "tcId" : 340,
-          "comment" : "k*G has a large x-coordinate",
-          "msg" : "313233343030",
-          "sig" : "303502104319055358e8617b0c46353d039cdaab022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "393838363036353435",
+          "sig" : "304402202270be7ee033a706b59746eab34816be7e15c8784061d5281060707a0abe0a7d022056a163341ee95e7e3c04294a57f5f7d24bf3c3c6f13ef2f161077c47bd27665d",
+          "result" : "valid"
         },
         {
           "tcId" : 341,
-          "comment" : "r too large",
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32343739313135383435",
+          "sig" : "3044022016b5d2bfcaba21167a69f7433d0c476b21ded37d84dc74ca401a3ecddb2752a8022062852cf97d89adfb0ebbe6f398ee641bfea8a2271580aac8a3d8326d8c6e0ef9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 342,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35303736383837333637",
+          "sig" : "3046022100d907eefa664115848b90c3d5baa0236f08eafaf81c0d52bb9d0f8acb57490847022100fd91bc45a76e31cdc58c4bfb3df27f6470d20b19f0fba6a77b6c8846650ed8a6",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 343,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "393838353036393637",
+          "sig" : "30450220048337b34f427e8774b3bf7c8ff4b1ae65d132ac8af94829bb2d32944579bb31022100bd6f8eab82213ccf80764644204bb6bf16c668729cdd31dd8596286c15686e8e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 344,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32373231333036313331",
+          "sig" : "3046022100b2bc46b7c44293557ab7ebeb0264924277193f87a25d94c924df1518ba7c7260022100abf1f6238ff696aaafaf4f0cbbe152c3d771c5bfc43f36d7e5f5235819d02c1a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 345,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323034313031363535",
+          "sig" : "3045022040d4b38a61232e654ffd08b91e18609851f4189f7bf8a425ad59d9cbb1b54c990221009e775a7bd0d934c3ed886037f5d3b356f60eda41191690566e99677d7aaf64f3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 346,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33313530363830393530",
+          "sig" : "3046022100ac8f64d7df8d9fea005744e3ac4af70aa3a38e5a0f3d069d85806a4f29710339022100c014e96decfef3857cc174f2c46ad0882bef0c4c8a17ce09441961e4ae8d2df3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 347,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31373237343630313033",
+          "sig" : "3044022041b3766f41a673a01e2c0cab5ceedbcec8d82530a393f884d72aa4e6685dea0a0220073a55dca2da577cafb40e12dd20bf8529a13a6acdf9a1c7d4b2048d60876cb3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 348,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3134353731343631323235",
+          "sig" : "304502201942755aa8128382cd8e35a4350c22cc45ba5704d99e8a240970df11956ad866022100f64cf1e0816cf7ac5044f73ba938e142ef3305cb09becb80a0a5b9ad7ba3eb07",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 349,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34313739353136303930",
+          "sig" : "3045022051aba4ff1c7ddf17e0632ab71684d8de6dc700219ef346cb28ce9dafc3565b3b022100b6aaebe1af0ad01f07a68bf1cf57f9d6040b43c14b7eb8238542760e32ce3b0c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 350,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35383932373133303534",
+          "sig" : "304502210091efbfcc731650e9f004c38b71db146c17bf871c82c4e87716f7ff2f7f9e51d00220089ea631a7c5f05311c521d21ba798b5174881f0fd8095fb3a77515913efb6e0",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 351,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33383936313832323937",
+          "sig" : "304502204a7e47bd281ea09b9e3a32934c7a969e1f788f978b41585989f4689e804663fb022100e65f6bd702403cbbed7f8ad0045f331d4a96fbf8c43f71f11615b7d1b9153b7f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 352,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "38323833333436373332",
+          "sig" : "3046022100c795f5da86e10a604d4f94bf7cac381c73edad1461d66929e53aa57ca294e89f022100bae784ab6c7b58332ee05e7d54169edf55ce45f030e71ae8df63969fb327a10c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 353,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33333636393734383931",
+          "sig" : "3046022100ea68b24843b225f505e01c0e608b20b4d93e8faf6b9cf70cf8f9134a80e7b668022100a3abc044b4728f80fe414bdc66f032b262356720547bec7729fad94151c6adc7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 354,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32313939313533323239",
+          "sig" : "3046022100bfe7502140c57a24a77edc3d9b3c4bc11d21bdb0b196977b7f2b13ac973ad697022100947a01da9731849d72b67ef7bc40b012480fd389895aad1f6b1cdbeab3b93b8d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 355,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35363030333136383232",
+          "sig" : "304402203434ee1142740a0ab8623b97fc8dc2567eda45dadf6039b45c448819e840cf3002203c0fac0487841997202c29f3bf2df540b115b29dc619160d52203d4a1fd4b9f7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 356,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "383639363531363935",
+          "sig" : "304502205338500e23ba96a0adc6ef84932e25fbad7435d9f70eb7f476c6912de12e33c8022100a002f5583ea8c0d7fb17136d0ee0415acf629879ce6b01ac52e3ecd7772a3704",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 357,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36353833393236333732",
+          "sig" : "304402204ff2d4e31f4180de6901d2d20341d12387c9c55f4cf003a742f049b84af6fe0502200312f38771414555fa5ed2817dcc629a8c7cf69d306300e87bc167278ec3ef37",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 358,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3133323035303135373235",
+          "sig" : "3044022051d665bad5f2d6306c6bbfe1f27555887670061d4df36ec9f4ce6cdfaf9ea7ac02202905e43f6207ee93df35a2e9fb9bc8098c448ae98a14e4ad1ebaea5d56b6e493",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 359,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35303835333330373931",
+          "sig" : "3046022100b804e0235f135aba7b7531b6831f26cc9fb77d3f83854957431be20706b813690221009d317fd08e4e0467617db819cde1d7d4d74da489b2bce4db055ea01eccfafcf2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 360,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37383636383133313139",
+          "sig" : "30450221008ab50ef3660ccb6af34c78e795ded6b256ffca5c94f249f3d907fb65235ef680022049d5aaeae5a6d0c15b286e428b5e720cf37a822ede445baa143ffae69aba91b8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 361,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32303832353339343239",
+          "sig" : "30440220571b9c46a47c5cc53a574c196c3fb07f3510c0f4443b9f2fe781252c24d343de022068a9aebd50ff165c89b5b9cb6c1754191958f360b4d2851a481a3e1106ee7809",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 362,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130303635393536363937",
+          "sig" : "304502204cb7817b04dc73be60d3711803bc10687a6e3f4ab79c4c1a4e9d63a73174d4eb022100ce398d2d6602d2af58a64042f830bf774aee18209d6fb5c743b6a6e437826b98",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 363,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33303234313831363034",
+          "sig" : "30450220684399c6cd6ebb1c5d5efb0d78dce40ebd48d9d944eb6548c9ce68d7fdc82229022100cf25c8e427fae359bfe60fa02964f4c9b8d6db54612e05c78c341f0a8c52d0b5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 364,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37373637383532383734",
+          "sig" : "3045022020b7b36d5bc76fa182ca27152a99a956e6a0880000694296e31af98a7312d04b022100eeeabc5521f9856e920eb7d29ed7e4042f178ff706dff8eeb24b429e3b63402a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 365,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "353434313939393734",
+          "sig" : "304402206b65c95e8e121d2e6ee506cfd62cb88e0bfb3589da40876898ef66c43982aca9022009642c05ad619b4402fd297eb57e29cca5c2eb6823931ba82de32d7c652ba73e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 366,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35383433343830333931",
+          "sig" : "3044022067c74cbf5ea4b777bf521ace099f4f094d8f58900e15e67e1b4bd399056629ed02203d2884655c49b8b5f64e802a054e7bf09b0fc80ca18ebf927b82e58bb4a00400",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 367,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "373138383932363239",
+          "sig" : "3045022079a5e40da5cf34c4c39adf7dfc5d454995a250314ebd212b5c8e3f4e6f875feb022100b268920e403ba17828ff271938a6558a5b2dd000229f8edb4a9d9f9b6ac1b472",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 368,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31373433323233343433",
+          "sig" : "3045022100c8b13006c3a51a322fff9321761b01de134f526be582b22e19693c443fc9fe46022034e7f60179c6162ab980fcd58f173b0e6c30b524d35c67921677522dcef843a1",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 369,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32343036303035393336",
+          "sig" : "304502203513db745489a487c88a6cedf8795b640f8f71578397bdabd6cc586c25bd66ad02210099a72cd3f0ca6c799149283ca0af37f86b88200d0c905bd3c9f1b859e55b1659",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 370,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31363134303336393838",
+          "sig" : "304402203a6386afb08f7ff8140b5a270f764e8706ef2830fb177446f7b4eeb8a25aac6402204b70854b38c29245b2b980eba10ea936c68a38c1da5255ce2386db23afc7c06a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 371,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32303935343235363835",
+          "sig" : "3046022100b8fc54a8a6be3c55e99c06f99ccdcce7af5c18a3c5829726a870cc1068458f64022100cc7237c39c8e6a4a1c8c62f5f88636549c7410798b89684c502c3adfe5fb7ad2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 372,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31303038303938393833",
+          "sig" : "3045022047b460851e5607f2021626635c565a63f78f558795e1b330d09115970dbbb8ab022100a6a9f4f213e08d3c736d3e1c44a35140cb107619f265a5b13608ed729fd6d894",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 373,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31353734313437393237",
+          "sig" : "30450221008cfda4f7a65864ebbea3144863da9b075c07b5b42cb4569643ddfd70dd753b190220595784b1ab217874b82b9585521f8090b9f6322884ab7a620464f51cf846c5b7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 374,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32383636373731353232",
+          "sig" : "304402204cd6a45bd7c8bf0edbdf073dbf1f746234cbbca31ec20b526b077c9f480096e702207cf97ae0d33f50b73a5d7adf8aa4eeeb6ff10f89a8794efe1d874e23299c1b3d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 375,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31363934323830373837",
+          "sig" : "304402202e233f4df8ffebeaec64842b23cce161c80d303b016eca562429b227ae2b58ec022046b6b56adec82f82b54daa6a5fca286740a1704828052072a5f0bc8c7b884242",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 376,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "39393231363932353638",
+          "sig" : "30440220549f658d4a3f98233a2c93bd5b1a52d64af10815ae60becb4139cac822b579c3022027bdddf0dbcf374a2aec8accc47a8ac897f8d1823dda8eb2052590970b39ce2a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 377,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131363039343339373938",
+          "sig" : "30450221009fabcc1e5fd965226902f594559e231369e584453974e74f49d7d762e134fb9d0220293cccc510793bac45ce5da2bb6c9e906437f59435ca206655f74b625df07c7c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 378,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37313836313632313030",
+          "sig" : "304502202e5c140fd6f5f823addc8088ffaae967e7f4897274316769561dfb31435825d9022100eda47327d7cfae1daa344ff5582a467bd18eb9f01caeab9c6da3c0cc89df6713",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 379,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323934333437313737",
+          "sig" : "304402204c11e3b7efbe3908ad2118e54d7d34d6c6eb4570bf7fdb11a7679fe93afa254c0220712e90f421836e542dac49d10bb39db4a98b2735b6336d8a3c392f3b90e60bbe",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 380,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3138353134343535313230",
+          "sig" : "3045022100dfb4619303f4ff689563d2275069fac44d63ea3c3b18f4fb1ac805d7df3d12ec022068e37b846583901db256329f9cf64f40c416fba50dcb9be333a3e29c76ae32db",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 381,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "343736303433393330",
+          "sig" : "3045022100e70e8e17bd758ff0c48f91cb2c53d293f0f5ae82eb9dfe76ab98f9b064278635022021dde32cb0389cad7bdf676d9b9b7d25bb034ad25a55ea71ee7ee26a18359dd2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 382,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32353637333738373431",
+          "sig" : "30440220421397ecae30617a5a6081ad1badf6ce9d9d4cb2afdabf1f900e7fdb7fb0af5a022057ca89dc22801c75fdbefdaeca65c675625f94de7d635062b08ed308df5762cc",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 383,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35373339393334393935",
+          "sig" : "304502200610c08076909bb722fba105c23eac8f66b4db1d58f66a882fc90d59acdec8e0022100af59e8d570761cac589d49f11c884007f7ac1eea1a44c6f3fdad1d542187d25e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 384,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33343738333636313339",
+          "sig" : "3045022059a1181cab0ee8ce94ab2b5ab4f4b13a422e38efe69f634bf947485a5b9ea49c0221009b3c913d98a4ab15f6a39f1802b8f2d28559aa1f8d03a3a88df00c89dc293a97",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 385,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "363439303532363032",
+          "sig" : "30460221008cae6c4dfbf901bd66ab82541011fa15c8e90e2c18c01bd881acaa2b63cb587b022100a86acf943f29cef91d1b66a7de5547df6cdfc45dd7bef816dcb8de9f5a425d2d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 386,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34373633383837343936",
+          "sig" : "30450221008b00c74b86474d782eac9974aea606d8f7ee78c79597e15687021f5991e86acd0220309dfe3686648eae104e87b3e9b5616a3ad479ca4f0b558ae4f1e5ab3115346a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 387,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "353739303230303830",
+          "sig" : "30450220433a915504c977809634a36fcf4480e4c8069fc127d201d30dfdb1f423c95fd4022100bcb1b89aafd50a1766b09741fc6a9a96e744ae9826d839bf85ffb50a91981773",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 388,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35333434373837383438",
+          "sig" : "304502204b69abd2b39840a545cdd4a72d384234580e2fd938b7091d0ecdb562780857db022100fdab9957119e0a4092af82f6cc29f3c8a692671ec86efb0a03c1112a0a1e0467",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 389,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3139323636343130393230",
+          "sig" : "3045022100dab9d3686c28363ad017b4a2b36d35bf2eb80633613d44deb9501d42a3efbd3802201392a562d79f9ab19014e4f7e2f2668259f3720a76c120d4a3c3964e880f7679",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 390,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33373033393135373035",
+          "sig" : "3045022023f94e47b440ce379b74c9311232b19a64e3e7c9b90da34b0c1c3f3d7af28105022100e1425903b1479c2ce18b108a6d1ec8b7a4f0f657dedb00de3a3ceea7fdeee9be",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 391,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3831353435373730",
+          "sig" : "30450221009d706a8fa85d15bd0c3492c6672dfe529f4073b217b3947b5b2cfd61f87ccb7102206aaaaf369f82a0e542f72ded7d7eb90c8314ffa613a0ea81da1c8393dbae2bac",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 392,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "313935353330333737",
+          "sig" : "3046022100ac77918c4085c8a7ce5020b00c315629aee053a445cb4661eb50f6b62a47da29022100df2aea2b9c11a6ce39d3cd9e1faf4a53057e0b1b2e48a324be9e773203fe9fbb",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 393,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31323637383130393033",
+          "sig" : "30460221009db2dbd2935f147fae7f6a95c8e2307bd8537c3d96eb732ad6d5ebdd89bc754e02210093a9ab99d2de9d08fe0a61e26c8fe1ebbf88726e4b69d551b57d15f0ae16df5a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 394,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131313830373230383135",
+          "sig" : "30440220769f70093939afbd1fa15873decfa803ca523ace8040280ba78cf833497722bc0220369875aba5e1ced5a4ca8444ec9399a38038b00e153a0ae34d9b3c9781447eea",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 395,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "38333831383639323930",
+          "sig" : "3045022026e5182b9822550ad52f46ad80781d6bef3d110a204db5e58a0746f796982200022100a9418e76029ced0cf78a571a9e59ad04086e91f70e6813981bb33c1dee891165",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 396,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33313331323837323737",
+          "sig" : "3046022100e7bd6aefcf7b27e1f3fadbe713f9adb3d23398e88200cd2e94989c9d12e921770221009583e0de3b76f8d4b1e634a81cbc34af54e2f8599f3684ce48d372760c8204c4",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 397,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3134333331393236353338",
+          "sig" : "30450221008638ed7eaa83609a01a6af9c52ec9bfddda90442b1e6031d61cfa22e48b2e1e2022020c284d596f71c6c8df732f5a5a2006302301e1a792e2b39663d93a9760762d2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 398,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "333434393038323336",
+          "sig" : "3044022061d924307a96180b06383608ba91674e15c3ea06ff2534412b93a587dde649c1022059b84aa2115b2547edac88088ca6313e9fbe1ca6a361c7e57938f9dde3f4349c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 399,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36383239383335393239",
+          "sig" : "30450220424fcfc3fd63d128c2eb125e88c7fe5d283b63470a786b82783edbb8a0b7a6d7022100b11548c2cd7fce9d44e795ca51af0b2f6a5180e9c9be0314007ed9e7f4bbe5e9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 400,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33343435313538303233",
+          "sig" : "3045022100a5f747ae6290fa9582c6ce8d5608621d495f061551bc4531bacba586a563b184022062faf8f92291e12812835b3f1d43c967bceb885b110bd06e5a68e2d74781ae2b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 401,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3132363937393837363434",
+          "sig" : "3045022100b731dc0d92c2cc7a605d78233f7814699bdf1cab2df297b6844eec4015af8ea0022039b1a0cc88eb85bcdc356b3620c51f1298c60aec5306b107e900ffdba049dd6f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 402,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "333939323432353533",
+          "sig" : "3046022100ef73c4fa322da39fb6503bab6b66b64d241056afbcd6908f84b61ccbbe890433022100f1ef85413e5764aa58a3128ccfcf388324fe5340e5edf8d0135ae76786ce415b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 403,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31363031393737393737",
+          "sig" : "30450220694cd30e2ad0182579331474b271ee2d48723bc8415dc6513873586ce705b76b022100c5ac0c0ed5a4017d110cb45d63aa955dc7dc5ce23e7965c5397c3ff46a884636",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 404,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130383738373535313435",
+          "sig" : "3046022100f38b2236be3024e10b894ffb1cc68d0bb8d4cf0fcd2cfc1779f8883765d3cd96022100da69cd0b74c25566d60a486edd559fc39d569fb2751445a4798df8a36891802c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 405,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37303034323532393939",
+          "sig" : "3046022100a881732c205a0b4b95669c00756fd91973450109a46f17d5a9d971b5e92b9aa40221008acefdca4e06c16b47ccad1c57c05912637e107096ba230c92b97187db79e19e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 406,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31353635333235323833",
+          "sig" : "3044022004452f554bae819b42effb84ef44a9f1cb7e2d75b4ba9ff9b9cfffaddde3fd1b022061a3fbc5e73c350f2e3d85a7452cd231a3f3375fc11f5fe153b185f53b09c1d0",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 407,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3233383236333432333530",
+          "sig" : "3045022005814f57f58efc7cb490119e584e635e6f0ad1c19fb5dc2edafda075bb55f98e0221009dd5c6e39009d67d965903ecffe08a851775cc1248cc19c0b77798282131b8f6",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 408,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31343437383437303635",
+          "sig" : "3045022100dc1c4a46085e198843b1f01980cd5e4a1ff6f8e8ff7014397f0afd5b247fb0a0022038a13dc723ed90b30251d742b14733a03292ff26530a1ebcaf3d10862a6eff82",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 409,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3134323630323035353434",
+          "sig" : "304502201067667bf525734ca7f2510e36348fd9c2c9bccf032dfd571de6d45abd49361a022100fa762568d3a19e5a1d8ea65e00202a5b16f9afae56733a01f86e35378c558da4",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 410,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31393933383335323835",
+          "sig" : "3046022100e58d69dc56bc1031644847e3e046e2ea845a515d969d07ea1aa53aea5bd92fa1022100bfe50b80f7c512f5ab521fe7e1a131045fde78d4de826c91573baaba1e35ca97",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 411,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34323932313533353233",
+          "sig" : "3046022100fe79c6b8c14d0f23d426e3d157f1b541f6bb91bf29957ef97c55949c9ba48a350221009da112c4a4cf4b1ff490c426f6c8ff122183964a0de56f7336ab382dc9d10285",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 412,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34343539393031343936",
+          "sig" : "3045022045d4ed7e9edacb5a730944ab0037fba0a136ed9d0d26b2f4d4058554f148fa6f022100f136f15fd30cfe5e5548b3f4965c16a66a7c12904686abe12da777619212ae8c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 413,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31333933393731313731",
+          "sig" : "304402204fb7c1727e40bae272f6143a50001b54b536f90233157896dbf845e263f2486302206fea5c924dca17519f6e502ef67efa08d39eb5cc3381266f0216864d2bd00a62",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 414,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32333930363936343935",
+          "sig" : "30450220779aac665dd988054b04f2e9d483ca79179b3372b58ca00fe43520f44fcb4c32022100b4eca1182cd51f0abd3ea2268dcda49a807ad4116a583102047498aa863653f5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 415,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131343436303536323634",
+          "sig" : "3046022100db7ac6f65fb1c38d80064fd11861631237a09924b4eeca4e1569fa4b7d80ad24022100a38d178d37e13e1afa07a9d03da025d594461938a62a6c6744f5c8f7d7b7bb81",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 416,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "363835303034373530",
+          "sig" : "3046022100c90043b4aadf795d870ac223f33acdbd1948c31afff059054dc99528c6503fa6022100829f67b312bb134f6954a23c611a7f7b5b2a69efced9c48db589ac0b4d3da827",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 417,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3232323035333630363139",
+          "sig" : "3045022100fa16c0125b6615b90e81f7499804308a90179bf3fcff6a4b2695271c68b23ded02200d6cda5ce041dc5a5f319ad9c0de4927d0cf5e89e37b79216194413d42976d54",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 418,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36323135363635313234",
+          "sig" : "304502201a4b5bd0f806549f46a3e71bfe412d6d89206017640ded66f3d0b2d9b26bec45022100aac5f74e3130264e01428570ee82ee47e245d160ed812ae252dedffd82e1ec2c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 419,
+          "comment" : "Signature generated without truncating the hash",
+          "flags" : [
+            "Untruncatedhash"
+          ],
           "msg" : "313233343030",
-          "sig" : "3046022100ffffffff00000001000000000000000000000000fffffffffffffffffffffffc022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3045022100f8e272234b51475ec4c6f327562a6e5c9080a96225e88b2e5f72a8eecbd41ab40220516b91617fc39e3141b3bc769f6a3b2e468e687f50bdc29e19088af62d203f4b",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
+        "uncompressed" : "04b6e08b1bcc89e7fb0b84d7497e310553495be4877eccc4b3d6d79f7c68a0573431760fa1bcea4972759174ac1103bc6011985ccee251918d0573fbcb78969116",
+        "wx" : "00b6e08b1bcc89e7fb0b84d7497e310553495be4877eccc4b3d6d79f7c68a05734",
+        "wy" : "31760fa1bcea4972759174ac1103bc6011985ccee251918d0573fbcb78969116"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b6e08b1bcc89e7fb0b84d7497e310553495be4877eccc4b3d6d79f7c68a0573431760fa1bcea4972759174ac1103bc6011985ccee251918d0573fbcb78969116",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEtuCLG8yJ5/sLhNdJfjEFU0lb5Id+\nzMSz1teffGigVzQxdg+hvOpJcnWRdKwRA7xgEZhczuJRkY0Fc/vLeJaRFg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 420,
+          "comment" : "k*G has a large x-coordinate",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "303502104319055358e8617b0c46353d039cdaab022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 421,
+          "comment" : "r too large",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046022100ffffffff00000001000000000000000000000000fffffffffffffffffffffffc022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
         "uncompressed" : "043590c6a10353d669bc94d8e2ff9e14bbeed4a7f45b887255ab7e37b676387bb615fc6f97ce39a3874c2b34cc571889abfa0a706c2cfb0e5a4750cc25690696f8",
         "wx" : "3590c6a10353d669bc94d8e2ff9e14bbeed4a7f45b887255ab7e37b676387bb6",
         "wy" : "15fc6f97ce39a3874c2b34cc571889abfa0a706c2cfb0e5a4750cc25690696f8"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043590c6a10353d669bc94d8e2ff9e14bbeed4a7f45b887255ab7e37b676387bb615fc6f97ce39a3874c2b34cc571889abfa0a706c2cfb0e5a4750cc25690696f8",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENZDGoQNT1mm8lNji/54Uu+7Up/Rb\niHJVq343tnY4e7YV/G+Xzjmjh0wrNMxXGImr+gpwbCz7DlpHUMwlaQaW+A==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043590c6a10353d669bc94d8e2ff9e14bbeed4a7f45b887255ab7e37b676387bb615fc6f97ce39a3874c2b34cc571889abfa0a706c2cfb0e5a4750cc25690696f8",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENZDGoQNT1mm8lNji/54Uu+7Up/Rb\niHJVq343tnY4e7YV/G+Xzjmjh0wrNMxXGImr+gpwbCz7DlpHUMwlaQaW+A==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 342,
+          "tcId" : 422,
           "comment" : "r,s are large",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3046022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254f022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc63254e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04369e96402f2cfd1a37b3acbdecfc562862dbca944a0f12d7aaacb8d325d7650aa723621922be2bdac9186290fdcdda028d94437966507d93f2fc1f5c887fdedb",
         "wx" : "369e96402f2cfd1a37b3acbdecfc562862dbca944a0f12d7aaacb8d325d7650a",
-        "wy" : "0a723621922be2bdac9186290fdcdda028d94437966507d93f2fc1f5c887fdedb"
+        "wy" : "00a723621922be2bdac9186290fdcdda028d94437966507d93f2fc1f5c887fdedb"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004369e96402f2cfd1a37b3acbdecfc562862dbca944a0f12d7aaacb8d325d7650aa723621922be2bdac9186290fdcdda028d94437966507d93f2fc1f5c887fdedb",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENp6WQC8s/Ro3s6y97PxWKGLbypRK\nDxLXqqy40yXXZQqnI2IZIr4r2skYYpD9zdoCjZRDeWZQfZPy/B9ciH/e2w==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004369e96402f2cfd1a37b3acbdecfc562862dbca944a0f12d7aaacb8d325d7650aa723621922be2bdac9186290fdcdda028d94437966507d93f2fc1f5c887fdedb",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENp6WQC8s/Ro3s6y97PxWKGLbypRK\nDxLXqqy40yXXZQqnI2IZIr4r2skYYpD9zdoCjZRDeWZQfZPy/B9ciH/e2w==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 343,
+          "tcId" : 423,
           "comment" : "r and s^-1 have a large Hamming weight",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100909135bdb6799286170f5ead2de4f6511453fe50914f3df2de54a36383df8dd4",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0427a0a80ea2e1aa798ea9bcc3aedbf01ab78e49c9ec2ad0e08a0429a0e1db4d0d32a8ee7bee9d0a40014e484f34a92bd6f33fe63624ea9579657441ac79666e7f",
         "wx" : "27a0a80ea2e1aa798ea9bcc3aedbf01ab78e49c9ec2ad0e08a0429a0e1db4d0d",
         "wy" : "32a8ee7bee9d0a40014e484f34a92bd6f33fe63624ea9579657441ac79666e7f"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000427a0a80ea2e1aa798ea9bcc3aedbf01ab78e49c9ec2ad0e08a0429a0e1db4d0d32a8ee7bee9d0a40014e484f34a92bd6f33fe63624ea9579657441ac79666e7f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJ6CoDqLhqnmOqbzDrtvwGreOScns\nKtDgigQpoOHbTQ0yqO577p0KQAFOSE80qSvW8z/mNiTqlXlldEGseWZufw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000427a0a80ea2e1aa798ea9bcc3aedbf01ab78e49c9ec2ad0e08a0429a0e1db4d0d32a8ee7bee9d0a40014e484f34a92bd6f33fe63624ea9579657441ac79666e7f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJ6CoDqLhqnmOqbzDrtvwGreOScns\nKtDgigQpoOHbTQ0yqO577p0KQAFOSE80qSvW8z/mNiTqlXlldEGseWZufw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 344,
+          "tcId" : 424,
           "comment" : "r and s^-1 have a large Hamming weight",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022027b4577ca009376f71303fd5dd227dcef5deb773ad5f5a84360644669ca249a5",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "049cff61712d4bc5b3638341e6e0a576a8098c9c6d3f198d389c4669f398dc0867f3b9e09f567f3dfd9c4d2c1163e82beadf16c76e8f9d7a64673800ea76fa1e59",
-        "wx" : "09cff61712d4bc5b3638341e6e0a576a8098c9c6d3f198d389c4669f398dc0867",
-        "wy" : "0f3b9e09f567f3dfd9c4d2c1163e82beadf16c76e8f9d7a64673800ea76fa1e59"
+        "wx" : "009cff61712d4bc5b3638341e6e0a576a8098c9c6d3f198d389c4669f398dc0867",
+        "wy" : "00f3b9e09f567f3dfd9c4d2c1163e82beadf16c76e8f9d7a64673800ea76fa1e59"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049cff61712d4bc5b3638341e6e0a576a8098c9c6d3f198d389c4669f398dc0867f3b9e09f567f3dfd9c4d2c1163e82beadf16c76e8f9d7a64673800ea76fa1e59",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnP9hcS1LxbNjg0Hm4KV2qAmMnG0/\nGY04nEZp85jcCGfzueCfVn89/ZxNLBFj6Cvq3xbHbo+demRnOADqdvoeWQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200049cff61712d4bc5b3638341e6e0a576a8098c9c6d3f198d389c4669f398dc0867f3b9e09f567f3dfd9c4d2c1163e82beadf16c76e8f9d7a64673800ea76fa1e59",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEnP9hcS1LxbNjg0Hm4KV2qAmMnG0/\nGY04nEZp85jcCGfzueCfVn89/ZxNLBFj6Cvq3xbHbo+demRnOADqdvoeWQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 345,
+          "tcId" : 425,
           "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3006020105020101",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04d9117cae81295e82682fa387991e668e1570e0e90100bf4e63964822460561bc19f96b1787ed15769929978ba3dd7f68c97adf5c16f671e756cd8f08c49456ca",
-        "wx" : "0d9117cae81295e82682fa387991e668e1570e0e90100bf4e63964822460561bc",
+        "wx" : "00d9117cae81295e82682fa387991e668e1570e0e90100bf4e63964822460561bc",
         "wy" : "19f96b1787ed15769929978ba3dd7f68c97adf5c16f671e756cd8f08c49456ca"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d9117cae81295e82682fa387991e668e1570e0e90100bf4e63964822460561bc19f96b1787ed15769929978ba3dd7f68c97adf5c16f671e756cd8f08c49456ca",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2RF8roEpXoJoL6OHmR5mjhVw4OkB\nAL9OY5ZIIkYFYbwZ+WsXh+0Vdpkpl4uj3X9oyXrfXBb2cedWzY8IxJRWyg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d9117cae81295e82682fa387991e668e1570e0e90100bf4e63964822460561bc19f96b1787ed15769929978ba3dd7f68c97adf5c16f671e756cd8f08c49456ca",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE2RF8roEpXoJoL6OHmR5mjhVw4OkB\nAL9OY5ZIIkYFYbwZ+WsXh+0Vdpkpl4uj3X9oyXrfXBb2cedWzY8IxJRWyg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 346,
+          "tcId" : 426,
           "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3006020105020103",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "048cfcbad3524c22b992529f943e3ce0b2d126085501d6e3edd4f1dbf74bdca21eafb259b1ba179cac09e8e43a88c8a09e7339910a7c941932e44b8be56f1fccde",
-        "wx" : "08cfcbad3524c22b992529f943e3ce0b2d126085501d6e3edd4f1dbf74bdca21e",
-        "wy" : "0afb259b1ba179cac09e8e43a88c8a09e7339910a7c941932e44b8be56f1fccde"
+        "wx" : "008cfcbad3524c22b992529f943e3ce0b2d126085501d6e3edd4f1dbf74bdca21e",
+        "wy" : "00afb259b1ba179cac09e8e43a88c8a09e7339910a7c941932e44b8be56f1fccde"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048cfcbad3524c22b992529f943e3ce0b2d126085501d6e3edd4f1dbf74bdca21eafb259b1ba179cac09e8e43a88c8a09e7339910a7c941932e44b8be56f1fccde",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjPy601JMIrmSUp+UPjzgstEmCFUB\n1uPt1PHb90vcoh6vslmxuhecrAno5DqIyKCeczmRCnyUGTLkS4vlbx/M3g==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048cfcbad3524c22b992529f943e3ce0b2d126085501d6e3edd4f1dbf74bdca21eafb259b1ba179cac09e8e43a88c8a09e7339910a7c941932e44b8be56f1fccde",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjPy601JMIrmSUp+UPjzgstEmCFUB\n1uPt1PHb90vcoh6vslmxuhecrAno5DqIyKCeczmRCnyUGTLkS4vlbx/M3g==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 347,
+          "tcId" : 427,
           "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3006020105020105",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04fbb51127e1f1b6a38e9fe9a2544614edb8e43ad7cd8c56f14b3235dda3bc11179abd9753a9e647e9340c395fb2b91384d6d33fcb6456214350b6f3fa00f4364c",
-        "wx" : "0fbb51127e1f1b6a38e9fe9a2544614edb8e43ad7cd8c56f14b3235dda3bc1117",
-        "wy" : "09abd9753a9e647e9340c395fb2b91384d6d33fcb6456214350b6f3fa00f4364c"
+        "wx" : "00fbb51127e1f1b6a38e9fe9a2544614edb8e43ad7cd8c56f14b3235dda3bc1117",
+        "wy" : "009abd9753a9e647e9340c395fb2b91384d6d33fcb6456214350b6f3fa00f4364c"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fbb51127e1f1b6a38e9fe9a2544614edb8e43ad7cd8c56f14b3235dda3bc11179abd9753a9e647e9340c395fb2b91384d6d33fcb6456214350b6f3fa00f4364c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+7URJ+HxtqOOn+miVEYU7bjkOtfN\njFbxSzI13aO8EReavZdTqeZH6TQMOV+yuROE1tM/y2RWIUNQtvP6APQ2TA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fbb51127e1f1b6a38e9fe9a2544614edb8e43ad7cd8c56f14b3235dda3bc11179abd9753a9e647e9340c395fb2b91384d6d33fcb6456214350b6f3fa00f4364c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE+7URJ+HxtqOOn+miVEYU7bjkOtfN\njFbxSzI13aO8EReavZdTqeZH6TQMOV+yuROE1tM/y2RWIUNQtvP6APQ2TA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 348,
+          "tcId" : 428,
           "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3006020105020106",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04cba74b6b024a29a173df9abb9593294a6b8e83efd7f48d67311dcfb557ca80b8e68417e9afb0494417a568129701137effb2174b5c50bb8adf716a4a5ca95d0c",
+        "wx" : "00cba74b6b024a29a173df9abb9593294a6b8e83efd7f48d67311dcfb557ca80b8",
+        "wy" : "00e68417e9afb0494417a568129701137effb2174b5c50bb8adf716a4a5ca95d0c"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cba74b6b024a29a173df9abb9593294a6b8e83efd7f48d67311dcfb557ca80b8e68417e9afb0494417a568129701137effb2174b5c50bb8adf716a4a5ca95d0c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEy6dLawJKKaFz35q7lZMpSmuOg+/X\n9I1nMR3PtVfKgLjmhBfpr7BJRBelaBKXARN+/7IXS1xQu4rfcWpKXKldDA==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 429,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020106020101",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04ea4518f4df8b277eb5ad16cb6bf851e841cedccd99c95c28f681c18a643d15ce4077c637f77b4da58ac8c9ab59523ebb0619d97dca2df1cb8a457b160af1adb9",
+        "wx" : "00ea4518f4df8b277eb5ad16cb6bf851e841cedccd99c95c28f681c18a643d15ce",
+        "wy" : "4077c637f77b4da58ac8c9ab59523ebb0619d97dca2df1cb8a457b160af1adb9"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ea4518f4df8b277eb5ad16cb6bf851e841cedccd99c95c28f681c18a643d15ce4077c637f77b4da58ac8c9ab59523ebb0619d97dca2df1cb8a457b160af1adb9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE6kUY9N+LJ361rRbLa/hR6EHO3M2Z\nyVwo9oHBimQ9Fc5Ad8Y393tNpYrIyatZUj67BhnZfcot8cuKRXsWCvGtuQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 430,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020106020103",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04e148d9966e5b9b536380927de72e59a6655e7070091b25b47b44fdb2a8bd390f35259cd39d6f6ed62340d12152b0fdc1702be5ebdb8f0061d6607b05ca3d7b1b",
+        "wx" : "00e148d9966e5b9b536380927de72e59a6655e7070091b25b47b44fdb2a8bd390f",
+        "wy" : "35259cd39d6f6ed62340d12152b0fdc1702be5ebdb8f0061d6607b05ca3d7b1b"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e148d9966e5b9b536380927de72e59a6655e7070091b25b47b44fdb2a8bd390f35259cd39d6f6ed62340d12152b0fdc1702be5ebdb8f0061d6607b05ca3d7b1b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE4UjZlm5bm1NjgJJ95y5ZpmVecHAJ\nGyW0e0T9sqi9OQ81JZzTnW9u1iNA0SFSsP3BcCvl69uPAGHWYHsFyj17Gw==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 431,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020106020106",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04a61edf1f6e011a27b9fb4e43ca2ef58c1dd6a7f5cf9e89a678d87b2f9a6d8a80b6e5624c5ef144000bde93ccec7ec58b3c646b42e3d92806b281f35c62c39ccf",
+        "wx" : "00a61edf1f6e011a27b9fb4e43ca2ef58c1dd6a7f5cf9e89a678d87b2f9a6d8a80",
+        "wy" : "00b6e5624c5ef144000bde93ccec7ec58b3c646b42e3d92806b281f35c62c39ccf"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a61edf1f6e011a27b9fb4e43ca2ef58c1dd6a7f5cf9e89a678d87b2f9a6d8a80b6e5624c5ef144000bde93ccec7ec58b3c646b42e3d92806b281f35c62c39ccf",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEph7fH24BGie5+05Dyi71jB3Wp/XP\nnommeNh7L5ptioC25WJMXvFEAAvek8zsfsWLPGRrQuPZKAaygfNcYsOczw==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 432,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020106020107",
+          "result" : "valid"
         },
         {
-          "tcId" : 349,
+          "tcId" : 433,
           "comment" : "r is larger than n",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
-          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632556020106",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3026022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc632557020107",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "04dc80905500d7d74ed47de5224d8734545f22b776ae086cabfffe6ce58d5ef994dc3067ce7d2cdfa9f4d5ace296b752814acc69c19a932d8b14077927901de3bf",
-        "wx" : "0dc80905500d7d74ed47de5224d8734545f22b776ae086cabfffe6ce58d5ef994",
-        "wy" : "0dc3067ce7d2cdfa9f4d5ace296b752814acc69c19a932d8b14077927901de3bf"
+        "uncompressed" : "04a1ff55a03cd061f2408c0ada1ae9f7197f53ef84190564fd3dace78839bc6420178e94a5d6028186997cd36f3c8d2631a272d7936b2cfb3d62730f8c0fe80983",
+        "wx" : "00a1ff55a03cd061f2408c0ada1ae9f7197f53ef84190564fd3dace78839bc6420",
+        "wy" : "178e94a5d6028186997cd36f3c8d2631a272d7936b2cfb3d62730f8c0fe80983"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004dc80905500d7d74ed47de5224d8734545f22b776ae086cabfffe6ce58d5ef994dc3067ce7d2cdfa9f4d5ace296b752814acc69c19a932d8b14077927901de3bf",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3ICQVQDX107UfeUiTYc0VF8it3au\nCGyr//5s5Y1e+ZTcMGfOfSzfqfTVrOKWt1KBSsxpwZqTLYsUB3knkB3jvw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a1ff55a03cd061f2408c0ada1ae9f7197f53ef84190564fd3dace78839bc6420178e94a5d6028186997cd36f3c8d2631a272d7936b2cfb3d62730f8c0fe80983",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEof9VoDzQYfJAjAraGun3GX9T74QZ\nBWT9PazniDm8ZCAXjpSl1gKBhpl80288jSYxonLXk2ss+z1icw+MD+gJgw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 350,
+          "tcId" : 434,
           "comment" : "s is larger than n",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
-          "sig" : "3026020105022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc75fbd8",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3026020106022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc75fbd8",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "041b824a11eed94fbcd9b722d06613bbcf7eca00b9136f2652642178f37b1a920ee900de495d9ef56fa6d19f3dd1e0edb23d23835ac8c2d3d13c0227e852e503eb",
         "wx" : "1b824a11eed94fbcd9b722d06613bbcf7eca00b9136f2652642178f37b1a920e",
-        "wy" : "0e900de495d9ef56fa6d19f3dd1e0edb23d23835ac8c2d3d13c0227e852e503eb"
+        "wy" : "00e900de495d9ef56fa6d19f3dd1e0edb23d23835ac8c2d3d13c0227e852e503eb"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041b824a11eed94fbcd9b722d06613bbcf7eca00b9136f2652642178f37b1a920ee900de495d9ef56fa6d19f3dd1e0edb23d23835ac8c2d3d13c0227e852e503eb",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEG4JKEe7ZT7zZtyLQZhO7z37KALkT\nbyZSZCF483sakg7pAN5JXZ71b6bRnz3R4O2yPSODWsjC09E8AifoUuUD6w==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041b824a11eed94fbcd9b722d06613bbcf7eca00b9136f2652642178f37b1a920ee900de495d9ef56fa6d19f3dd1e0edb23d23835ac8c2d3d13c0227e852e503eb",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEG4JKEe7ZT7zZtyLQZhO7z37KALkT\nbyZSZCF483sakg7pAN5JXZ71b6bRnz3R4O2yPSODWsjC09E8AifoUuUD6w==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 351,
+          "tcId" : 435,
           "comment" : "small r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3027020201000221008f1e3c7862c58b16bb76eddbb76eddbb516af4f63f2d74d76e0d28c9bb75ea88",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "042914b30c4c784696ffc3dddcec05f36cb1488bc342b9f529d5387acb9e48cb8d3dbd30d0d5d6d6a39108863c2d6a6e8571cd3261fb9eb98ce46125bd8f139136",
         "wx" : "2914b30c4c784696ffc3dddcec05f36cb1488bc342b9f529d5387acb9e48cb8d",
         "wy" : "3dbd30d0d5d6d6a39108863c2d6a6e8571cd3261fb9eb98ce46125bd8f139136"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042914b30c4c784696ffc3dddcec05f36cb1488bc342b9f529d5387acb9e48cb8d3dbd30d0d5d6d6a39108863c2d6a6e8571cd3261fb9eb98ce46125bd8f139136",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKRSzDEx4Rpb/w93c7AXzbLFIi8NC\nufUp1Th6y55Iy409vTDQ1dbWo5EIhjwtam6Fcc0yYfueuYzkYSW9jxORNg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042914b30c4c784696ffc3dddcec05f36cb1488bc342b9f529d5387acb9e48cb8d3dbd30d0d5d6d6a39108863c2d6a6e8571cd3261fb9eb98ce46125bd8f139136",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKRSzDEx4Rpb/w93c7AXzbLFIi8NC\nufUp1Th6y55Iy409vTDQ1dbWo5EIhjwtam6Fcc0yYfueuYzkYSW9jxORNg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 352,
+          "tcId" : 436,
           "comment" : "smallish r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "302c02072d9b4d347952d6022100ef3043e7329581dbb3974497710ab11505ee1c87ff907beebadd195a0ffe6d7a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "042579f546fe2f2aeb5f822feb28f2f8371618d04815455a7e903c10024a17da415528e951147f76bee1314e65a49c6ec70686e62d38fbc23472f96e3d3b33fd1f",
         "wx" : "2579f546fe2f2aeb5f822feb28f2f8371618d04815455a7e903c10024a17da41",
         "wy" : "5528e951147f76bee1314e65a49c6ec70686e62d38fbc23472f96e3d3b33fd1f"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042579f546fe2f2aeb5f822feb28f2f8371618d04815455a7e903c10024a17da415528e951147f76bee1314e65a49c6ec70686e62d38fbc23472f96e3d3b33fd1f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJXn1Rv4vKutfgi/rKPL4NxYY0EgV\nRVp+kDwQAkoX2kFVKOlRFH92vuExTmWknG7HBobmLTj7wjRy+W49OzP9Hw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042579f546fe2f2aeb5f822feb28f2f8371618d04815455a7e903c10024a17da415528e951147f76bee1314e65a49c6ec70686e62d38fbc23472f96e3d3b33fd1f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJXn1Rv4vKutfgi/rKPL4NxYY0EgV\nRVp+kDwQAkoX2kFVKOlRFH92vuExTmWknG7HBobmLTj7wjRy+W49OzP9Hw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 353,
+          "tcId" : 437,
           "comment" : "100-bit r and small s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3032020d1033e67e37b32b445580bf4eff0221008b748b74000000008b748b748b748b7466e769ad4a16d3dcd87129b8e91d1b4d",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04b102196bf455ee5aafc6f895504d3c3b6b2d37c35f8669bd0f0b694795fbd992f777b6f829b9628ac35db0ef43f6a89f0a42812614e4c15924d8d47ebe45bae5",
-        "wx" : "0b102196bf455ee5aafc6f895504d3c3b6b2d37c35f8669bd0f0b694795fbd992",
-        "wy" : "0f777b6f829b9628ac35db0ef43f6a89f0a42812614e4c15924d8d47ebe45bae5"
+        "wx" : "00b102196bf455ee5aafc6f895504d3c3b6b2d37c35f8669bd0f0b694795fbd992",
+        "wy" : "00f777b6f829b9628ac35db0ef43f6a89f0a42812614e4c15924d8d47ebe45bae5"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b102196bf455ee5aafc6f895504d3c3b6b2d37c35f8669bd0f0b694795fbd992f777b6f829b9628ac35db0ef43f6a89f0a42812614e4c15924d8d47ebe45bae5",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsQIZa/RV7lqvxviVUE08O2stN8Nf\nhmm9DwtpR5X72ZL3d7b4KbliisNdsO9D9qifCkKBJhTkwVkk2NR+vkW65Q==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b102196bf455ee5aafc6f895504d3c3b6b2d37c35f8669bd0f0b694795fbd992f777b6f829b9628ac35db0ef43f6a89f0a42812614e4c15924d8d47ebe45bae5",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsQIZa/RV7lqvxviVUE08O2stN8Nf\nhmm9DwtpR5X72ZL3d7b4KbliisNdsO9D9qifCkKBJhTkwVkk2NR+vkW65Q==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 354,
+          "tcId" : 438,
           "comment" : "small r and 100 bit s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "302702020100022100ef9f6ba4d97c09d03178fa20b4aaad83be3cf9cb824a879fec3270fc4b81ef5b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "044d056ab2ff57662fd6eebbe23930fef5cd08083e24146190cd01960b1fcd3749fe7ec5847651c857898be0f09efd6e0116a5dbe327f6f3080a65fc966bf64d91",
         "wx" : "4d056ab2ff57662fd6eebbe23930fef5cd08083e24146190cd01960b1fcd3749",
-        "wy" : "0fe7ec5847651c857898be0f09efd6e0116a5dbe327f6f3080a65fc966bf64d91"
+        "wy" : "00fe7ec5847651c857898be0f09efd6e0116a5dbe327f6f3080a65fc966bf64d91"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044d056ab2ff57662fd6eebbe23930fef5cd08083e24146190cd01960b1fcd3749fe7ec5847651c857898be0f09efd6e0116a5dbe327f6f3080a65fc966bf64d91",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETQVqsv9XZi/W7rviOTD+9c0ICD4k\nFGGQzQGWCx/NN0n+fsWEdlHIV4mL4PCe/W4BFqXb4yf28wgKZfyWa/ZNkQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044d056ab2ff57662fd6eebbe23930fef5cd08083e24146190cd01960b1fcd3749fe7ec5847651c857898be0f09efd6e0116a5dbe327f6f3080a65fc966bf64d91",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETQVqsv9XZi/W7rviOTD+9c0ICD4k\nFGGQzQGWCx/NN0n+fsWEdlHIV4mL4PCe/W4BFqXb4yf28wgKZfyWa/ZNkQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 355,
+          "tcId" : 439,
           "comment" : "100-bit r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3032020d062522bbd3ecbe7c39e93e7c25022100ef9f6ba4d97c09d03178fa20b4aaad83be3cf9cb824a879fec3270fc4b81ef5b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04361c4a62cd867613138dfe24ccebc4b7df1b55fc7410f4995ee2b6b9ab2220584f116c6c84e53d262fd13a5f5de6b57e7a1981de4ecdffdf3323b4e91d80649c",
         "wx" : "361c4a62cd867613138dfe24ccebc4b7df1b55fc7410f4995ee2b6b9ab222058",
         "wy" : "4f116c6c84e53d262fd13a5f5de6b57e7a1981de4ecdffdf3323b4e91d80649c"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004361c4a62cd867613138dfe24ccebc4b7df1b55fc7410f4995ee2b6b9ab2220584f116c6c84e53d262fd13a5f5de6b57e7a1981de4ecdffdf3323b4e91d80649c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENhxKYs2GdhMTjf4kzOvEt98bVfx0\nEPSZXuK2uasiIFhPEWxshOU9Ji/ROl9d5rV+ehmB3k7N/98zI7TpHYBknA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004361c4a62cd867613138dfe24ccebc4b7df1b55fc7410f4995ee2b6b9ab2220584f116c6c84e53d262fd13a5f5de6b57e7a1981de4ecdffdf3323b4e91d80649c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENhxKYs2GdhMTjf4kzOvEt98bVfx0\nEPSZXuK2uasiIFhPEWxshOU9Ji/ROl9d5rV+ehmB3k7N/98zI7TpHYBknA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 356,
+          "tcId" : 440,
           "comment" : "r and s^-1 are close to n",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3045022100ffffffff00000000ffffffffffffffffbce6faada7179e84f3b9cac2fc6324d50220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
+        "uncompressed" : "048156a2127c4c46a1ecf24c0522b85fabe94e6c8b9d962420b2acc9e2b6291af05235bf5dc5ccdd1bd333bce846197de363ba0dc158ef0f0174d714a09e76a66f",
+        "wx" : "008156a2127c4c46a1ecf24c0522b85fabe94e6c8b9d962420b2acc9e2b6291af0",
+        "wy" : "5235bf5dc5ccdd1bd333bce846197de363ba0dc158ef0f0174d714a09e76a66f"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048156a2127c4c46a1ecf24c0522b85fabe94e6c8b9d962420b2acc9e2b6291af05235bf5dc5ccdd1bd333bce846197de363ba0dc158ef0f0174d714a09e76a66f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEgVaiEnxMRqHs8kwFIrhfq+lObIud\nliQgsqzJ4rYpGvBSNb9dxczdG9MzvOhGGX3jY7oNwVjvDwF01xSgnnambw==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 441,
+          "comment" : "r and s are 64-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30160209009c44febf31c3594f020900839ed28247c2b06b",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04cb180dda5ed44ca0f78cc19c6659c88451b4d0084a4a904cb2dc770f78318613fae0bd290165858bd670788f5f78ad7806b49a2b932409e3dfb7195ccafaad0d",
+        "wx" : "00cb180dda5ed44ca0f78cc19c6659c88451b4d0084a4a904cb2dc770f78318613",
+        "wy" : "00fae0bd290165858bd670788f5f78ad7806b49a2b932409e3dfb7195ccafaad0d"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cb180dda5ed44ca0f78cc19c6659c88451b4d0084a4a904cb2dc770f78318613fae0bd290165858bd670788f5f78ad7806b49a2b932409e3dfb7195ccafaad0d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEyxgN2l7UTKD3jMGcZlnIhFG00AhK\nSpBMstx3D3gxhhP64L0pAWWFi9ZweI9feK14BrSaK5MkCePftxlcyvqtDQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 442,
+          "comment" : "r and s are 100-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "301e020d09df8b682430beef6f5fd7c7cd020d0fd0a62e13778f4222a0d61c8a",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0417e9a8ed4d6141f99dcc7794468576b16a9404c82a1969b91db0ca7534a5e00bbc4edd49e6dcf0476bd986551c3adccd4ddcdcdee6eb567cb68d925b4674113d",
+        "wx" : "17e9a8ed4d6141f99dcc7794468576b16a9404c82a1969b91db0ca7534a5e00b",
+        "wy" : "00bc4edd49e6dcf0476bd986551c3adccd4ddcdcdee6eb567cb68d925b4674113d"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000417e9a8ed4d6141f99dcc7794468576b16a9404c82a1969b91db0ca7534a5e00bbc4edd49e6dcf0476bd986551c3adccd4ddcdcdee6eb567cb68d925b4674113d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEF+mo7U1hQfmdzHeURoV2sWqUBMgq\nGWm5HbDKdTSl4Au8Tt1J5tzwR2vZhlUcOtzNTdzc3ubrVny2jZJbRnQRPQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 443,
+          "comment" : "r and s are 128-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260211008a598e563a89f526c32ebec8de26367c02110084f633e2042630e99dd0f1e16f7a04bf",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04f123d6999fec34a68c99539d2c9d50268fcdfafa99215d900c93c0c59bd34d933095156ba887f0f965804af24995cf5572553e6adb04da368a90419e523185ce",
+        "wx" : "00f123d6999fec34a68c99539d2c9d50268fcdfafa99215d900c93c0c59bd34d93",
+        "wy" : "3095156ba887f0f965804af24995cf5572553e6adb04da368a90419e523185ce"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f123d6999fec34a68c99539d2c9d50268fcdfafa99215d900c93c0c59bd34d933095156ba887f0f965804af24995cf5572553e6adb04da368a90419e523185ce",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE8SPWmZ/sNKaMmVOdLJ1QJo/N+vqZ\nIV2QDJPAxZvTTZMwlRVrqIfw+WWASvJJlc9VclU+atsE2jaKkEGeUjGFzg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 444,
+          "comment" : "r and s are 160-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302e021500aa6eeb5823f7fa31b466bb473797f0d0314c0bdf021500e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
         "uncompressed" : "04db9d5c5113f00822a146c9cda2e75cb6634cd0dff54aff6e22875171f57a0dad1c424cdd83eb01c02f6f8d36f42c6dc7e39db74358da8ac9bc9dc5890d46f667",
-        "wx" : "0db9d5c5113f00822a146c9cda2e75cb6634cd0dff54aff6e22875171f57a0dad",
+        "wx" : "00db9d5c5113f00822a146c9cda2e75cb6634cd0dff54aff6e22875171f57a0dad",
         "wy" : "1c424cdd83eb01c02f6f8d36f42c6dc7e39db74358da8ac9bc9dc5890d46f667"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004db9d5c5113f00822a146c9cda2e75cb6634cd0dff54aff6e22875171f57a0dad1c424cdd83eb01c02f6f8d36f42c6dc7e39db74358da8ac9bc9dc5890d46f667",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE251cURPwCCKhRsnNoudctmNM0N/1\nSv9uIodRcfV6Da0cQkzdg+sBwC9vjTb0LG3H4523Q1jaism8ncWJDUb2Zw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004db9d5c5113f00822a146c9cda2e75cb6634cd0dff54aff6e22875171f57a0dad1c424cdd83eb01c02f6f8d36f42c6dc7e39db74358da8ac9bc9dc5890d46f667",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE251cURPwCCKhRsnNoudctmNM0N/1\nSv9uIodRcfV6Da0cQkzdg+sBwC9vjTb0LG3H4523Q1jaism8ncWJDUb2Zw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 357,
+          "tcId" : 445,
           "comment" : "s == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30250220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70020101",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 358,
+          "tcId" : 446,
           "comment" : "s == 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30250220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70020100",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "0499f19f07b33e03caf4703e04b930d57d6d9baa44460c596a2d3064e0b63ea41286a74c4612a812ee348d2b43f80de627c11c75d81511e22a199c32119b792c6a",
-        "wx" : "099f19f07b33e03caf4703e04b930d57d6d9baa44460c596a2d3064e0b63ea412",
-        "wy" : "086a74c4612a812ee348d2b43f80de627c11c75d81511e22a199c32119b792c6a"
+        "uncompressed" : "044d9cddf6b4ff05cdf5f557a32db1712e49ab45ae53ade49b9469e665ffa2db773ead4c88e83f38cd16d61dda97645355424279e5132dfec14421cabfc1203a6b",
+        "wx" : "4d9cddf6b4ff05cdf5f557a32db1712e49ab45ae53ade49b9469e665ffa2db77",
+        "wy" : "3ead4c88e83f38cd16d61dda97645355424279e5132dfec14421cabfc1203a6b"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000499f19f07b33e03caf4703e04b930d57d6d9baa44460c596a2d3064e0b63ea41286a74c4612a812ee348d2b43f80de627c11c75d81511e22a199c32119b792c6a",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmfGfB7M+A8r0cD4EuTDVfW2bqkRG\nDFlqLTBk4LY+pBKGp0xGEqgS7jSNK0P4DeYnwRx12BUR4ioZnDIRm3ksag==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044d9cddf6b4ff05cdf5f557a32db1712e49ab45ae53ade49b9469e665ffa2db773ead4c88e83f38cd16d61dda97645355424279e5132dfec14421cabfc1203a6b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETZzd9rT/Bc319VejLbFxLkmrRa5T\nreSblGnmZf+i23c+rUyI6D84zRbWHdqXZFNVQkJ55RMt/sFEIcq/wSA6aw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 359,
-          "comment" : "point at infinity during verify",
+          "tcId" : 447,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a80220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022002f676969f451a8ccafa4c4f09791810e6d632dbd60b1d5540f3284fbe1889b0",
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
+        "uncompressed" : "045eb0559c2fde581a0df6207f3b2872d8e80a1ec8f6d542bf0319ec254c1c23ea272a1ab985cdfab8573a797ed554e137bda258ae3c841ccbf6559187b3471233",
+        "wx" : "5eb0559c2fde581a0df6207f3b2872d8e80a1ec8f6d542bf0319ec254c1c23ea",
+        "wy" : "272a1ab985cdfab8573a797ed554e137bda258ae3c841ccbf6559187b3471233"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045eb0559c2fde581a0df6207f3b2872d8e80a1ec8f6d542bf0319ec254c1c23ea272a1ab985cdfab8573a797ed554e137bda258ae3c841ccbf6559187b3471233",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXrBVnC/eWBoN9iB/Oyhy2OgKHsj2\n1UK/AxnsJUwcI+onKhq5hc36uFc6eX7VVOE3vaJYrjyEHMv2VZGHs0cSMw==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 448,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002204e260962e33362ef0046126d2d5a4edc6947ab20e19b8ec19cf79e5908b6e628",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "042cb4debf57562b9aa191e38d101c51d8bd3eedf242a1123cd3c6060526c4dd2bdc6abd94d54374aede721d0c78193e9b999508a9f2a9ae8737f87a5fc7e0c673",
+        "wx" : "2cb4debf57562b9aa191e38d101c51d8bd3eedf242a1123cd3c6060526c4dd2b",
+        "wy" : "00dc6abd94d54374aede721d0c78193e9b999508a9f2a9ae8737f87a5fc7e0c673"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042cb4debf57562b9aa191e38d101c51d8bd3eedf242a1123cd3c6060526c4dd2bdc6abd94d54374aede721d0c78193e9b999508a9f2a9ae8737f87a5fc7e0c673",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELLTev1dWK5qhkeONEBxR2L0+7fJC\noRI808YGBSbE3Svcar2U1UN0rt5yHQx4GT6bmZUIqfKproc3+Hpfx+DGcw==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 449,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220077ed0d8f20f697d8fc591ac64dd5219c7932122b4f9b9ec6441e44a0092cf21",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0463d556714900ed08e751f58c1978c1a673c9a9bf975fc4b8af32c2e7944f21d4c2cdf2e7b72fcffe3e8767dc769856ef9fec98ef0139b22f87166300a3781599",
+        "wx" : "63d556714900ed08e751f58c1978c1a673c9a9bf975fc4b8af32c2e7944f21d4",
+        "wy" : "00c2cdf2e7b72fcffe3e8767dc769856ef9fec98ef0139b22f87166300a3781599"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000463d556714900ed08e751f58c1978c1a673c9a9bf975fc4b8af32c2e7944f21d4c2cdf2e7b72fcffe3e8767dc769856ef9fec98ef0139b22f87166300a3781599",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEY9VWcUkA7QjnUfWMGXjBpnPJqb+X\nX8S4rzLC55RPIdTCzfLnty/P/j6HZ9x2mFbvn+yY7wE5si+HFmMAo3gVmQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 450,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002203e0292a67e181c6c0105ee35e956e78e9bdd033c6e71ae57884039a245e4175f",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "040d09be47824c5c23f727bfb550c6dbbdf90abb35d3623013f1c6d7d31be03d95845fede0a0f580dff795e7d5b278a2c78bfa5c4facd1fccfe190ec8eef206778",
+        "wx" : "0d09be47824c5c23f727bfb550c6dbbdf90abb35d3623013f1c6d7d31be03d95",
+        "wy" : "00845fede0a0f580dff795e7d5b278a2c78bfa5c4facd1fccfe190ec8eef206778"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040d09be47824c5c23f727bfb550c6dbbdf90abb35d3623013f1c6d7d31be03d95845fede0a0f580dff795e7d5b278a2c78bfa5c4facd1fccfe190ec8eef206778",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDQm+R4JMXCP3J7+1UMbbvfkKuzXT\nYjAT8cbX0xvgPZWEX+3goPWA3/eV59WyeKLHi/pcT6zR/M/hkOyO7yBneA==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 451,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022013d22b06d6b8f5d97e0c64962b4a3bae30f668ca6217ef5b35d799f159e23ebe",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0435b75a83731a5b56325add4f28a09742039e0e62f75728e896783fd957400d5be3f3fa5269577faa7089e9c8e9d9f732ef78d433e4be382820323c197c5bbc39",
+        "wx" : "35b75a83731a5b56325add4f28a09742039e0e62f75728e896783fd957400d5b",
+        "wy" : "00e3f3fa5269577faa7089e9c8e9d9f732ef78d433e4be382820323c197c5bbc39"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000435b75a83731a5b56325add4f28a09742039e0e62f75728e896783fd957400d5be3f3fa5269577faa7089e9c8e9d9f732ef78d433e4be382820323c197c5bbc39",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAENbdag3MaW1YyWt1PKKCXQgOeDmL3\nVyjolng/2VdADVvj8/pSaVd/qnCJ6cjp2fcy73jUM+S+OCggMjwZfFu8OQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 452,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002204523ce342e4994bb8968bf6613f60c06c86111f15a3a389309e72cd447d5dd99",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04fdd28d47e3d60ed4c7fd48e68003f48c5346354ecae2e4b1b4ff43ecd6058fcb010d7e9f008ae48f88a90640999a931ee47d77b2cfb442c614b14054af2c9ddf",
+        "wx" : "00fdd28d47e3d60ed4c7fd48e68003f48c5346354ecae2e4b1b4ff43ecd6058fcb",
+        "wy" : "010d7e9f008ae48f88a90640999a931ee47d77b2cfb442c614b14054af2c9ddf"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fdd28d47e3d60ed4c7fd48e68003f48c5346354ecae2e4b1b4ff43ecd6058fcb010d7e9f008ae48f88a90640999a931ee47d77b2cfb442c614b14054af2c9ddf",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/dKNR+PWDtTH/UjmgAP0jFNGNU7K\n4uSxtP9D7NYFj8sBDX6fAIrkj4ipBkCZmpMe5H13ss+0QsYUsUBUryyd3w==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 453,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022037d765be3c9c78189ad30edb5097a4db670de11686d01420e37039d4677f4809",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0473d914dde798f430d51de4e43b3cc5aa557fc4797d9a1820813509979efe3753089ffa286ba30505e3a9ae5c9587854ddb3de2a04ee7a0dbed0dfb087e2d190b",
+        "wx" : "73d914dde798f430d51de4e43b3cc5aa557fc4797d9a1820813509979efe3753",
+        "wy" : "089ffa286ba30505e3a9ae5c9587854ddb3de2a04ee7a0dbed0dfb087e2d190b"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000473d914dde798f430d51de4e43b3cc5aa557fc4797d9a1820813509979efe3753089ffa286ba30505e3a9ae5c9587854ddb3de2a04ee7a0dbed0dfb087e2d190b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEc9kU3eeY9DDVHeTkOzzFqlV/xHl9\nmhgggTUJl57+N1MIn/ooa6MFBeOprlyVh4VN2z3ioE7noNvtDfsIfi0ZCw==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 454,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022044237823b54e0c74c2bf5f759d9ac5f8cb897d537ffa92effd4f0bb6c9acd860",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0424861819b9fb20fb1fcc75eb7a44b2abbb36047812429119ba5b232dfc1ad3c244ec4740e65634fae7d692ea166cb4640201486845c2fb96d4f49beaecc3289a",
+        "wx" : "24861819b9fb20fb1fcc75eb7a44b2abbb36047812429119ba5b232dfc1ad3c2",
+        "wy" : "44ec4740e65634fae7d692ea166cb4640201486845c2fb96d4f49beaecc3289a"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000424861819b9fb20fb1fcc75eb7a44b2abbb36047812429119ba5b232dfc1ad3c244ec4740e65634fae7d692ea166cb4640201486845c2fb96d4f49beaecc3289a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJIYYGbn7IPsfzHXrekSyq7s2BHgS\nQpEZulsjLfwa08JE7EdA5lY0+ufWkuoWbLRkAgFIaEXC+5bU9Jvq7MMomg==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 455,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220266d30a485385906054ca86d46f5f2b17e7f4646a3092092ad92877126538111",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04de056c8c24eb527ad5021ddcf3b16b099b668a03f7da03075f410a0770347bde01880d2a7b162491221c0b370fe81f28924422a4c70117682b898bc325791ce4",
+        "wx" : "00de056c8c24eb527ad5021ddcf3b16b099b668a03f7da03075f410a0770347bde",
+        "wy" : "01880d2a7b162491221c0b370fe81f28924422a4c70117682b898bc325791ce4"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004de056c8c24eb527ad5021ddcf3b16b099b668a03f7da03075f410a0770347bde01880d2a7b162491221c0b370fe81f28924422a4c70117682b898bc325791ce4",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3gVsjCTrUnrVAh3c87FrCZtmigP3\n2gMHX0EKB3A0e94BiA0qexYkkSIcCzcP6B8okkQipMcBF2griYvDJXkc5A==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 456,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220538c7b3798e84d0ce90340165806348971ed44db8f0c674f5f215968390f92ee",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04cf2de76812f62ecd4e7d8e674d1b79dddbdca18677c8ba338a71b65134d0429fad6d87d6d6592ba1130b81198f6fbe39719cb872d30fc1757af2ae86307b3f9e",
+        "wx" : "00cf2de76812f62ecd4e7d8e674d1b79dddbdca18677c8ba338a71b65134d0429f",
+        "wy" : "00ad6d87d6d6592ba1130b81198f6fbe39719cb872d30fc1757af2ae86307b3f9e"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cf2de76812f62ecd4e7d8e674d1b79dddbdca18677c8ba338a71b65134d0429fad6d87d6d6592ba1130b81198f6fbe39719cb872d30fc1757af2ae86307b3f9e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzy3naBL2Ls1OfY5nTRt53dvcoYZ3\nyLozinG2UTTQQp+tbYfW1lkroRMLgRmPb745cZy4ctMPwXV68q6GMHs/ng==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 457,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002206fef0ef15d1688e15e704c4e6bb8bb7f40d52d3af5c661bb78c4ed9b408699b3",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0428d9b9fe0d3c2471f224476eb89c13fa68b433213c31b6376b16226abfeae1c636fef52918dd106cd21958f1f379b09278051472309731ea1192121b3b78f873",
+        "wx" : "28d9b9fe0d3c2471f224476eb89c13fa68b433213c31b6376b16226abfeae1c6",
+        "wy" : "36fef52918dd106cd21958f1f379b09278051472309731ea1192121b3b78f873"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000428d9b9fe0d3c2471f224476eb89c13fa68b433213c31b6376b16226abfeae1c636fef52918dd106cd21958f1f379b09278051472309731ea1192121b3b78f873",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKNm5/g08JHHyJEduuJwT+mi0MyE8\nMbY3axYiar/q4cY2/vUpGN0QbNIZWPHzebCSeAUUcjCXMeoRkhIbO3j4cw==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 458,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002206f44275e9aeb1331efcb8d58f35c0252791427e403ad84daad51d247cc2a64c6",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04334ddf8629f0b980796f255e650e247598f6f71e90c501dd11fcb58ea1e6c0a39215c31a4741e4b28657fc7ddb490c0e2a21c7b770460301344dbdd67e85f30d",
+        "wx" : "334ddf8629f0b980796f255e650e247598f6f71e90c501dd11fcb58ea1e6c0a3",
+        "wy" : "009215c31a4741e4b28657fc7ddb490c0e2a21c7b770460301344dbdd67e85f30d"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004334ddf8629f0b980796f255e650e247598f6f71e90c501dd11fcb58ea1e6c0a39215c31a4741e4b28657fc7ddb490c0e2a21c7b770460301344dbdd67e85f30d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEM03fhinwuYB5byVeZQ4kdZj29x6Q\nxQHdEfy1jqHmwKOSFcMaR0HksoZX/H3bSQwOKiHHt3BGAwE0Tb3WfoXzDQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 459,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022021323755b103d2f9da6ab83eccab9ad8598bcf625652f10e7a3eeee3c3945fb3",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "048e889d0a2530f73421ad2e08302651f41ddeb1ae5083ce7e313e06d6928c375afeca9b4490f6aa5e8d45d187ec8d3ab699f29c0cc77386c56f93f2f39e0f2874",
+        "wx" : "008e889d0a2530f73421ad2e08302651f41ddeb1ae5083ce7e313e06d6928c375a",
+        "wy" : "00feca9b4490f6aa5e8d45d187ec8d3ab699f29c0cc77386c56f93f2f39e0f2874"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200048e889d0a2530f73421ad2e08302651f41ddeb1ae5083ce7e313e06d6928c375afeca9b4490f6aa5e8d45d187ec8d3ab699f29c0cc77386c56f93f2f39e0f2874",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEjoidCiUw9zQhrS4IMCZR9B3esa5Q\ng85+MT4G1pKMN1r+yptEkPaqXo1F0YfsjTq2mfKcDMdzhsVvk/Lzng8odA==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 460,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002206c50acfe76de1289e7a5edb240f1c2a7879db6873d5d931f3c6ac467a6eac171",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04297ef19b14f0dfb7c4a294732096ed4304bc5e2eeb86581e0014ddb6e14920878bf2260ecb396e33383c4898bd954dd3c6e7bcdd7810ad0a649f97722bad0095",
+        "wx" : "297ef19b14f0dfb7c4a294732096ed4304bc5e2eeb86581e0014ddb6e1492087",
+        "wy" : "008bf2260ecb396e33383c4898bd954dd3c6e7bcdd7810ad0a649f97722bad0095"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004297ef19b14f0dfb7c4a294732096ed4304bc5e2eeb86581e0014ddb6e14920878bf2260ecb396e33383c4898bd954dd3c6e7bcdd7810ad0a649f97722bad0095",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKX7xmxTw37fEopRzIJbtQwS8Xi7r\nhlgeABTdtuFJIIeL8iYOyzluMzg8SJi9lU3Txue83XgQrQpkn5dyK60AlQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 461,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220755b7fffb0b17ad57dca50fcefb7fe297b029df25e5ccb5069e8e70c2742c2a6",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "0499f19f07b33e03caf4703e04b930d57d6d9baa44460c596a2d3064e0b63ea41286a74c4612a812ee348d2b43f80de627c11c75d81511e22a199c32119b792c6a",
+        "wx" : "0099f19f07b33e03caf4703e04b930d57d6d9baa44460c596a2d3064e0b63ea412",
+        "wy" : "0086a74c4612a812ee348d2b43f80de627c11c75d81511e22a199c32119b792c6a"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000499f19f07b33e03caf4703e04b930d57d6d9baa44460c596a2d3064e0b63ea41286a74c4612a812ee348d2b43f80de627c11c75d81511e22a199c32119b792c6a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmfGfB7M+A8r0cD4EuTDVfW2bqkRG\nDFlqLTBk4LY+pBKGp0xGEqgS7jSNK0P4DeYnwRx12BUR4ioZnDIRm3ksag==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 462,
+          "comment" : "point at infinity during verify",
+          "flags" : [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304402207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a80220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04313f3309b236484c6eb4ea381e007854467a617343a2e97d845801c01a632cfe33f231854bba89a8ca3f802a2764d3bf6c3233c811a31e5e8028a0b862cb1977",
+        "wx" : "313f3309b236484c6eb4ea381e007854467a617343a2e97d845801c01a632cfe",
+        "wy" : "33f231854bba89a8ca3f802a2764d3bf6c3233c811a31e5e8028a0b862cb1977"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004313f3309b236484c6eb4ea381e007854467a617343a2e97d845801c01a632cfe33f231854bba89a8ca3f802a2764d3bf6c3233c811a31e5e8028a0b862cb1977",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMT8zCbI2SExutOo4HgB4VEZ6YXND\noul9hFgBwBpjLP4z8jGFS7qJqMo/gConZNO/bDIzyBGjHl6AKKC4YssZdw==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 463,
+          "comment" : "edge case for signature malleability",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304402207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a902207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a8",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
+        "uncompressed" : "04d3aa01fe59bad92cffe3db59e1385391fafd7af4e4ce462e8aac157274cc8a05c7a7e603e18538aac15f89610beacc21e39898e6c5f7680a81c5bd7bd744a989",
+        "wx" : "00d3aa01fe59bad92cffe3db59e1385391fafd7af4e4ce462e8aac157274cc8a05",
+        "wy" : "00c7a7e603e18538aac15f89610beacc21e39898e6c5f7680a81c5bd7bd744a989"
+      },
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004d3aa01fe59bad92cffe3db59e1385391fafd7af4e4ce462e8aac157274cc8a05c7a7e603e18538aac15f89610beacc21e39898e6c5f7680a81c5bd7bd744a989",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE06oB/lm62Sz/49tZ4ThTkfr9evTk\nzkYuiqwVcnTMigXHp+YD4YU4qsFfiWEL6swh45iY5sX3aAqBxb1710SpiQ==\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 464,
+          "comment" : "edge case for signature malleability",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304402207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a902207fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192a9",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp256r1",
+        "keySize" : 256,
         "uncompressed" : "045e31eccd4704ebf7a4247ea57f9351abadff63679f2276e2a3b05009ebc1b8df648465a925010db823b2a5f3a6072343a6cc9961a9c482399d0d82051c2e3232",
         "wx" : "5e31eccd4704ebf7a4247ea57f9351abadff63679f2276e2a3b05009ebc1b8df",
         "wy" : "648465a925010db823b2a5f3a6072343a6cc9961a9c482399d0d82051c2e3232"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045e31eccd4704ebf7a4247ea57f9351abadff63679f2276e2a3b05009ebc1b8df648465a925010db823b2a5f3a6072343a6cc9961a9c482399d0d82051c2e3232",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXjHszUcE6/ekJH6lf5NRq63/Y2ef\nInbio7BQCevBuN9khGWpJQENuCOypfOmByNDpsyZYanEgjmdDYIFHC4yMg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200045e31eccd4704ebf7a4247ea57f9351abadff63679f2276e2a3b05009ebc1b8df648465a925010db823b2a5f3a6072343a6cc9961a9c482399d0d82051c2e3232",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEXjHszUcE6/ekJH6lf5NRq63/Y2ef\nInbio7BQCevBuN9khGWpJQENuCOypfOmByNDpsyZYanEgjmdDYIFHC4yMg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 360,
+          "tcId" : 465,
           "comment" : "u1 == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b023210281",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04ce0a47f881fd7315a733c4317848fa33c72e38de0b8fda36b61aa9a164f5808a85b05d25115ea4097ddf63f878c8e83657e66de136a8f9e62ed81a58bf117ff9",
-        "wx" : "0ce0a47f881fd7315a733c4317848fa33c72e38de0b8fda36b61aa9a164f5808a",
-        "wy" : "085b05d25115ea4097ddf63f878c8e83657e66de136a8f9e62ed81a58bf117ff9"
+        "wx" : "00ce0a47f881fd7315a733c4317848fa33c72e38de0b8fda36b61aa9a164f5808a",
+        "wy" : "0085b05d25115ea4097ddf63f878c8e83657e66de136a8f9e62ed81a58bf117ff9"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ce0a47f881fd7315a733c4317848fa33c72e38de0b8fda36b61aa9a164f5808a85b05d25115ea4097ddf63f878c8e83657e66de136a8f9e62ed81a58bf117ff9",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzgpH+IH9cxWnM8QxeEj6M8cuON4L\nj9o2thqpoWT1gIqFsF0lEV6kCX3fY/h4yOg2V+Zt4Tao+eYu2BpYvxF/+Q==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ce0a47f881fd7315a733c4317848fa33c72e38de0b8fda36b61aa9a164f5808a85b05d25115ea4097ddf63f878c8e83657e66de136a8f9e62ed81a58bf117ff9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzgpH+IH9cxWnM8QxeEj6M8cuON4L\nj9o2thqpoWT1gIqFsF0lEV6kCX3fY/h4yOg2V+Zt4Tao+eYu2BpYvxF/+Q==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 361,
+          "tcId" : 466,
           "comment" : "u1 == n - 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30450220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022100bc07ff031506dc74a75086a43252fb43731975a16dca6b025e867412d94222d0",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04cd6f487b47f36c0dea8f4b04c4e6ac637c76b725929c611f48addcf3d2f65941b50ea8f3a491190ee0b20cfb6efd113608e7c7c127577500e7f5c4a4e490fd60",
-        "wx" : "0cd6f487b47f36c0dea8f4b04c4e6ac637c76b725929c611f48addcf3d2f65941",
-        "wy" : "0b50ea8f3a491190ee0b20cfb6efd113608e7c7c127577500e7f5c4a4e490fd60"
+        "wx" : "00cd6f487b47f36c0dea8f4b04c4e6ac637c76b725929c611f48addcf3d2f65941",
+        "wy" : "00b50ea8f3a491190ee0b20cfb6efd113608e7c7c127577500e7f5c4a4e490fd60"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cd6f487b47f36c0dea8f4b04c4e6ac637c76b725929c611f48addcf3d2f65941b50ea8f3a491190ee0b20cfb6efd113608e7c7c127577500e7f5c4a4e490fd60",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzW9Ie0fzbA3qj0sExOasY3x2tyWS\nnGEfSK3c89L2WUG1DqjzpJEZDuCyDPtu/RE2COfHwSdXdQDn9cSk5JD9YA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004cd6f487b47f36c0dea8f4b04c4e6ac637c76b725929c611f48addcf3d2f65941b50ea8f3a491190ee0b20cfb6efd113608e7c7c127577500e7f5c4a4e490fd60",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEzW9Ie0fzbA3qj0sExOasY3x2tyWS\nnGEfSK3c89L2WUG1DqjzpJEZDuCyDPtu/RE2COfHwSdXdQDn9cSk5JD9YA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 362,
+          "tcId" : 467,
           "comment" : "u2 == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c700220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04456e5f8067d68a1b0a2e8fe2b28acad5755687154a0f167734ebabbdc059070d720dbe96659a66ef0cf27a73e7b3f3f145a60e0ad29f1e21dcc2bb42f0d82c1e",
         "wx" : "456e5f8067d68a1b0a2e8fe2b28acad5755687154a0f167734ebabbdc059070d",
         "wy" : "720dbe96659a66ef0cf27a73e7b3f3f145a60e0ad29f1e21dcc2bb42f0d82c1e"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004456e5f8067d68a1b0a2e8fe2b28acad5755687154a0f167734ebabbdc059070d720dbe96659a66ef0cf27a73e7b3f3f145a60e0ad29f1e21dcc2bb42f0d82c1e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERW5fgGfWihsKLo/isorK1XVWhxVK\nDxZ3NOurvcBZBw1yDb6WZZpm7wzyenPns/PxRaYOCtKfHiHcwrtC8NgsHg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004456e5f8067d68a1b0a2e8fe2b28acad5755687154a0f167734ebabbdc059070d720dbe96659a66ef0cf27a73e7b3f3f145a60e0ad29f1e21dcc2bb42f0d82c1e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAERW5fgGfWihsKLo/isorK1XVWhxVK\nDxZ3NOurvcBZBw1yDb6WZZpm7wzyenPns/PxRaYOCtKfHiHcwrtC8NgsHg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 363,
+          "tcId" : 468,
           "comment" : "u2 == n - 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30450220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70022100aaaaaaaa00000000aaaaaaaaaaaaaaaa7def51c91a0fbf034d26872ca84218e1",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0442bf0c0ac1e3850baf5515748a878e34249f71035e20a9f54ed468ec273cb0fc5b3138500230055c71f12d53f5c7d0e3d8aa54a94c668cb311e20d195fc71abb",
         "wx" : "42bf0c0ac1e3850baf5515748a878e34249f71035e20a9f54ed468ec273cb0fc",
         "wy" : "5b3138500230055c71f12d53f5c7d0e3d8aa54a94c668cb311e20d195fc71abb"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000442bf0c0ac1e3850baf5515748a878e34249f71035e20a9f54ed468ec273cb0fc5b3138500230055c71f12d53f5c7d0e3d8aa54a94c668cb311e20d195fc71abb",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQr8MCsHjhQuvVRV0ioeONCSfcQNe\nIKn1TtRo7Cc8sPxbMThQAjAFXHHxLVP1x9Dj2KpUqUxmjLMR4g0ZX8cauw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000442bf0c0ac1e3850baf5515748a878e34249f71035e20a9f54ed468ec273cb0fc5b3138500230055c71f12d53f5c7d0e3d8aa54a94c668cb311e20d195fc71abb",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEQr8MCsHjhQuvVRV0ioeONCSfcQNe\nIKn1TtRo7Cc8sPxbMThQAjAFXHHxLVP1x9Dj2KpUqUxmjLMR4g0ZX8cauw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 364,
+          "tcId" : 469,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02206bfd55a8f8fdb68472e52873ef39ac3eace6d53df576f0ad2da4607bb52c0d46",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04ffdd48da63d3af67223f16c51eb7e95600eb0b0e8b964f4fcd8c534face3c2c2b4e009ab2a76829480e69c9e43b2f1fe076cfafb3fa8d27dd4d6bab4d6c3db54",
-        "wx" : "0ffdd48da63d3af67223f16c51eb7e95600eb0b0e8b964f4fcd8c534face3c2c2",
-        "wy" : "0b4e009ab2a76829480e69c9e43b2f1fe076cfafb3fa8d27dd4d6bab4d6c3db54"
+        "wx" : "00ffdd48da63d3af67223f16c51eb7e95600eb0b0e8b964f4fcd8c534face3c2c2",
+        "wy" : "00b4e009ab2a76829480e69c9e43b2f1fe076cfafb3fa8d27dd4d6bab4d6c3db54"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffdd48da63d3af67223f16c51eb7e95600eb0b0e8b964f4fcd8c534face3c2c2b4e009ab2a76829480e69c9e43b2f1fe076cfafb3fa8d27dd4d6bab4d6c3db54",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/91I2mPTr2ciPxbFHrfpVgDrCw6L\nlk9PzYxTT6zjwsK04AmrKnaClIDmnJ5DsvH+B2z6+z+o0n3U1rq01sPbVA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004ffdd48da63d3af67223f16c51eb7e95600eb0b0e8b964f4fcd8c534face3c2c2b4e009ab2a76829480e69c9e43b2f1fe076cfafb3fa8d27dd4d6bab4d6c3db54",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE/91I2mPTr2ciPxbFHrfpVgDrCw6L\nlk9PzYxTT6zjwsK04AmrKnaClIDmnJ5DsvH+B2z6+z+o0n3U1rq01sPbVA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 365,
+          "tcId" : 470,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0220654937791db0686f712ff9b453eeadb0026c9b058bba49199ca3e8fac03c094f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04793cbfce6f335dcfede7c6898ea1c537d7661ed6a8c9d308d64a2560d21c6e2c483d23a5ff05da00eaf9d52cf5362be9b53b95316c6a32e9ebe68d9ac35c2fd6",
         "wx" : "793cbfce6f335dcfede7c6898ea1c537d7661ed6a8c9d308d64a2560d21c6e2c",
         "wy" : "483d23a5ff05da00eaf9d52cf5362be9b53b95316c6a32e9ebe68d9ac35c2fd6"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004793cbfce6f335dcfede7c6898ea1c537d7661ed6a8c9d308d64a2560d21c6e2c483d23a5ff05da00eaf9d52cf5362be9b53b95316c6a32e9ebe68d9ac35c2fd6",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeTy/zm8zXc/t58aJjqHFN9dmHtao\nydMI1kolYNIcbixIPSOl/wXaAOr51Sz1NivptTuVMWxqMunr5o2aw1wv1g==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004793cbfce6f335dcfede7c6898ea1c537d7661ed6a8c9d308d64a2560d21c6e2c483d23a5ff05da00eaf9d52cf5362be9b53b95316c6a32e9ebe68d9ac35c2fd6",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEeTy/zm8zXc/t58aJjqHFN9dmHtao\nydMI1kolYNIcbixIPSOl/wXaAOr51Sz1NivptTuVMWxqMunr5o2aw1wv1g==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 366,
+          "tcId" : 471,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100c51bbee23a95437abe5c978f8fe596a31c858ac8d55be9786aa5d36a5ac74e97",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04a9f7023f559d4bb6c9f4bc3643e2824aff5451d929479ec3ea5eb30bad2c36ac6a7c77e8dd21f4ad49b103e67da9d3cda62b653dd194fad2ba8d1dd37bb0ea9b",
-        "wx" : "0a9f7023f559d4bb6c9f4bc3643e2824aff5451d929479ec3ea5eb30bad2c36ac",
+        "wx" : "00a9f7023f559d4bb6c9f4bc3643e2824aff5451d929479ec3ea5eb30bad2c36ac",
         "wy" : "6a7c77e8dd21f4ad49b103e67da9d3cda62b653dd194fad2ba8d1dd37bb0ea9b"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a9f7023f559d4bb6c9f4bc3643e2824aff5451d929479ec3ea5eb30bad2c36ac6a7c77e8dd21f4ad49b103e67da9d3cda62b653dd194fad2ba8d1dd37bb0ea9b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqfcCP1WdS7bJ9Lw2Q+KCSv9UUdkp\nR57D6l6zC60sNqxqfHfo3SH0rUmxA+Z9qdPNpitlPdGU+tK6jR3Te7Dqmw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a9f7023f559d4bb6c9f4bc3643e2824aff5451d929479ec3ea5eb30bad2c36ac6a7c77e8dd21f4ad49b103e67da9d3cda62b653dd194fad2ba8d1dd37bb0ea9b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqfcCP1WdS7bJ9Lw2Q+KCSv9UUdkp\nR57D6l6zC60sNqxqfHfo3SH0rUmxA+Z9qdPNpitlPdGU+tK6jR3Te7Dqmw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 367,
+          "tcId" : 472,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0221008ba4c3da7154ba564ab344ae12005aa482b6c1639ea191f8568afb6e47163c45",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04df79ee082b2fc77e9ce4633471f569bbcb5ce53856e3067774f37e8a64a2c7ffaa488a6c34d499df76f427de3609bfcfd9feae67ffe0b0de594463c453b0ab16",
-        "wx" : "0df79ee082b2fc77e9ce4633471f569bbcb5ce53856e3067774f37e8a64a2c7ff",
-        "wy" : "0aa488a6c34d499df76f427de3609bfcfd9feae67ffe0b0de594463c453b0ab16"
+        "wx" : "00df79ee082b2fc77e9ce4633471f569bbcb5ce53856e3067774f37e8a64a2c7ff",
+        "wy" : "00aa488a6c34d499df76f427de3609bfcfd9feae67ffe0b0de594463c453b0ab16"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004df79ee082b2fc77e9ce4633471f569bbcb5ce53856e3067774f37e8a64a2c7ffaa488a6c34d499df76f427de3609bfcfd9feae67ffe0b0de594463c453b0ab16",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE33nuCCsvx36c5GM0cfVpu8tc5ThW\n4wZ3dPN+imSix/+qSIpsNNSZ33b0J942Cb/P2f6uZ//gsN5ZRGPEU7CrFg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004df79ee082b2fc77e9ce4633471f569bbcb5ce53856e3067774f37e8a64a2c7ffaa488a6c34d499df76f427de3609bfcfd9feae67ffe0b0de594463c453b0ab16",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE33nuCCsvx36c5GM0cfVpu8tc5ThW\n4wZ3dPN+imSix/+qSIpsNNSZ33b0J942Cb/P2f6uZ//gsN5ZRGPEU7CrFg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 368,
+          "tcId" : 473,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02204c3dafcf4ba55bf1344ae12005aa4a74f46eaa85f5023131cc637ae2ea90ab26",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "044cc3bf65e32e00284adfca00f40df755415c485091ac0489ae9a337103a5f8f0123ab86dd433b933b4f2063c002144df3cfeba78dad0ed89c0377541532908c2",
         "wx" : "4cc3bf65e32e00284adfca00f40df755415c485091ac0489ae9a337103a5f8f0",
         "wy" : "123ab86dd433b933b4f2063c002144df3cfeba78dad0ed89c0377541532908c2"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044cc3bf65e32e00284adfca00f40df755415c485091ac0489ae9a337103a5f8f0123ab86dd433b933b4f2063c002144df3cfeba78dad0ed89c0377541532908c2",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETMO/ZeMuAChK38oA9A33VUFcSFCR\nrASJrpozcQOl+PASOrht1DO5M7TyBjwAIUTfPP66eNrQ7YnAN3VBUykIwg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044cc3bf65e32e00284adfca00f40df755415c485091ac0489ae9a337103a5f8f0123ab86dd433b933b4f2063c002144df3cfeba78dad0ed89c0377541532908c2",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETMO/ZeMuAChK38oA9A33VUFcSFCR\nrASJrpozcQOl+PASOrht1DO5M7TyBjwAIUTfPP66eNrQ7YnAN3VBUykIwg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 369,
+          "tcId" : 474,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100987b5f9e974ab7e26895c2400b5494e9e8dd550bea04626398c6f5c5d521564c",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04264a7ad439a4828a9dc97ecf837155355f99ae0b65975f851b541ad3a0e032f067268b7298c73e581866fbcbd161689b16b81cf262e007ce68e25a28c83ef041",
         "wx" : "264a7ad439a4828a9dc97ecf837155355f99ae0b65975f851b541ad3a0e032f0",
         "wy" : "67268b7298c73e581866fbcbd161689b16b81cf262e007ce68e25a28c83ef041"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004264a7ad439a4828a9dc97ecf837155355f99ae0b65975f851b541ad3a0e032f067268b7298c73e581866fbcbd161689b16b81cf262e007ce68e25a28c83ef041",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJkp61DmkgoqdyX7Pg3FVNV+Zrgtl\nl1+FG1Qa06DgMvBnJotymMc+WBhm+8vRYWibFrgc8mLgB85o4looyD7wQQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004264a7ad439a4828a9dc97ecf837155355f99ae0b65975f851b541ad3a0e032f067268b7298c73e581866fbcbd161689b16b81cf262e007ce68e25a28c83ef041",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJkp61DmkgoqdyX7Pg3FVNV+Zrgtl\nl1+FG1Qa06DgMvBnJotymMc+WBhm+8vRYWibFrgc8mLgB85o4looyD7wQQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 370,
+          "tcId" : 475,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100fcf97e2fbf0e80d412005aa4a75086a3f004f59d512cb47271798733ab418606",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "041d7ff4d3a41206c8143635f12876e0ea0875ea5e4a5a249250d0eda33daa211f56e89c0beaf910ac934ca12380455600d0fd85b56a7035cb171b3f1c72a15569",
         "wx" : "1d7ff4d3a41206c8143635f12876e0ea0875ea5e4a5a249250d0eda33daa211f",
         "wy" : "56e89c0beaf910ac934ca12380455600d0fd85b56a7035cb171b3f1c72a15569"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041d7ff4d3a41206c8143635f12876e0ea0875ea5e4a5a249250d0eda33daa211f56e89c0beaf910ac934ca12380455600d0fd85b56a7035cb171b3f1c72a15569",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHX/006QSBsgUNjXxKHbg6gh16l5K\nWiSSUNDtoz2qIR9W6JwL6vkQrJNMoSOARVYA0P2FtWpwNcsXGz8ccqFVaQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041d7ff4d3a41206c8143635f12876e0ea0875ea5e4a5a249250d0eda33daa211f56e89c0beaf910ac934ca12380455600d0fd85b56a7035cb171b3f1c72a15569",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHX/006QSBsgUNjXxKHbg6gh16l5K\nWiSSUNDtoz2qIR9W6JwL6vkQrJNMoSOARVYA0P2FtWpwNcsXGz8ccqFVaQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 371,
+          "tcId" : 476,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022079d482b60864d6c5cb4fd5db9e7e28ccd9a5948c316c8740fb429c0f37169a02",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04b09685f338dceb421778a1458d52bed734c236242da2baa280d6f6b7b86e4f117fe6a34146b422d7aebd1a51b20948d7872a514c4cfd7686dc436b70733d6473",
-        "wx" : "0b09685f338dceb421778a1458d52bed734c236242da2baa280d6f6b7b86e4f11",
+        "wx" : "00b09685f338dceb421778a1458d52bed734c236242da2baa280d6f6b7b86e4f11",
         "wy" : "7fe6a34146b422d7aebd1a51b20948d7872a514c4cfd7686dc436b70733d6473"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b09685f338dceb421778a1458d52bed734c236242da2baa280d6f6b7b86e4f117fe6a34146b422d7aebd1a51b20948d7872a514c4cfd7686dc436b70733d6473",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsJaF8zjc60IXeKFFjVK+1zTCNiQt\norqigNb2t7huTxF/5qNBRrQi1669GlGyCUjXhypRTEz9dobcQ2twcz1kcw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b09685f338dceb421778a1458d52bed734c236242da2baa280d6f6b7b86e4f117fe6a34146b422d7aebd1a51b20948d7872a514c4cfd7686dc436b70733d6473",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsJaF8zjc60IXeKFFjVK+1zTCNiQt\norqigNb2t7huTxF/5qNBRrQi1669GlGyCUjXhypRTEz9dobcQ2twcz1kcw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 372,
+          "tcId" : 477,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0221008ecd11081a4d0759c14f7bf46813d52cc6738115321be0a4da78a3356bb71510",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04dd811f2c0f5e9d4fbb2ef31818c1cd807247bc14fcd1170bef00e2c71dc037b443a15cdf8f3fbdc87e06250c0720d261d2b8d087fa7bf9548f6293f0ce5ae899",
-        "wx" : "0dd811f2c0f5e9d4fbb2ef31818c1cd807247bc14fcd1170bef00e2c71dc037b4",
+        "wx" : "00dd811f2c0f5e9d4fbb2ef31818c1cd807247bc14fcd1170bef00e2c71dc037b4",
         "wy" : "43a15cdf8f3fbdc87e06250c0720d261d2b8d087fa7bf9548f6293f0ce5ae899"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004dd811f2c0f5e9d4fbb2ef31818c1cd807247bc14fcd1170bef00e2c71dc037b443a15cdf8f3fbdc87e06250c0720d261d2b8d087fa7bf9548f6293f0ce5ae899",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3YEfLA9enU+7LvMYGMHNgHJHvBT8\n0RcL7wDixx3AN7RDoVzfjz+9yH4GJQwHINJh0rjQh/p7+VSPYpPwzlromQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004dd811f2c0f5e9d4fbb2ef31818c1cd807247bc14fcd1170bef00e2c71dc037b443a15cdf8f3fbdc87e06250c0720d261d2b8d087fa7bf9548f6293f0ce5ae899",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE3YEfLA9enU+7LvMYGMHNgHJHvBT8\n0RcL7wDixx3AN7RDoVzfjz+9yH4GJQwHINJh0rjQh/p7+VSPYpPwzlromQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 373,
+          "tcId" : 478,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100e8dbffed13c9a2093085c079714f11f24eb583d73ba2b416b3169183e7d9b4c2",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0469d60ae1f39e1da95809d408894707ad2134f4943a1db089bebf815a391f18db32b401d98bf894d3b6d59e6eb45573285642e358ad687b7d7bf9600b1987809e",
         "wx" : "69d60ae1f39e1da95809d408894707ad2134f4943a1db089bebf815a391f18db",
         "wy" : "32b401d98bf894d3b6d59e6eb45573285642e358ad687b7d7bf9600b1987809e"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000469d60ae1f39e1da95809d408894707ad2134f4943a1db089bebf815a391f18db32b401d98bf894d3b6d59e6eb45573285642e358ad687b7d7bf9600b1987809e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEadYK4fOeHalYCdQIiUcHrSE09JQ6\nHbCJvr+BWjkfGNsytAHZi/iU07bVnm60VXMoVkLjWK1oe317+WALGYeAng==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000469d60ae1f39e1da95809d408894707ad2134f4943a1db089bebf815a391f18db32b401d98bf894d3b6d59e6eb45573285642e358ad687b7d7bf9600b1987809e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEadYK4fOeHalYCdQIiUcHrSE09JQ6\nHbCJvr+BWjkfGNsytAHZi/iU07bVnm60VXMoVkLjWK1oe317+WALGYeAng==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 374,
+          "tcId" : 479,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100ca01552a838124bec68d6bc6086329e06673900eac5c262e5ce79a8521cd1eae",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04a658553a0620c95e987b5c3163bcfea68c52065f53c9d553f2a924d8b3ed511f79f0dfec4536b65aa5fb31297e96f6b464aa669b9268b3156c43d4612978a577",
-        "wx" : "0a658553a0620c95e987b5c3163bcfea68c52065f53c9d553f2a924d8b3ed511f",
+        "wx" : "00a658553a0620c95e987b5c3163bcfea68c52065f53c9d553f2a924d8b3ed511f",
         "wy" : "79f0dfec4536b65aa5fb31297e96f6b464aa669b9268b3156c43d4612978a577"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a658553a0620c95e987b5c3163bcfea68c52065f53c9d553f2a924d8b3ed511f79f0dfec4536b65aa5fb31297e96f6b464aa669b9268b3156c43d4612978a577",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEplhVOgYgyV6Ye1wxY7z+poxSBl9T\nydVT8qkk2LPtUR958N/sRTa2WqX7MSl+lva0ZKpmm5JosxVsQ9RhKXildw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a658553a0620c95e987b5c3163bcfea68c52065f53c9d553f2a924d8b3ed511f79f0dfec4536b65aa5fb31297e96f6b464aa669b9268b3156c43d4612978a577",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEplhVOgYgyV6Ye1wxY7z+poxSBl9T\nydVT8qkk2LPtUR958N/sRTa2WqX7MSl+lva0ZKpmm5JosxVsQ9RhKXildw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 375,
+          "tcId" : 480,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0221009402aa560702497c8d1ad78c10c653c11000256fb1a0add7c6156a474737180b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04bc4d3354a6a973dd8088919cc181194e879ed7920db30d0d1278edf74413b7b92450d162b26dcb25fbbd53ea4044189981d737055925bd2e86bfb0374b09f3ca",
-        "wx" : "0bc4d3354a6a973dd8088919cc181194e879ed7920db30d0d1278edf74413b7b9",
+        "wx" : "00bc4d3354a6a973dd8088919cc181194e879ed7920db30d0d1278edf74413b7b9",
         "wy" : "2450d162b26dcb25fbbd53ea4044189981d737055925bd2e86bfb0374b09f3ca"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bc4d3354a6a973dd8088919cc181194e879ed7920db30d0d1278edf74413b7b92450d162b26dcb25fbbd53ea4044189981d737055925bd2e86bfb0374b09f3ca",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvE0zVKapc92AiJGcwYEZToee15IN\nsw0NEnjt90QTt7kkUNFism3LJfu9U+pARBiZgdc3BVklvS6Gv7A3Swnzyg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bc4d3354a6a973dd8088919cc181194e879ed7920db30d0d1278edf74413b7b92450d162b26dcb25fbbd53ea4044189981d737055925bd2e86bfb0374b09f3ca",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvE0zVKapc92AiJGcwYEZToee15IN\nsw0NEnjt90QTt7kkUNFism3LJfu9U+pARBiZgdc3BVklvS6Gv7A3Swnzyg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 376,
+          "tcId" : 481,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02205e03ff818a836e3a53a8435219297da1b98cbad0b6e535812f433a096ca11168",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "040eb628724fce764c687d874ade7b8e0aa4abf20ee6e3610fac9fe3e72f97ab5aed09f4843660eb1daf015d397a7c1073d7ae43bda0ba3e117008785abfffa00f",
         "wx" : "0eb628724fce764c687d874ade7b8e0aa4abf20ee6e3610fac9fe3e72f97ab5a",
-        "wy" : "0ed09f4843660eb1daf015d397a7c1073d7ae43bda0ba3e117008785abfffa00f"
+        "wy" : "00ed09f4843660eb1daf015d397a7c1073d7ae43bda0ba3e117008785abfffa00f"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040eb628724fce764c687d874ade7b8e0aa4abf20ee6e3610fac9fe3e72f97ab5aed09f4843660eb1daf015d397a7c1073d7ae43bda0ba3e117008785abfffa00f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDrYock/OdkxofYdK3nuOCqSr8g7m\n42EPrJ/j5y+Xq1rtCfSENmDrHa8BXTl6fBBz165DvaC6PhFwCHhav/+gDw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040eb628724fce764c687d874ade7b8e0aa4abf20ee6e3610fac9fe3e72f97ab5aed09f4843660eb1daf015d397a7c1073d7ae43bda0ba3e117008785abfffa00f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDrYock/OdkxofYdK3nuOCqSr8g7m\n42EPrJ/j5y+Xq1rtCfSENmDrHa8BXTl6fBBz165DvaC6PhFwCHhav/+gDw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 377,
+          "tcId" : 482,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100e28ddf709d4aa1bddf2e4bc7c7f2cb516cb642bb3e39c3feaf2fcf16ab9539f4",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04e7ac5cc7f296912f703f59fe88e49b521da245e12e6eee161ee6b3b1127611a77b3bedd2a773cf58b0629b936dd85dad2d0c39676306ed63e1a9bcd0e08bccc2",
-        "wx" : "0e7ac5cc7f296912f703f59fe88e49b521da245e12e6eee161ee6b3b1127611a7",
+        "wx" : "00e7ac5cc7f296912f703f59fe88e49b521da245e12e6eee161ee6b3b1127611a7",
         "wy" : "7b3bedd2a773cf58b0629b936dd85dad2d0c39676306ed63e1a9bcd0e08bccc2"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e7ac5cc7f296912f703f59fe88e49b521da245e12e6eee161ee6b3b1127611a77b3bedd2a773cf58b0629b936dd85dad2d0c39676306ed63e1a9bcd0e08bccc2",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE56xcx/KWkS9wP1n+iOSbUh2iReEu\nbu4WHuazsRJ2Ead7O+3Sp3PPWLBim5Nt2F2tLQw5Z2MG7WPhqbzQ4IvMwg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004e7ac5cc7f296912f703f59fe88e49b521da245e12e6eee161ee6b3b1127611a77b3bedd2a773cf58b0629b936dd85dad2d0c39676306ed63e1a9bcd0e08bccc2",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE56xcx/KWkS9wP1n+iOSbUh2iReEu\nbu4WHuazsRJ2Ead7O+3Sp3PPWLBim5Nt2F2tLQw5Z2MG7WPhqbzQ4IvMwg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 378,
+          "tcId" : 483,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02207fffffffaaaaaaaaffffffffffffffffe9a2538f37b28a2c513dee40fecbb71a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "042407b60abf3ee5edaf92ed505a11d0ddce0ea33eca58a031bb2f162c512f4062fb81bff36bf967e834e3d5d468730dcd70440022ab60061a62fac53350fe259f",
         "wx" : "2407b60abf3ee5edaf92ed505a11d0ddce0ea33eca58a031bb2f162c512f4062",
-        "wy" : "0fb81bff36bf967e834e3d5d468730dcd70440022ab60061a62fac53350fe259f"
+        "wy" : "00fb81bff36bf967e834e3d5d468730dcd70440022ab60061a62fac53350fe259f"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042407b60abf3ee5edaf92ed505a11d0ddce0ea33eca58a031bb2f162c512f4062fb81bff36bf967e834e3d5d468730dcd70440022ab60061a62fac53350fe259f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJAe2Cr8+5e2vku1QWhHQ3c4Ooz7K\nWKAxuy8WLFEvQGL7gb/za/ln6DTj1dRocw3NcEQAIqtgBhpi+sUzUP4lnw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042407b60abf3ee5edaf92ed505a11d0ddce0ea33eca58a031bb2f162c512f4062fb81bff36bf967e834e3d5d468730dcd70440022ab60061a62fac53350fe259f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEJAe2Cr8+5e2vku1QWhHQ3c4Ooz7K\nWKAxuy8WLFEvQGL7gb/za/ln6DTj1dRocw3NcEQAIqtgBhpi+sUzUP4lnw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 379,
+          "tcId" : 484,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100b62f26b5f2a2b26f6de86d42ad8a13da3ab3cccd0459b201de009e526adf21f2",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0447b2ad96dfc2f23fe5926809f38042b2c801962bd7394cefbf4aacb2554b7b0bdf2b937a16a7d96a2a0682cd164428890208597f2cdcc734fda73600b5cf6c59",
         "wx" : "47b2ad96dfc2f23fe5926809f38042b2c801962bd7394cefbf4aacb2554b7b0b",
-        "wy" : "0df2b937a16a7d96a2a0682cd164428890208597f2cdcc734fda73600b5cf6c59"
+        "wy" : "00df2b937a16a7d96a2a0682cd164428890208597f2cdcc734fda73600b5cf6c59"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000447b2ad96dfc2f23fe5926809f38042b2c801962bd7394cefbf4aacb2554b7b0bdf2b937a16a7d96a2a0682cd164428890208597f2cdcc734fda73600b5cf6c59",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAER7Ktlt/C8j/lkmgJ84BCssgBlivX\nOUzvv0qsslVLewvfK5N6FqfZaioGgs0WRCiJAghZfyzcxzT9pzYAtc9sWQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000447b2ad96dfc2f23fe5926809f38042b2c801962bd7394cefbf4aacb2554b7b0bdf2b937a16a7d96a2a0682cd164428890208597f2cdcc734fda73600b5cf6c59",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAER7Ktlt/C8j/lkmgJ84BCssgBlivX\nOUzvv0qsslVLewvfK5N6FqfZaioGgs0WRCiJAghZfyzcxzT9pzYAtc9sWQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 380,
+          "tcId" : 485,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bb1d9ac949dd748cd02bbbe749bd351cd57b38bb61403d700686aa7b4c90851e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0469a65b75f31ae7b4930292f90902461befcee5d1606939c28e01b652a7fbc498cf68619e5860128f56cecf53eba2ffe82889a9bb04a5fa4c8b722bc91d55978a",
         "wx" : "69a65b75f31ae7b4930292f90902461befcee5d1606939c28e01b652a7fbc498",
-        "wy" : "0cf68619e5860128f56cecf53eba2ffe82889a9bb04a5fa4c8b722bc91d55978a"
+        "wy" : "00cf68619e5860128f56cecf53eba2ffe82889a9bb04a5fa4c8b722bc91d55978a"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000469a65b75f31ae7b4930292f90902461befcee5d1606939c28e01b652a7fbc498cf68619e5860128f56cecf53eba2ffe82889a9bb04a5fa4c8b722bc91d55978a",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaaZbdfMa57STApL5CQJGG+/O5dFg\naTnCjgG2Uqf7xJjPaGGeWGASj1bOz1Prov/oKImpuwSl+kyLcivJHVWXig==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000469a65b75f31ae7b4930292f90902461befcee5d1606939c28e01b652a7fbc498cf68619e5860128f56cecf53eba2ffe82889a9bb04a5fa4c8b722bc91d55978a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaaZbdfMa57STApL5CQJGG+/O5dFg\naTnCjgG2Uqf7xJjPaGGeWGASj1bOz1Prov/oKImpuwSl+kyLcivJHVWXig==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 381,
+          "tcId" : 486,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022066755a00638cdaec1c732513ca0234ece52545dac11f816e818f725b4f60aaf2",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04b2037176c84db04a6c773e32f9ed1d6b25ef4c303c6725c6932ec2cc2788bcbb9361505e6b771691adb41598f292d6521722404bf183241b195738b77abd6cfe",
-        "wx" : "0b2037176c84db04a6c773e32f9ed1d6b25ef4c303c6725c6932ec2cc2788bcbb",
-        "wy" : "09361505e6b771691adb41598f292d6521722404bf183241b195738b77abd6cfe"
+        "wx" : "00b2037176c84db04a6c773e32f9ed1d6b25ef4c303c6725c6932ec2cc2788bcbb",
+        "wy" : "009361505e6b771691adb41598f292d6521722404bf183241b195738b77abd6cfe"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b2037176c84db04a6c773e32f9ed1d6b25ef4c303c6725c6932ec2cc2788bcbb9361505e6b771691adb41598f292d6521722404bf183241b195738b77abd6cfe",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsgNxdshNsEpsdz4y+e0dayXvTDA8\nZyXGky7CzCeIvLuTYVBea3cWka20FZjyktZSFyJAS/GDJBsZVzi3er1s/g==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b2037176c84db04a6c773e32f9ed1d6b25ef4c303c6725c6932ec2cc2788bcbb9361505e6b771691adb41598f292d6521722404bf183241b195738b77abd6cfe",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEsgNxdshNsEpsdz4y+e0dayXvTDA8\nZyXGky7CzCeIvLuTYVBea3cWka20FZjyktZSFyJAS/GDJBsZVzi3er1s/g==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 382,
+          "tcId" : 487,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022055a00c9fcdaebb6032513ca0234ecfffe98ebe492fdf02e48ca48e982beb3669",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "041eef95aef71f793afd50bb2604064d63e88bef7404a4d0e206446245ae2e7834c96e86dd040f9794b63712d90e719576b8b92c406ab0f288ad9b327bd124454f",
         "wx" : "1eef95aef71f793afd50bb2604064d63e88bef7404a4d0e206446245ae2e7834",
-        "wy" : "0c96e86dd040f9794b63712d90e719576b8b92c406ab0f288ad9b327bd124454f"
+        "wy" : "00c96e86dd040f9794b63712d90e719576b8b92c406ab0f288ad9b327bd124454f"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041eef95aef71f793afd50bb2604064d63e88bef7404a4d0e206446245ae2e7834c96e86dd040f9794b63712d90e719576b8b92c406ab0f288ad9b327bd124454f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHu+VrvcfeTr9ULsmBAZNY+iL73QE\npNDiBkRiRa4ueDTJbobdBA+XlLY3EtkOcZV2uLksQGqw8oitmzJ70SRFTw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041eef95aef71f793afd50bb2604064d63e88bef7404a4d0e206446245ae2e7834c96e86dd040f9794b63712d90e719576b8b92c406ab0f288ad9b327bd124454f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHu+VrvcfeTr9ULsmBAZNY+iL73QE\npNDiBkRiRa4ueDTJbobdBA+XlLY3EtkOcZV2uLksQGqw8oitmzJ70SRFTw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 383,
+          "tcId" : 488,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100ab40193f9b5d76c064a27940469d9fffd31d7c925fbe05c919491d3057d66cd2",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04a9734899c954e5b7adbca8f783428b5fbcbdfd3d2813f8d2f95b31a78ab107567667abf8c02ce4951bc59b2564130c27d7b64cdbc5cad95ca42d5bbb7cd4e793",
-        "wx" : "0a9734899c954e5b7adbca8f783428b5fbcbdfd3d2813f8d2f95b31a78ab10756",
+        "wx" : "00a9734899c954e5b7adbca8f783428b5fbcbdfd3d2813f8d2f95b31a78ab10756",
         "wy" : "7667abf8c02ce4951bc59b2564130c27d7b64cdbc5cad95ca42d5bbb7cd4e793"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a9734899c954e5b7adbca8f783428b5fbcbdfd3d2813f8d2f95b31a78ab107567667abf8c02ce4951bc59b2564130c27d7b64cdbc5cad95ca42d5bbb7cd4e793",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqXNImclU5betvKj3g0KLX7y9/T0o\nE/jS+Vsxp4qxB1Z2Z6v4wCzklRvFmyVkEwwn17ZM28XK2VykLVu7fNTnkw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004a9734899c954e5b7adbca8f783428b5fbcbdfd3d2813f8d2f95b31a78ab107567667abf8c02ce4951bc59b2564130c27d7b64cdbc5cad95ca42d5bbb7cd4e793",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqXNImclU5betvKj3g0KLX7y9/T0o\nE/jS+Vsxp4qxB1Z2Z6v4wCzklRvFmyVkEwwn17ZM28XK2VykLVu7fNTnkw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 384,
+          "tcId" : 489,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100ca0234ebb5fdcb13ca0234ecffffffffcb0dadbbc7f549f8a26b4408d0dc8600",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "041ae51662331a1dbfab0751d30dfab2273a04a239e055a537b16ab595f9612396434f21c2bfe6555c9fc4a8e82dab1fa5631881b016e0831d9e1bbf5799fcf32e",
         "wx" : "1ae51662331a1dbfab0751d30dfab2273a04a239e055a537b16ab595f9612396",
         "wy" : "434f21c2bfe6555c9fc4a8e82dab1fa5631881b016e0831d9e1bbf5799fcf32e"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041ae51662331a1dbfab0751d30dfab2273a04a239e055a537b16ab595f9612396434f21c2bfe6555c9fc4a8e82dab1fa5631881b016e0831d9e1bbf5799fcf32e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGuUWYjMaHb+rB1HTDfqyJzoEojng\nVaU3sWq1lflhI5ZDTyHCv+ZVXJ/EqOgtqx+lYxiBsBbggx2eG79XmfzzLg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041ae51662331a1dbfab0751d30dfab2273a04a239e055a537b16ab595f9612396434f21c2bfe6555c9fc4a8e82dab1fa5631881b016e0831d9e1bbf5799fcf32e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEGuUWYjMaHb+rB1HTDfqyJzoEojng\nVaU3sWq1lflhI5ZDTyHCv+ZVXJ/EqOgtqx+lYxiBsBbggx2eG79XmfzzLg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 385,
+          "tcId" : 490,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bfffffff3ea3677e082b9310572620ae19933a9e65b285598711c77298815ad3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0453c90cdd8b0dadd21c44ad557b327f4dbf57144aaf06597deb3f94125206a6c14603475bd79b30e36340cd09b0b59e6cd46ce90150e9ffe5c8a0172b2c9898e3",
         "wx" : "53c90cdd8b0dadd21c44ad557b327f4dbf57144aaf06597deb3f94125206a6c1",
         "wy" : "4603475bd79b30e36340cd09b0b59e6cd46ce90150e9ffe5c8a0172b2c9898e3"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000453c90cdd8b0dadd21c44ad557b327f4dbf57144aaf06597deb3f94125206a6c14603475bd79b30e36340cd09b0b59e6cd46ce90150e9ffe5c8a0172b2c9898e3",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEU8kM3YsNrdIcRK1VezJ/Tb9XFEqv\nBll96z+UElIGpsFGA0db15sw42NAzQmwtZ5s1GzpAVDp/+XIoBcrLJiY4w==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000453c90cdd8b0dadd21c44ad557b327f4dbf57144aaf06597deb3f94125206a6c14603475bd79b30e36340cd09b0b59e6cd46ce90150e9ffe5c8a0172b2c9898e3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEU8kM3YsNrdIcRK1VezJ/Tb9XFEqv\nBll96z+UElIGpsFGA0db15sw42NAzQmwtZ5s1GzpAVDp/+XIoBcrLJiY4w==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 386,
+          "tcId" : 491,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0220266666663bbbbbbbe6666666666666665b37902e023fab7c8f055d86e5cc41f4",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0433797539515c51f429967b8e36930d9fdda1edb13aecec9771f7cde5f6f2e74eba51d0b6456bb902dba1f3ea436f96ad2355da454dc9b32c503c4bc6cfd6d410",
         "wx" : "33797539515c51f429967b8e36930d9fdda1edb13aecec9771f7cde5f6f2e74e",
-        "wy" : "0ba51d0b6456bb902dba1f3ea436f96ad2355da454dc9b32c503c4bc6cfd6d410"
+        "wy" : "00ba51d0b6456bb902dba1f3ea436f96ad2355da454dc9b32c503c4bc6cfd6d410"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000433797539515c51f429967b8e36930d9fdda1edb13aecec9771f7cde5f6f2e74eba51d0b6456bb902dba1f3ea436f96ad2355da454dc9b32c503c4bc6cfd6d410",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEM3l1OVFcUfQplnuONpMNn92h7bE6\n7OyXcffN5fby5066UdC2RWu5Atuh8+pDb5atI1XaRU3JsyxQPEvGz9bUEA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000433797539515c51f429967b8e36930d9fdda1edb13aecec9771f7cde5f6f2e74eba51d0b6456bb902dba1f3ea436f96ad2355da454dc9b32c503c4bc6cfd6d410",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEM3l1OVFcUfQplnuONpMNn92h7bE6\n7OyXcffN5fby5066UdC2RWu5Atuh8+pDb5atI1XaRU3JsyxQPEvGz9bUEA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 387,
+          "tcId" : 492,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bfffffff36db6db7a492492492492492146c573f4c6dfc8d08a443e258970b09",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "040a8f5f1d5bbd2783fa7f37c86879057fb2fcf25383aafb86d03d6bafb41a17b3eaf6da715fe950349fd5736117b08e15e32cf1d2fdc003e510009f1b4ba1e648",
         "wx" : "0a8f5f1d5bbd2783fa7f37c86879057fb2fcf25383aafb86d03d6bafb41a17b3",
-        "wy" : "0eaf6da715fe950349fd5736117b08e15e32cf1d2fdc003e510009f1b4ba1e648"
+        "wy" : "00eaf6da715fe950349fd5736117b08e15e32cf1d2fdc003e510009f1b4ba1e648"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040a8f5f1d5bbd2783fa7f37c86879057fb2fcf25383aafb86d03d6bafb41a17b3eaf6da715fe950349fd5736117b08e15e32cf1d2fdc003e510009f1b4ba1e648",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECo9fHVu9J4P6fzfIaHkFf7L88lOD\nqvuG0D1rr7QaF7Pq9tpxX+lQNJ/Vc2EXsI4V4yzx0v3AA+UQAJ8bS6HmSA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040a8f5f1d5bbd2783fa7f37c86879057fb2fcf25383aafb86d03d6bafb41a17b3eaf6da715fe950349fd5736117b08e15e32cf1d2fdc003e510009f1b4ba1e648",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECo9fHVu9J4P6fzfIaHkFf7L88lOD\nqvuG0D1rr7QaF7Pq9tpxX+lQNJ/Vc2EXsI4V4yzx0v3AA+UQAJ8bS6HmSA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 388,
+          "tcId" : 493,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd022100bfffffff2aaaaaab7fffffffffffffffc815d0e60b3e596ecb1ad3a27cfd49c4",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "041dbc94e96c056b9d2cb6773bb24b69ed473851badf927a29955aff290ef3675a65e587561122aa8226facb95df08308cadf01c8351a1569176d917821113aa7c",
         "wx" : "1dbc94e96c056b9d2cb6773bb24b69ed473851badf927a29955aff290ef3675a",
         "wy" : "65e587561122aa8226facb95df08308cadf01c8351a1569176d917821113aa7c"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041dbc94e96c056b9d2cb6773bb24b69ed473851badf927a29955aff290ef3675a65e587561122aa8226facb95df08308cadf01c8351a1569176d917821113aa7c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHbyU6WwFa50stnc7sktp7Uc4Ubrf\nknoplVr/KQ7zZ1pl5YdWESKqgib6y5XfCDCMrfAcg1GhVpF22ReCEROqfA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041dbc94e96c056b9d2cb6773bb24b69ed473851badf927a29955aff290ef3675a65e587561122aa8226facb95df08308cadf01c8351a1569176d917821113aa7c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEHbyU6WwFa50stnc7sktp7Uc4Ubrf\nknoplVr/KQ7zZ1pl5YdWESKqgib6y5XfCDCMrfAcg1GhVpF22ReCEROqfA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 389,
+          "tcId" : 494,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02207fffffff55555555ffffffffffffffffd344a71e6f651458a27bdc81fd976e37",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04084ab885dbff7f12e6cdadb59d456e500797779425c7518c259c83718289e6e991c345d3a093e86670605bbc2ff4c69d0ed694fd433ec6b6ba1bf7d56c3e6b51",
         "wx" : "084ab885dbff7f12e6cdadb59d456e500797779425c7518c259c83718289e6e9",
-        "wy" : "091c345d3a093e86670605bbc2ff4c69d0ed694fd433ec6b6ba1bf7d56c3e6b51"
+        "wy" : "0091c345d3a093e86670605bbc2ff4c69d0ed694fd433ec6b6ba1bf7d56c3e6b51"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004084ab885dbff7f12e6cdadb59d456e500797779425c7518c259c83718289e6e991c345d3a093e86670605bbc2ff4c69d0ed694fd433ec6b6ba1bf7d56c3e6b51",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECEq4hdv/fxLmza21nUVuUAeXd5Ql\nx1GMJZyDcYKJ5umRw0XToJPoZnBgW7wv9MadDtaU/UM+xra6G/fVbD5rUQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004084ab885dbff7f12e6cdadb59d456e500797779425c7518c259c83718289e6e991c345d3a093e86670605bbc2ff4c69d0ed694fd433ec6b6ba1bf7d56c3e6b51",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAECEq4hdv/fxLmza21nUVuUAeXd5Ql\nx1GMJZyDcYKJ5umRw0XToJPoZnBgW7wv9MadDtaU/UM+xra6G/fVbD5rUQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 390,
+          "tcId" : 495,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02203fffffff800000007fffffffffffffffde737d56d38bcf4279dce5617e3192aa",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04003adfa4c620a207096cd18ee8fd2a90e20106cf824a0c63d6dec727a9fe7f509430d26bdd5f71e819d12b70069901461ae083cc809122d4fb86b5c475244e5a",
         "wx" : "3adfa4c620a207096cd18ee8fd2a90e20106cf824a0c63d6dec727a9fe7f50",
-        "wy" : "09430d26bdd5f71e819d12b70069901461ae083cc809122d4fb86b5c475244e5a"
+        "wy" : "009430d26bdd5f71e819d12b70069901461ae083cc809122d4fb86b5c475244e5a"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004003adfa4c620a207096cd18ee8fd2a90e20106cf824a0c63d6dec727a9fe7f509430d26bdd5f71e819d12b70069901461ae083cc809122d4fb86b5c475244e5a",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADrfpMYgogcJbNGO6P0qkOIBBs+C\nSgxj1t7HJ6n+f1CUMNJr3V9x6BnRK3AGmQFGGuCDzICRItT7hrXEdSROWg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004003adfa4c620a207096cd18ee8fd2a90e20106cf824a0c63d6dec727a9fe7f509430d26bdd5f71e819d12b70069901461ae083cc809122d4fb86b5c475244e5a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEADrfpMYgogcJbNGO6P0qkOIBBs+C\nSgxj1t7HJ6n+f1CUMNJr3V9x6BnRK3AGmQFGGuCDzICRItT7hrXEdSROWg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 391,
+          "tcId" : 496,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02205d8ecd64a4eeba466815ddf3a4de9a8e6abd9c5db0a01eb80343553da648428f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "047c98b2d47eb433c0d18e533cfbc8909d66f7b79d5925ccb17eccec9d105c58848d5ca99b350bd7d10ab5ee6fcfe46623fdc03e9f828158f4d4cc08ad1ff83de4",
         "wx" : "7c98b2d47eb433c0d18e533cfbc8909d66f7b79d5925ccb17eccec9d105c5884",
-        "wy" : "08d5ca99b350bd7d10ab5ee6fcfe46623fdc03e9f828158f4d4cc08ad1ff83de4"
+        "wy" : "008d5ca99b350bd7d10ab5ee6fcfe46623fdc03e9f828158f4d4cc08ad1ff83de4"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047c98b2d47eb433c0d18e533cfbc8909d66f7b79d5925ccb17eccec9d105c58848d5ca99b350bd7d10ab5ee6fcfe46623fdc03e9f828158f4d4cc08ad1ff83de4",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfJiy1H60M8DRjlM8+8iQnWb3t51Z\nJcyxfszsnRBcWISNXKmbNQvX0Qq17m/P5GYj/cA+n4KBWPTUzAitH/g95A==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047c98b2d47eb433c0d18e533cfbc8909d66f7b79d5925ccb17eccec9d105c58848d5ca99b350bd7d10ab5ee6fcfe46623fdc03e9f828158f4d4cc08ad1ff83de4",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfJiy1H60M8DRjlM8+8iQnWb3t51Z\nJcyxfszsnRBcWISNXKmbNQvX0Qq17m/P5GYj/cA+n4KBWPTUzAitH/g95A==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 392,
+          "tcId" : 497,
           "comment" : "point duplication during verification",
-          "msg" : "313233343030",
-          "sig" : "304502206f2347cab7dd76858fe0555ac3bc99048c4aacafdfb6bcbe05ea6c42c4934569022100b4cfa1996ec1d24cdbc8fa17fcabc3a5d4b2b36cf4b50a7b775ab78785710746",
-          "result" : "valid",
           "flags" : [
             "PointDuplication"
-          ]
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502206f2347cab7dd76858fe0555ac3bc99048c4aacafdfb6bcbe05ea6c42c4934569022100b4cfa1996ec1d24cdbc8fa17fcabc3a5d4b2b36cf4b50a7b775ab78785710746",
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "047c98b2d47eb433c0d18e533cfbc8909d66f7b79d5925ccb17eccec9d105c588472a35663caf4282ff54a1190301b99dc023fc1617d7ea70b2b33f752e007c21b",
         "wx" : "7c98b2d47eb433c0d18e533cfbc8909d66f7b79d5925ccb17eccec9d105c5884",
         "wy" : "72a35663caf4282ff54a1190301b99dc023fc1617d7ea70b2b33f752e007c21b"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047c98b2d47eb433c0d18e533cfbc8909d66f7b79d5925ccb17eccec9d105c588472a35663caf4282ff54a1190301b99dc023fc1617d7ea70b2b33f752e007c21b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfJiy1H60M8DRjlM8+8iQnWb3t51Z\nJcyxfszsnRBcWIRyo1ZjyvQoL/VKEZAwG5ncAj/BYX1+pwsrM/dS4AfCGw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200047c98b2d47eb433c0d18e533cfbc8909d66f7b79d5925ccb17eccec9d105c588472a35663caf4282ff54a1190301b99dc023fc1617d7ea70b2b33f752e007c21b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEfJiy1H60M8DRjlM8+8iQnWb3t51Z\nJcyxfszsnRBcWIRyo1ZjyvQoL/VKEZAwG5ncAj/BYX1+pwsrM/dS4AfCGw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 393,
+          "tcId" : 498,
           "comment" : "duplication bug",
-          "msg" : "313233343030",
-          "sig" : "304502206f2347cab7dd76858fe0555ac3bc99048c4aacafdfb6bcbe05ea6c42c4934569022100b4cfa1996ec1d24cdbc8fa17fcabc3a5d4b2b36cf4b50a7b775ab78785710746",
-          "result" : "invalid",
           "flags" : [
             "PointDuplication"
-          ]
+          ],
+          "msg" : "313233343030",
+          "sig" : "304502206f2347cab7dd76858fe0555ac3bc99048c4aacafdfb6bcbe05ea6c42c4934569022100b4cfa1996ec1d24cdbc8fa17fcabc3a5d4b2b36cf4b50a7b775ab78785710746",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04b7a90e21e7547d73267940033cea05042c50f7c9fa5eaeb471cd6260c685f2e38bb7309d0c3bab249faaf3e44179d6dd5302375c580fd0570a788c6be3680c67",
-        "wx" : "0b7a90e21e7547d73267940033cea05042c50f7c9fa5eaeb471cd6260c685f2e3",
-        "wy" : "08bb7309d0c3bab249faaf3e44179d6dd5302375c580fd0570a788c6be3680c67"
+        "wx" : "00b7a90e21e7547d73267940033cea05042c50f7c9fa5eaeb471cd6260c685f2e3",
+        "wy" : "008bb7309d0c3bab249faaf3e44179d6dd5302375c580fd0570a788c6be3680c67"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b7a90e21e7547d73267940033cea05042c50f7c9fa5eaeb471cd6260c685f2e38bb7309d0c3bab249faaf3e44179d6dd5302375c580fd0570a788c6be3680c67",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEt6kOIedUfXMmeUADPOoFBCxQ98n6\nXq60cc1iYMaF8uOLtzCdDDurJJ+q8+RBedbdUwI3XFgP0FcKeIxr42gMZw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004b7a90e21e7547d73267940033cea05042c50f7c9fa5eaeb471cd6260c685f2e38bb7309d0c3bab249faaf3e44179d6dd5302375c580fd0570a788c6be3680c67",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEt6kOIedUfXMmeUADPOoFBCxQ98n6\nXq60cc1iYMaF8uOLtzCdDDurJJ+q8+RBedbdUwI3XFgP0FcKeIxr42gMZw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 394,
+          "tcId" : 499,
           "comment" : "point with x-coordinate 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30250201010220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "041550a173373b2d594374f0642cd73de06a045c09c7a4f388c731e8cd8971adfc9a3a9843583a86c0e1c62cbde67165f40a926b1028ba38aa3895e188ebbc7066",
         "wx" : "1550a173373b2d594374f0642cd73de06a045c09c7a4f388c731e8cd8971adfc",
-        "wy" : "09a3a9843583a86c0e1c62cbde67165f40a926b1028ba38aa3895e188ebbc7066"
+        "wy" : "009a3a9843583a86c0e1c62cbde67165f40a926b1028ba38aa3895e188ebbc7066"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041550a173373b2d594374f0642cd73de06a045c09c7a4f388c731e8cd8971adfc9a3a9843583a86c0e1c62cbde67165f40a926b1028ba38aa3895e188ebbc7066",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFVChczc7LVlDdPBkLNc94GoEXAnH\npPOIxzHozYlxrfyaOphDWDqGwOHGLL3mcWX0CpJrECi6OKo4leGI67xwZg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200041550a173373b2d594374f0642cd73de06a045c09c7a4f388c731e8cd8971adfc9a3a9843583a86c0e1c62cbde67165f40a926b1028ba38aa3895e188ebbc7066",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEFVChczc7LVlDdPBkLNc94GoEXAnH\npPOIxzHozYlxrfyaOphDWDqGwOHGLL3mcWX0CpJrECi6OKo4leGI67xwZg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 395,
+          "tcId" : 500,
           "comment" : "point with x-coordinate 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3045022101000000000000000000000000000000000000000000000000000000000000000002203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aa9",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04313447778195daa1791a6530cd0697ae34bf9d8d225984394f72eef3505971110996a8fbdd1a70ecd64cb00b595afe1669bfef80d91756a62d84c1d83e0f22ab",
         "wx" : "313447778195daa1791a6530cd0697ae34bf9d8d225984394f72eef350597111",
         "wy" : "0996a8fbdd1a70ecd64cb00b595afe1669bfef80d91756a62d84c1d83e0f22ab"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004313447778195daa1791a6530cd0697ae34bf9d8d225984394f72eef3505971110996a8fbdd1a70ecd64cb00b595afe1669bfef80d91756a62d84c1d83e0f22ab",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMTRHd4GV2qF5GmUwzQaXrjS/nY0i\nWYQ5T3Lu81BZcREJlqj73Rpw7NZMsAtZWv4Wab/vgNkXVqYthMHYPg8iqw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004313447778195daa1791a6530cd0697ae34bf9d8d225984394f72eef3505971110996a8fbdd1a70ecd64cb00b595afe1669bfef80d91756a62d84c1d83e0f22ab",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEMTRHd4GV2qF5GmUwzQaXrjS/nY0i\nWYQ5T3Lu81BZcREJlqj73Rpw7NZMsAtZWv4Wab/vgNkXVqYthMHYPg8iqw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 396,
+          "tcId" : 501,
           "comment" : "comparison with point at infinity ",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30440220555555550000000055555555555555553ef7a8e48d07df81a693439654210c7002203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aa9",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "044ada634941476ca63c2c5803eec2f33b2d17920f798a5be6275f5a54cd2e7639b1a04bead5c7314c427492db21b9544d81caa8159587e41aa023aa967f31aaa1",
         "wx" : "4ada634941476ca63c2c5803eec2f33b2d17920f798a5be6275f5a54cd2e7639",
-        "wy" : "0b1a04bead5c7314c427492db21b9544d81caa8159587e41aa023aa967f31aaa1"
+        "wy" : "00b1a04bead5c7314c427492db21b9544d81caa8159587e41aa023aa967f31aaa1"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044ada634941476ca63c2c5803eec2f33b2d17920f798a5be6275f5a54cd2e7639b1a04bead5c7314c427492db21b9544d81caa8159587e41aa023aa967f31aaa1",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEStpjSUFHbKY8LFgD7sLzOy0Xkg95\nilvmJ19aVM0udjmxoEvq1ccxTEJ0ktshuVRNgcqoFZWH5BqgI6qWfzGqoQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044ada634941476ca63c2c5803eec2f33b2d17920f798a5be6275f5a54cd2e7639b1a04bead5c7314c427492db21b9544d81caa8159587e41aa023aa967f31aaa1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEStpjSUFHbKY8LFgD7sLzOy0Xkg95\nilvmJ19aVM0udjmxoEvq1ccxTEJ0ktshuVRNgcqoFZWH5BqgI6qWfzGqoQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 397,
+          "tcId" : 502,
           "comment" : "extreme value for k and edgecase s",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc476699780220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04aacce093270fa59ad412b5459a08e490743b97086c781ac3c8d54030b41a31193bece4956172d56befb7011d684e772905e48d2115444a75ac7a325a3f25f4b1",
-        "wx" : "0aacce093270fa59ad412b5459a08e490743b97086c781ac3c8d54030b41a3119",
+        "wx" : "00aacce093270fa59ad412b5459a08e490743b97086c781ac3c8d54030b41a3119",
         "wy" : "3bece4956172d56befb7011d684e772905e48d2115444a75ac7a325a3f25f4b1"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004aacce093270fa59ad412b5459a08e490743b97086c781ac3c8d54030b41a31193bece4956172d56befb7011d684e772905e48d2115444a75ac7a325a3f25f4b1",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqszgkycPpZrUErVFmgjkkHQ7lwhs\neBrDyNVAMLQaMRk77OSVYXLVa++3AR1oTncpBeSNIRVESnWsejJaPyX0sQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004aacce093270fa59ad412b5459a08e490743b97086c781ac3c8d54030b41a31193bece4956172d56befb7011d684e772905e48d2115444a75ac7a325a3f25f4b1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEqszgkycPpZrUErVFmgjkkHQ7lwhs\neBrDyNVAMLQaMRk77OSVYXLVa++3AR1oTncpBeSNIRVESnWsejJaPyX0sQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 398,
+          "tcId" : 503,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022100b6db6db6249249254924924924924924625bd7a09bec4ca81bcdd9f8fd6b63cc",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04f62b8d7feeff5a847ab79212269e55e62fa87ebe930821747b57a511a5ea99f0439ee057bb27898582a683c3fdb7f95404d41d42f276803751a316eb3aab7ebf",
-        "wx" : "0f62b8d7feeff5a847ab79212269e55e62fa87ebe930821747b57a511a5ea99f0",
+        "wx" : "00f62b8d7feeff5a847ab79212269e55e62fa87ebe930821747b57a511a5ea99f0",
         "wy" : "439ee057bb27898582a683c3fdb7f95404d41d42f276803751a316eb3aab7ebf"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f62b8d7feeff5a847ab79212269e55e62fa87ebe930821747b57a511a5ea99f0439ee057bb27898582a683c3fdb7f95404d41d42f276803751a316eb3aab7ebf",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9iuNf+7/WoR6t5ISJp5V5i+ofr6T\nCCF0e1elEaXqmfBDnuBXuyeJhYKmg8P9t/lUBNQdQvJ2gDdRoxbrOqt+vw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f62b8d7feeff5a847ab79212269e55e62fa87ebe930821747b57a511a5ea99f0439ee057bb27898582a683c3fdb7f95404d41d42f276803751a316eb3aab7ebf",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE9iuNf+7/WoR6t5ISJp5V5i+ofr6T\nCCF0e1elEaXqmfBDnuBXuyeJhYKmg8P9t/lUBNQdQvJ2gDdRoxbrOqt+vw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 399,
+          "tcId" : 504,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022100cccccccc00000000cccccccccccccccc971f2ef152794b9d8fc7d568c9e8eaa7",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "044baa07ff6e7bb9aa223d1c61932005fe98fe78b787fdab4bd3619bc8833072a2bcacd63802c56af82607953e72a0f5d3c23bd265544e020951824ea485555d33",
         "wx" : "4baa07ff6e7bb9aa223d1c61932005fe98fe78b787fdab4bd3619bc8833072a2",
-        "wy" : "0bcacd63802c56af82607953e72a0f5d3c23bd265544e020951824ea485555d33"
+        "wy" : "00bcacd63802c56af82607953e72a0f5d3c23bd265544e020951824ea485555d33"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044baa07ff6e7bb9aa223d1c61932005fe98fe78b787fdab4bd3619bc8833072a2bcacd63802c56af82607953e72a0f5d3c23bd265544e020951824ea485555d33",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAES6oH/257uaoiPRxhkyAF/pj+eLeH\n/atL02GbyIMwcqK8rNY4AsVq+CYHlT5yoPXTwjvSZVROAglRgk6khVVdMw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044baa07ff6e7bb9aa223d1c61932005fe98fe78b787fdab4bd3619bc8833072a2bcacd63802c56af82607953e72a0f5d3c23bd265544e020951824ea485555d33",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAES6oH/257uaoiPRxhkyAF/pj+eLeH\n/atL02GbyIMwcqK8rNY4AsVq+CYHlT5yoPXTwjvSZVROAglRgk6khVVdMw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 400,
+          "tcId" : 505,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc4766997802203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aaa",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "040c753ed1ba92f766800fdd0ae1c0d7f8f4cd8305fd803d8bca881397b5937e2db568509b1faf3cf251de6db9810e8b8caed235da10eeddbed62775c8e5c9460a",
         "wx" : "0c753ed1ba92f766800fdd0ae1c0d7f8f4cd8305fd803d8bca881397b5937e2d",
-        "wy" : "0b568509b1faf3cf251de6db9810e8b8caed235da10eeddbed62775c8e5c9460a"
+        "wy" : "00b568509b1faf3cf251de6db9810e8b8caed235da10eeddbed62775c8e5c9460a"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040c753ed1ba92f766800fdd0ae1c0d7f8f4cd8305fd803d8bca881397b5937e2db568509b1faf3cf251de6db9810e8b8caed235da10eeddbed62775c8e5c9460a",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDHU+0bqS92aAD90K4cDX+PTNgwX9\ngD2LyogTl7WTfi21aFCbH6888lHebbmBDouMrtI12hDu3b7WJ3XI5clGCg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200040c753ed1ba92f766800fdd0ae1c0d7f8f4cd8305fd803d8bca881397b5937e2db568509b1faf3cf251de6db9810e8b8caed235da10eeddbed62775c8e5c9460a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEDHU+0bqS92aAD90K4cDX+PTNgwX9\ngD2LyogTl7WTfi21aFCbH6888lHebbmBDouMrtI12hDu3b7WJ3XI5clGCg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 401,
+          "tcId" : 506,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022049249248db6db6dbb6db6db6db6db6db5a8b230d0b2b51dcd7ebf0c9fef7c185",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04030fdcae6541f22c5bab254e4f1a285c507d1cefea03bf90cf19daf3cb62df695ff2c94d588f2c2b2b0a12bebc011bcee4fa1b54506ec07d0a29d24a0891193c",
-        "wx" : "30fdcae6541f22c5bab254e4f1a285c507d1cefea03bf90cf19daf3cb62df69",
+        "wx" : "030fdcae6541f22c5bab254e4f1a285c507d1cefea03bf90cf19daf3cb62df69",
         "wy" : "5ff2c94d588f2c2b2b0a12bebc011bcee4fa1b54506ec07d0a29d24a0891193c"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004030fdcae6541f22c5bab254e4f1a285c507d1cefea03bf90cf19daf3cb62df695ff2c94d588f2c2b2b0a12bebc011bcee4fa1b54506ec07d0a29d24a0891193c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAw/crmVB8ixbqyVOTxooXFB9HO/q\nA7+Qzxna88ti32lf8slNWI8sKysKEr68ARvO5PobVFBuwH0KKdJKCJEZPA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004030fdcae6541f22c5bab254e4f1a285c507d1cefea03bf90cf19daf3cb62df695ff2c94d588f2c2b2b0a12bebc011bcee4fa1b54506ec07d0a29d24a0891193c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAw/crmVB8ixbqyVOTxooXFB9HO/q\nA7+Qzxna88ti32lf8slNWI8sKysKEr68ARvO5PobVFBuwH0KKdJKCJEZPA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 402,
+          "tcId" : 507,
           "comment" : "extreme value for k",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402207cf27b188d034f7e8a52380304b51ac3c08969e277f21b35a60b48fc47669978022016a4502e2781e11ac82cbc9d1edd8c981584d13e18411e2f6e0478c34416e3bb",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0403fc621eaf90c23d8f9fa125d2c59b8728ebccb30ca3e3db879a06ca90f20cdcae58d3f0c6aef0e805be10ea54e23cf6f0397f9addddc2b09088855316b0ef44",
-        "wx" : "3fc621eaf90c23d8f9fa125d2c59b8728ebccb30ca3e3db879a06ca90f20cdc",
-        "wy" : "0ae58d3f0c6aef0e805be10ea54e23cf6f0397f9addddc2b09088855316b0ef44"
+        "wx" : "03fc621eaf90c23d8f9fa125d2c59b8728ebccb30ca3e3db879a06ca90f20cdc",
+        "wy" : "00ae58d3f0c6aef0e805be10ea54e23cf6f0397f9addddc2b09088855316b0ef44"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000403fc621eaf90c23d8f9fa125d2c59b8728ebccb30ca3e3db879a06ca90f20cdcae58d3f0c6aef0e805be10ea54e23cf6f0397f9addddc2b09088855316b0ef44",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEA/xiHq+Qwj2Pn6El0sWbhyjrzLMM\no+Pbh5oGypDyDNyuWNPwxq7w6AW+EOpU4jz28Dl/mt3dwrCQiIVTFrDvRA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000403fc621eaf90c23d8f9fa125d2c59b8728ebccb30ca3e3db879a06ca90f20cdcae58d3f0c6aef0e805be10ea54e23cf6f0397f9addddc2b09088855316b0ef44",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEA/xiHq+Qwj2Pn6El0sWbhyjrzLMM\no+Pbh5oGypDyDNyuWNPwxq7w6AW+EOpU4jz28Dl/mt3dwrCQiIVTFrDvRA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 403,
+          "tcId" : 508,
           "comment" : "extreme value for k and edgecase s",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2960220555555550000000055555555555555553ef7a8e48d07df81a693439654210c70",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0470f2ce24dc62923bb09cc92d74329bbd0d2e6b0e354c0be2383d24acdccb9e4cd42d1f973466f5e5462a939084a294ebfc7a45629c70ee5def46de9536ea7bf7",
         "wx" : "70f2ce24dc62923bb09cc92d74329bbd0d2e6b0e354c0be2383d24acdccb9e4c",
-        "wy" : "0d42d1f973466f5e5462a939084a294ebfc7a45629c70ee5def46de9536ea7bf7"
+        "wy" : "00d42d1f973466f5e5462a939084a294ebfc7a45629c70ee5def46de9536ea7bf7"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000470f2ce24dc62923bb09cc92d74329bbd0d2e6b0e354c0be2383d24acdccb9e4cd42d1f973466f5e5462a939084a294ebfc7a45629c70ee5def46de9536ea7bf7",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcPLOJNxikjuwnMktdDKbvQ0uaw41\nTAviOD0krNzLnkzULR+XNGb15UYqk5CEopTr/HpFYpxw7l3vRt6VNup79w==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000470f2ce24dc62923bb09cc92d74329bbd0d2e6b0e354c0be2383d24acdccb9e4cd42d1f973466f5e5462a939084a294ebfc7a45629c70ee5def46de9536ea7bf7",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcPLOJNxikjuwnMktdDKbvQ0uaw41\nTAviOD0krNzLnkzULR+XNGb15UYqk5CEopTr/HpFYpxw7l3vRt6VNup79w==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 404,
+          "tcId" : 509,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022100b6db6db6249249254924924924924924625bd7a09bec4ca81bcdd9f8fd6b63cc",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04732b8ac0c30fe44307431235271cb5d6e5f677a19ce3f058b939a7bf19349d3c858cc735af8577468275847cf5ec19972e6c20738276e2708b23c595bfc4433d",
         "wx" : "732b8ac0c30fe44307431235271cb5d6e5f677a19ce3f058b939a7bf19349d3c",
-        "wy" : "0858cc735af8577468275847cf5ec19972e6c20738276e2708b23c595bfc4433d"
+        "wy" : "00858cc735af8577468275847cf5ec19972e6c20738276e2708b23c595bfc4433d"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004732b8ac0c30fe44307431235271cb5d6e5f677a19ce3f058b939a7bf19349d3c858cc735af8577468275847cf5ec19972e6c20738276e2708b23c595bfc4433d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcyuKwMMP5EMHQxI1Jxy11uX2d6Gc\n4/BYuTmnvxk0nTyFjMc1r4V3RoJ1hHz17BmXLmwgc4J24nCLI8WVv8RDPQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004732b8ac0c30fe44307431235271cb5d6e5f677a19ce3f058b939a7bf19349d3c858cc735af8577468275847cf5ec19972e6c20738276e2708b23c595bfc4433d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEcyuKwMMP5EMHQxI1Jxy11uX2d6Gc\n4/BYuTmnvxk0nTyFjMc1r4V3RoJ1hHz17BmXLmwgc4J24nCLI8WVv8RDPQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 405,
+          "tcId" : 510,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304502206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022100cccccccc00000000cccccccccccccccc971f2ef152794b9d8fc7d568c9e8eaa7",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0447aff9501825a166782bb58a5b459006eacdbce5e5323addad34ec1b6444cdce9199c31502ad4277c73ddd0c807b72634c45762404837d9814a5d4b5a7c3f398",
         "wx" : "47aff9501825a166782bb58a5b459006eacdbce5e5323addad34ec1b6444cdce",
-        "wy" : "09199c31502ad4277c73ddd0c807b72634c45762404837d9814a5d4b5a7c3f398"
+        "wy" : "009199c31502ad4277c73ddd0c807b72634c45762404837d9814a5d4b5a7c3f398"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000447aff9501825a166782bb58a5b459006eacdbce5e5323addad34ec1b6444cdce9199c31502ad4277c73ddd0c807b72634c45762404837d9814a5d4b5a7c3f398",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAER6/5UBgloWZ4K7WKW0WQBurNvOXl\nMjrdrTTsG2REzc6RmcMVAq1Cd8c93QyAe3JjTEV2JASDfZgUpdS1p8PzmA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000447aff9501825a166782bb58a5b459006eacdbce5e5323addad34ec1b6444cdce9199c31502ad4277c73ddd0c807b72634c45762404837d9814a5d4b5a7c3f398",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAER6/5UBgloWZ4K7WKW0WQBurNvOXl\nMjrdrTTsG2REzc6RmcMVAq1Cd8c93QyAe3JjTEV2JASDfZgUpdS1p8PzmA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 406,
+          "tcId" : 511,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c29602203333333300000000333333333333333325c7cbbc549e52e763f1f55a327a3aaa",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04aed8eeff77644bf83b9222f8f57173fa8217ec7e0763ee7d7171fb6092fba5c06486a86d94f48834ba5adbaf349687f9cee400389642b828e68207b147ca2c46",
-        "wx" : "0aed8eeff77644bf83b9222f8f57173fa8217ec7e0763ee7d7171fb6092fba5c0",
+        "wx" : "00aed8eeff77644bf83b9222f8f57173fa8217ec7e0763ee7d7171fb6092fba5c0",
         "wy" : "6486a86d94f48834ba5adbaf349687f9cee400389642b828e68207b147ca2c46"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004aed8eeff77644bf83b9222f8f57173fa8217ec7e0763ee7d7171fb6092fba5c06486a86d94f48834ba5adbaf349687f9cee400389642b828e68207b147ca2c46",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAErtju/3dkS/g7kiL49XFz+oIX7H4H\nY+59cXH7YJL7pcBkhqhtlPSINLpa2680lof5zuQAOJZCuCjmggexR8osRg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004aed8eeff77644bf83b9222f8f57173fa8217ec7e0763ee7d7171fb6092fba5c06486a86d94f48834ba5adbaf349687f9cee400389642b828e68207b147ca2c46",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAErtju/3dkS/g7kiL49XFz+oIX7H4H\nY+59cXH7YJL7pcBkhqhtlPSINLpa2680lof5zuQAOJZCuCjmggexR8osRg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 407,
+          "tcId" : 512,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022049249248db6db6dbb6db6db6db6db6db5a8b230d0b2b51dcd7ebf0c9fef7c185",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04f7c54a585a904300d05b53ef3b854e71999a344b89adc0caaa28e254db9bc7c7c161a79f38ff446051303577e40638fb020329940a63c241bb32c2205eb57b7d",
-        "wx" : "0f7c54a585a904300d05b53ef3b854e71999a344b89adc0caaa28e254db9bc7c7",
-        "wy" : "0c161a79f38ff446051303577e40638fb020329940a63c241bb32c2205eb57b7d"
+        "wx" : "00f7c54a585a904300d05b53ef3b854e71999a344b89adc0caaa28e254db9bc7c7",
+        "wy" : "00c161a79f38ff446051303577e40638fb020329940a63c241bb32c2205eb57b7d"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f7c54a585a904300d05b53ef3b854e71999a344b89adc0caaa28e254db9bc7c7c161a79f38ff446051303577e40638fb020329940a63c241bb32c2205eb57b7d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE98VKWFqQQwDQW1PvO4VOcZmaNEuJ\nrcDKqijiVNubx8fBYaefOP9EYFEwNXfkBjj7AgMplApjwkG7MsIgXrV7fQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004f7c54a585a904300d05b53ef3b854e71999a344b89adc0caaa28e254db9bc7c7c161a79f38ff446051303577e40638fb020329940a63c241bb32c2205eb57b7d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE98VKWFqQQwDQW1PvO4VOcZmaNEuJ\nrcDKqijiVNubx8fBYaefOP9EYFEwNXfkBjj7AgMplApjwkG7MsIgXrV7fQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 408,
+          "tcId" : 513,
           "comment" : "extreme value for k",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304402206b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296022016a4502e2781e11ac82cbc9d1edd8c981584d13e18411e2f6e0478c34416e3bb",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
         "wx" : "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
         "wy" : "4fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaxfR8uEsQkf4vOblY6RA8ncDfYEt\n6zOg9KE5RdiYwpZP40Li/hp/m47n60p8D54WK84zV2sxXs7LtkBoN79R9Q==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c2964fe342e2fe1a7f9b8ee7eb4a7c0f9e162bce33576b315ececbb6406837bf51f5",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaxfR8uEsQkf4vOblY6RA8ncDfYEt\n6zOg9KE5RdiYwpZP40Li/hp/m47n60p8D54WK84zV2sxXs7LtkBoN79R9Q==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 409,
-          "comment" : "testing point duplication",
+          "tcId" : 514,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "3044022043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b0232102810220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 410,
-          "comment" : "testing point duplication",
+          "tcId" : 515,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "3045022100bc07ff031506dc74a75086a43252fb43731975a16dca6b025e867412d94222d00220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a",
         "wx" : "6b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296",
-        "wy" : "0b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a"
+        "wy" : "00b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaxfR8uEsQkf4vOblY6RA8ncDfYEt\n6zOg9KE5RdiYwpawHL0cAeWAZXEYFLWD8GHp1DHMqZTOoTE0Sb+XyECuCg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200046b17d1f2e12c4247f8bce6e563a440f277037d812deb33a0f4a13945d898c296b01cbd1c01e58065711814b583f061e9d431cca994cea1313449bf97c840ae0a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEaxfR8uEsQkf4vOblY6RA8ncDfYEt\n6zOg9KE5RdiYwpawHL0cAeWAZXEYFLWD8GHp1DHMqZTOoTE0Sb+XyECuCg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 411,
-          "comment" : "testing point duplication",
+          "tcId" : 516,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "3044022043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b0232102810220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 412,
-          "comment" : "testing point duplication",
+          "tcId" : 517,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "3045022100bc07ff031506dc74a75086a43252fb43731975a16dca6b025e867412d94222d00220249249246db6db6ddb6db6db6db6db6dad4591868595a8ee6bf5f864ff7be0c2",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
-        "uncompressed" : "0404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
-        "wx" : "4aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad5",
-        "wy" : "087d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d"
-      },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000404aaec73635726f213fb8a9e64da3b8632e41495a944d0045b522eba7240fad587d9315798aaa3a5ba01775787ced05eaaf7b4e09fc81d6d1aa546e8365d525d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEBKrsc2NXJvIT+4qeZNo7hjLkFJWp\nRNAEW1IuunJA+tWH2TFXmKqjpboBd1eHztBeqve04J/IHW0apUboNl1SXQ==\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-512",
-      "type" : "ECDSAVer",
-      "tests" : [
-        {
-          "tcId" : 413,
-          "comment" : "pseudorandom signature",
-          "msg" : "",
-          "sig" : "30440220093f3825c0cf820cced816a3a67446c85606a6d529e43857643fccc11e1f705f0220769782888c63058630f97a5891c8700e82979e4f233586bfc5042fa73cb70a4e",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 414,
-          "comment" : "pseudorandom signature",
-          "msg" : "4d7367",
-          "sig" : "3046022100e8564e3e515a09f9f35258442b99e162d27e10975fcb7963d3c26319dc093f84022100c3af01ed0fd0148749ca323364846c862fc6f4beb682b7ead3b2d89b9da8bad4",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 415,
-          "comment" : "pseudorandom signature",
-          "msg" : "313233343030",
-          "sig" : "304502201412254f8c1dd2742a00ddee5192e7baa288741026871f3057ad9f983b5ab114022100bcdf878fa156f37040922698ad6fb6928601ddc26c40448ea660e67c25eda090",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 416,
-          "comment" : "pseudorandom signature",
-          "msg" : "0000000000000000000000000000000000000000",
-          "sig" : "30450221009e0676048381839bb0a4703a0ae38facfe1e2c61bd25950c896aa975cd6ec86902206ea0cedf96f11fff0e746941183492f4d17272c92449afd20e34041a6894ee82",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp256r1",
-        "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "044f337ccfd67726a805e4f1600ae2849df3807eca117380239fbd816900000000ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685",
         "wx" : "4f337ccfd67726a805e4f1600ae2849df3807eca117380239fbd816900000000",
-        "wy" : "0ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685"
+        "wy" : "00ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044f337ccfd67726a805e4f1600ae2849df3807eca117380239fbd816900000000ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETzN8z9Z3JqgF5PFgCuKEnfOAfsoR\nc4Ajn72BaQAAAADtneoSTMjDlkFkEemIww9CfrUEr0OjFGzV336mBmbWhQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200044f337ccfd67726a805e4f1600ae2849df3807eca117380239fbd816900000000ed9dea124cc8c396416411e988c30f427eb504af43a3146cd5df7ea60666d685",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAETzN8z9Z3JqgF5PFgCuKEnfOAfsoR\nc4Ajn72BaQAAAADtneoSTMjDlkFkEemIww9CfrUEr0OjFGzV336mBmbWhQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 417,
+          "tcId" : 518,
           "comment" : "x-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30440220554482404173a5582884b0d168a32ef8033d7eb780936c390e8eedf720c7f56402200a15413f9ed0d454b92ab901119e7251a4d444ba1421ba639fa57e0d8cf6b313",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 418,
+          "tcId" : 519,
           "comment" : "x-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304502200b1d838dd54a462745e2c8d5f32637f26fb16dde20a385e45f8a20a8a1f8370e022100ae855e0a10ef087075fda0ed84e2bc5786a681172ea9834e53351316df332bbd",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 419,
+          "tcId" : 520,
           "comment" : "x-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3045022100af89e4f2b03e5d1f0352e258ef71493040c17d70c36cfd044128302df2ed5e4a0220420f04148c3e6f06561bd448362d6c6fa3f9aeeb7e42843b4674e7ddfd0ba901",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f49726500493584fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000",
         "wx" : "3cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f497265004935",
-        "wy" : "084fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000"
+        "wy" : "0084fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f49726500493584fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPPA9YU2JOc/UmaB4c/rCgWGPBrj/\nh+gBXD9JcmUASTWE+hdNeRxyvyzjiAqJYN0qfHoTOKgvhanlnNvegAAAAA==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f49726500493584fa174d791c72bf2ce3880a8960dd2a7c7a1338a82f85a9e59cdbde80000000",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPPA9YU2JOc/UmaB4c/rCgWGPBrj/\nh+gBXD9JcmUASTWE+hdNeRxyvyzjiAqJYN0qfHoTOKgvhanlnNvegAAAAA==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 420,
+          "tcId" : 521,
           "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304402206c1581f1485ccc4e657606fa1a38cf227e3870dc9f41e26b84e28483635e321b02201b3e3c22af23e919b30330f8710f6ef3760c0e2237a9a9f5cf30a1d9f5bbd464",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 421,
+          "tcId" : 522,
           "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3045022100dc83bf97ca28db0e04104a16fe3de694311a6cd9f230a300504ae71d8ec755b1022064a83af0ab3e6037003a1f4240dffd8a342afdee50604ed1afa416fd009e4668",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 422,
+          "tcId" : 523,
           "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30450220575b70b4375684291b95d81e3c820ed9bde9e5b7343036e4951f3c46894a6d9d022100f10d716efbfeba953701b603fc9ef6ff6e47edef38c9eeef2d55e6486bc4d6e6",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f4972650049357b05e8b186e38d41d31c77f5769f22d58385ecc857d07a561a6324217fffffff",
         "wx" : "3cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f497265004935",
         "wy" : "7b05e8b186e38d41d31c77f5769f22d58385ecc857d07a561a6324217fffffff"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f4972650049357b05e8b186e38d41d31c77f5769f22d58385ecc857d07a561a6324217fffffff",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPPA9YU2JOc/UmaB4c/rCgWGPBrj/\nh+gBXD9JcmUASTV7BeixhuONQdMcd/V2nyLVg4XsyFfQelYaYyQhf////w==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200043cf03d614d8939cfd499a07873fac281618f06b8ff87e8015c3f4972650049357b05e8b186e38d41d31c77f5769f22d58385ecc857d07a561a6324217fffffff",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEPPA9YU2JOc/UmaB4c/rCgWGPBrj/\nh+gBXD9JcmUASTV7BeixhuONQdMcd/V2nyLVg4XsyFfQelYaYyQhf////w==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 423,
+          "tcId" : 524,
           "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30450221008d4f113189dfd3d3239e331f76d3fca9cef86fcd5dc9b4ab2ca38aeba56c178b022078389c3cf11dcff6d6c7f5efd277d480060691144b568a6f090c8902557bfc61",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 424,
+          "tcId" : 525,
           "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3046022100834d10ec2d2d50eeebfecd6328f03fafbb488fc043c362cbc67880ec0ebd04b302210094c026feaf6e68759146fe5b6fd52eaa3c3c5552d83719d2cb900615e2a634db",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 425,
+          "tcId" : 526,
           "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304502206894de495e7bb5566807d475d96a0d414a94f4f02c3ab7c2edc2916deafc1e1f022100a603642c20fabc07182867fcc6923d35be23ad3f97a5f93c6ec5b9cce8239569",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "042829c31faa2e400e344ed94bca3fcd0545956ebcfe8ad0f6dfa5ff8effffffffa01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e",
         "wx" : "2829c31faa2e400e344ed94bca3fcd0545956ebcfe8ad0f6dfa5ff8effffffff",
-        "wy" : "0a01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e"
+        "wy" : "00a01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042829c31faa2e400e344ed94bca3fcd0545956ebcfe8ad0f6dfa5ff8effffffffa01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKCnDH6ouQA40TtlLyj/NBUWVbrz+\nitD236X/jv////+gGq+vAA5SWFhVr6dnat4oQRMJkFLfV+frO9N+vrkiLg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d030107034200042829c31faa2e400e344ed94bca3fcd0545956ebcfe8ad0f6dfa5ff8effffffffa01aafaf000e52585855afa7676ade284113099052df57e7eb3bd37ebeb9222e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEKCnDH6ouQA40TtlLyj/NBUWVbrz+\nitD236X/jv////+gGq+vAA5SWFhVr6dnat4oQRMJkFLfV+frO9N+vrkiLg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 426,
+          "tcId" : 527,
           "comment" : "x-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3046022100e500c086fedd59e090ce7bfb615751ed9abe4c09b839ee8f05320245b9796f3e022100807b1d0638c86ef6113fff0d63497800e1b848b5a303a54c748e45ca8f35d7d7",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 427,
+          "tcId" : 528,
           "comment" : "x-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3046022100b922c1abe1a8309c0acf90e586c6de8c33e37057673390a97ff098f71680b32b022100f86d92b051b7923d82555c205e21b54eab869766c716209648c3e6cc2629057d",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 428,
+          "tcId" : 529,
           "comment" : "x-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3046022100823c37e46c74ec8497d89245fde3bf53ddb462c00d840e983dcb1b72bbf8bf27022100c4552f2425d14f0f0fa988778403d60a58962e7c548715af83b2edabbb24a49f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f55a8abcba2dda8474311ee54149b973cae0c0fb89557ad0bf78e6529a1663bd73",
-        "wx" : "0fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f5",
+        "wx" : "00fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f5",
         "wy" : "5a8abcba2dda8474311ee54149b973cae0c0fb89557ad0bf78e6529a1663bd73"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f55a8abcba2dda8474311ee54149b973cae0c0fb89557ad0bf78e6529a1663bd73",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE////+UgIHmoEWN2PnnOPJmX/kFmt\naqwHCDGMTKmnpPVairy6LdqEdDEe5UFJuXPK4MD7iVV60L945lKaFmO9cw==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004fffffff948081e6a0458dd8f9e738f2665ff9059ad6aac0708318c4ca9a7a4f55a8abcba2dda8474311ee54149b973cae0c0fb89557ad0bf78e6529a1663bd73",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAE////+UgIHmoEWN2PnnOPJmX/kFmt\naqwHCDGMTKmnpPVairy6LdqEdDEe5UFJuXPK4MD7iVV60L945lKaFmO9cw==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 429,
+          "tcId" : 530,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30450220577a08a95db6dcda9985109942d3786630f640190f920b95bd4d5d84e0f163ef022100d762286e92925973fd38b67ef944a99c0ec5b499b7175cbb4369e053c1fcbb10",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 430,
+          "tcId" : 531,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304402207ba458cfe952326922c7aa2854bdc673ce3daaf65d464dfb9f700701503056b102200df8821c92d20546fa741fb426bf56728a53182691964225c9b380b56b22ee6d",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 431,
+          "tcId" : 532,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304402205cd60c3b021b4be116f06f1d447f65e458329a8bbae1d9b5977d18cf5618486102204c635cd7aa9aebb5716d5ae09e57f8c481a741a029b40f71ec47344ef883e86e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400000003fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e1099872070e8e87c555fa13659cca5d7fadcfcb0023ea889548ca48af2ba7e71",
-        "wx" : "3fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e",
+        "wx" : "03fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e",
         "wy" : "1099872070e8e87c555fa13659cca5d7fadcfcb0023ea889548ca48af2ba7e71"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000003fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e1099872070e8e87c555fa13659cca5d7fadcfcb0023ea889548ca48af2ba7e71",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAAAAA/oV+WOUnV8DpvXH+G+eABXu\nsjrrv/EXOTe6dI4QmYcgcOjofFVfoTZZzKXX+tz8sAI+qIlUjKSK8rp+cQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d0301070342000400000003fa15f963949d5f03a6f5c7f86f9e0015eeb23aebbff1173937ba748e1099872070e8e87c555fa13659cca5d7fadcfcb0023ea889548ca48af2ba7e71",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEAAAAA/oV+WOUnV8DpvXH+G+eABXu\nsjrrv/EXOTe6dI4QmYcgcOjofFVfoTZZzKXX+tz8sAI+qIlUjKSK8rp+cQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 432,
+          "tcId" : 533,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304402204b50e1e8cf830e04c17e7472caf60da8150ffa568e2c64498cc972a379e542e502202e3adaa5afab89cca91693609555f40543578852cde29c21cb037c0c0b78478e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 433,
+          "tcId" : 534,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304402205aea930c7d8fffcd5c6df2c9430ef76f8b5ed58a8b9c95847288abf8f09a1ac202207ddfef7688a6053ce4eeeeefd6f1a9d71381b7548925f6682aa0a9d05cf5a3a3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 434,
+          "tcId" : 535,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304602210098b092c2d14b5b14a23e9368e0ce1be744dfae9f9a5cdaba51e7872099df96f202210090d3e4f87bd7bc94589f8150b6b01045cd8759a00af78b24d7de771887610df5",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015000000001352bb4a0fa2ea4cceb9ab63dd684ade5a1127bcf300a698a7193bc2",
-        "wx" : "0bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015",
+        "wx" : "00bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015",
         "wy" : "1352bb4a0fa2ea4cceb9ab63dd684ade5a1127bcf300a698a7193bc2"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015000000001352bb4a0fa2ea4cceb9ab63dd684ade5a1127bcf300a698a7193bc2",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvLspFMefBF6qbsu8YSgWs75dLWeW\ncH2BJen4UcGK8BUAAAAAE1K7Sg+i6kzOuatj3WhK3loRJ7zzAKaYpxk7wg==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015000000001352bb4a0fa2ea4cceb9ab63dd684ade5a1127bcf300a698a7193bc2",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvLspFMefBF6qbsu8YSgWs75dLWeW\ncH2BJen4UcGK8BUAAAAAE1K7Sg+i6kzOuatj3WhK3loRJ7zzAKaYpxk7wg==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 435,
+          "tcId" : 536,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30460221009e95f2856a9fff9a172b07817c8c60fe185cd3ce9582678f8cc4b02bc444621a022100c54ca51d8117d904f0d3773911cb2792348fae21c2da7dad25f990d122376e4c",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 436,
+          "tcId" : 537,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3046022100e77df8f9782696344c33de29ebdc9f8d3fcf463d950cdbe256fd4fc2fd44877e02210087028850c962cf2fb450ffe6b983981e499dc498fbd654fa454c9e07c8cb5ca8",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 437,
+          "tcId" : 538,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3045022100bd2dd6f5026d2b5ad7ead74bdf52b8cbcabc08facee0a1c8584658a85ed0c5dc02203e8543e819bdae47d872e29a85ba38addf3eaeaad8786d79c3fb027f6f1ff4bf",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp256r1",
         "keySize" : 256,
-        "type" : "ECPublicKey",
         "uncompressed" : "04bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d",
-        "wx" : "0bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015",
-        "wy" : "0fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d"
+        "wx" : "00bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015",
+        "wy" : "00fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d"
       },
-      "keyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvLspFMefBF6qbsu8YSgWs75dLWeW\ncH2BJen4UcGK8BX////+7K1EtvBdFbMxRlScIpe1IqXu2EMM/1lnWObEPQ==\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3059301306072a8648ce3d020106082a8648ce3d03010703420004bcbb2914c79f045eaa6ecbbc612816b3be5d2d6796707d8125e9f851c18af015fffffffeecad44b6f05d15b33146549c2297b522a5eed8430cff596758e6c43d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEvLspFMefBF6qbsu8YSgWs75dLWeW\ncH2BJen4UcGK8BX////+7K1EtvBdFbMxRlScIpe1IqXu2EMM/1lnWObEPQ==\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 438,
+          "tcId" : 539,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3045022100bd5c0294acc28c15c5d1ebc7274c9ca21a081c8a67da430a34a7fff1a564fabb02207ec103a2385b4ff38b47d306434e9091de24dc9f1a25967ee06f8a0a53ac0181",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 439,
+          "tcId" : 540,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "304402203c7dbfb43dd80379ee2c23ad5472873a22c8a0179ac8f381ad9e0f193231dc1f02207cf8e07530ade503b3d43a84b75a2a76fc40763daed4e9734e745c58c9ae72d3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 440,
+          "tcId" : 541,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3045022100b38ca4dac6d949be5e5f969860269f0eedff2eb92f45bfc02470300cc96dd52602201c7b22992bb13749cc0c5bc25330a17446e40db734203f9035172725fc70f863",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     }

--- a/Tests/Test Vectors/ecdsa_secp384r1_sha384_test.json
+++ b/Tests/Test Vectors/ecdsa_secp384r1_sha384_test.json
@@ -1,4452 +1,6570 @@
 {
   "algorithm" : "ECDSA",
-  "generatorVersion" : "0.4.12",
+  "schema" : "ecdsa_verify_schema.json",
+  "generatorVersion" : "0.9rc5",
+  "numberOfTests" : 491,
+  "header" : [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of ASN encoded ECDSA signatures."
+  ],
   "notes" : {
-    "BER" : "This is a signature with correct values for (r, s) but using some alternative BER encoding instead of DER encoding. Implementations should not accept such signatures to limit signature malleability.",
-    "EdgeCase" : "Edge case values such as r=1 and s=0 can lead to forgeries if the ECDSA implementation does not check boundaries and computes s^(-1)==0.",
-    "MissingZero" : "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
-    "PointDuplication" : "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission."
+    "ArithmeticError" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "cves" : [
+        "CVE-2017-18146"
+      ]
+    },
+    "BerEncodedSignature" : {
+      "bugType" : "BER_ENCODING",
+      "description" : "ECDSA signatures are usually DER encoded. This signature contains valid values for r and s, but it uses alternative BER encoding.",
+      "effect" : "Accepting alternative BER encodings may be benign in some cases, or be an issue if protocol requires signature malleability.",
+      "cves" : [
+        "CVE-2020-14966",
+        "CVE-2020-13822",
+        "CVE-2019-14859",
+        "CVE-2016-1000342"
+      ]
+    },
+    "EdgeCasePublicKey" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidEncoding" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "ECDSA signatures are encoded using ASN.1. This test vector contains an incorrectly encoded signature. The test vector itself was generated from a valid signature by modifying its encoding.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature" : {
+      "bugType" : "AUTH_BYPASS",
+      "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "cves" : [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "InvalidTypesInSignature" : {
+      "bugType" : "AUTH_BYPASS",
+      "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "cves" : [
+        "CVE-2022-21449"
+      ]
+    },
+    "MissingZero" : {
+      "bugType" : "LEGACY",
+      "description" : "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
+      "effect" : "While signatures are more malleable if such signatures are accepted, this typically leads to no vulnerability, since a badly encoded signature can be reencoded correctly."
+    },
+    "ModifiedInteger" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModifiedSignature" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an invalid signature that was generated from a valid signature by modifying it.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect" : "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves" : [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves" : [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SmallRandS" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect" : "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves" : [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "ValidSignature" : {
+      "bugType" : "BASIC",
+      "description" : "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
   },
-  "numberOfTests" : 392,
-  "header" : [],
   "testGroups" : [
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
+        "uncompressed" : "0429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+        "wx" : "29bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc",
+        "wy" : "009a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEKb23bV+nQb/XAjPLOmbMfUS+s7BmPZKo\nE2ZQR4vO+2HvGC4VWlQ0Wl6OXojwZOW8mlJat/dk2tPa4UaMK0GfO2K5upF9XoxP\nsexHQEo/x2R0snEwgb6dtMAOBDran8Sj\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 1,
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
+          "msg" : "",
+          "sig" : "3064023032401249714e9091f05a5e109d5c1216fdc05e98614261aa0dbd9e9cd4415dee29238afbd3b103c1e40ee5c9144aee0f02304326756fb2c4fd726360dd6479b5849478c7a9d054a833a58c1631c33b63c3441336ddf2c7fe0ed129aae6d4ddfeb753",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 2,
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
+          "msg" : "4d7367",
+          "sig" : "3066023100d7143a836608b25599a7f28dec6635494c2992ad1e2bbeecb7ef601a9c01746e710ce0d9c48accb38a79ede5b9638f3402310080f9e165e8c61035bf8aa7b5533960e46dd0e211c904a064edb6de41f797c0eae4e327612ee3f816f4157272bb4fabc9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 3,
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30650230234503fcca578121986d96be07fbc8da5d894ed8588c6dbcdbe974b4b813b21c52d20a8928f2e2fdac14705b0705498c023100cd7b9b766b97b53d1a80fc0b760af16a11bf4a59c7c367c6c7275dfb6e18a88091eed3734bf5cf41b3dc6fecd6d3baaf",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 4,
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
+          "msg" : "0000000000000000000000000000000000000000",
+          "sig" : "306502305cad9ae1565f2588f86d821c2cc1b4d0fdf874331326568f5b0e130e4e0c0ec497f8f5f564212bd2a26ecb782cf0a18d023100bf2e9d0980fbb00696673e7fbb03e1f854b9d7596b759a17bf6e6e67a95ea6c1664f82dc449ae5ea779abd99c78e6840",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
         "uncompressed" : "042da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f",
         "wx" : "2da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa",
         "wy" : "4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200042da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAELaV92hCJJ2pUP5/9rAv/DZdsrXHrcoDn\n2b/Z/uS9svIPR/+IgnQ4l3LZjMV1ITiqS20FTWnc8+JexJ34cHFeNIg7GDYZfXb4\nrZYuePZXG7x0B7DWCR+eTYjwFCdEBhdP\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200042da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAELaV92hCJJ2pUP5/9rAv/DZdsrXHrcoDn\n2b/Z/uS9svIPR/+IgnQ4l3LZjMV1ITiqS20FTWnc8+JexJ34cHFeNIg7GDYZfXb4\nrZYuePZXG7x0B7DWCR+eTYjwFCdEBhdP\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 1,
+          "tcId" : 5,
           "comment" : "signature malleability",
+          "flags" : [
+            "ValidSignature"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d702301840da9fc1d2f8f8900cf485d5413b8c2574ee3a8d4ca03995ca30240e09513805bf6209b58ac7aa9cff54eecd82b9f1",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 2,
-          "comment" : "Legacy:ASN encoding of s misses leading 0",
-          "msg" : "313233343030",
-          "sig" : "3064023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70230e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "acceptable",
-          "flags" : [
-            "MissingZero"
-          ]
-        },
-        {
-          "tcId" : 3,
-          "comment" : "valid",
-          "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 4,
-          "comment" : "long form encoding of length",
-          "msg" : "313233343030",
-          "sig" : "308165023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : [
-            "BER"
-          ]
-        },
-        {
-          "tcId" : 5,
-          "comment" : "long form encoding of length",
-          "msg" : "313233343030",
-          "sig" : "306602813012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : [
-            "BER"
-          ]
+          "result" : "valid"
         },
         {
           "tcId" : 6,
-          "comment" : "long form encoding of length",
-          "msg" : "313233343030",
-          "sig" : "3066023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d702813100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
+          "comment" : "Legacy: ASN encoding of s misses leading 0",
           "flags" : [
-            "BER"
-          ]
+            "MissingZero"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70230e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 7,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "30820065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
+          "comment" : "valid",
           "flags" : [
-            "BER"
-          ]
+            "ValidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "valid"
         },
         {
           "tcId" : 8,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "30670282003012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
+          "comment" : "length of sequence [r, s] uses long form encoding",
           "flags" : [
-            "BER"
-          ]
+            "BerEncodedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308165023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 9,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70282003100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
+          "comment" : "length of sequence [r, s] contains a leading 0",
           "flags" : [
-            "BER"
-          ]
+            "BerEncodedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30820065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 10,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] uses 102 instead of 101",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
           "sig" : "3066023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
           "tcId" : 11,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] uses 100 instead of 101",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
           "tcId" : 12,
-          "comment" : "wrong length",
+          "comment" : "uint32 overflow in length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023112b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30850100000065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 13,
-          "comment" : "wrong length",
+          "comment" : "uint64 overflow in length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065022f12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3089010000000000000065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 14,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023200e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30847fffffff023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 15,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023000e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308480000000023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 16,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30850100000065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3084ffffffff023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 17,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**40 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a0285010000003012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3085ffffffffff023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 18,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70285010000003100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3088ffffffffffffffff023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 19,
-          "comment" : "uint64 overflow in length",
+          "comment" : "incorrect length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3089010000000000000065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30ff023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 20,
-          "comment" : "uint64 overflow in length",
+          "comment" : "replaced sequence [r, s] by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306e028901000000000000003012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 21,
-          "comment" : "uint64 overflow in length",
+          "comment" : "removing sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306e023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7028901000000000000003100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "",
+          "result" : "invalid"
         },
         {
           "tcId" : 22,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "lonely sequence tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30847fffffff023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30",
+          "result" : "invalid"
         },
         {
           "tcId" : 23,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "appending 0's to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306902847fffffff12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
+          "result" : "invalid"
         },
         {
           "tcId" : 24,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "prepending 0's to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3069023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d702847fffffff00e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30670000023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 25,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "appending unused 0's to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3084ffffffff023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
+          "result" : "invalid"
         },
         {
           "tcId" : 26,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "appending null value to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30690284ffffffff12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820500",
+          "result" : "invalid"
         },
         {
           "tcId" : 27,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "prepending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3069023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70284ffffffff00e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a4981773065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 28,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "prepending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3085ffffffffff023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306925003065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 29,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "appending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a0285ffffffffff12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30673065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820004deadbeef",
+          "result" : "invalid"
         },
         {
           "tcId" : 30,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70285ffffffffff00e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306daa00bb00cd003065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 31,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3088ffffffffffffffff023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306d2238aa00bb00cd00023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 32,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306d0288ffffffffffffffff12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306d023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d72239aa00bb00cd00023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 33,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "truncated length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306d023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70288ffffffffffffffff00e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3081",
+          "result" : "invalid"
         },
         {
           "tcId" : 34,
-          "comment" : "incorrect length",
+          "comment" : "including undefined tags to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30ff023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306baa02aabb3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 35,
-          "comment" : "incorrect length",
+          "comment" : "using composition with indefinite length for sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306502ff12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30803065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
+          "result" : "invalid"
         },
         {
           "tcId" : 36,
-          "comment" : "incorrect length",
+          "comment" : "using composition with wrong tag for sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d702ff00e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30803165023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
+          "result" : "invalid"
         },
         {
           "tcId" : 37,
-          "comment" : "indefinite length without termination",
+          "comment" : "Replacing sequence [r, s] with NULL",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 38,
-          "comment" : "indefinite length without termination",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065028012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "2e65023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 39,
-          "comment" : "indefinite length without termination",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7028000e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "2f65023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 40,
-          "comment" : "removing sequence",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3165023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 41,
-          "comment" : "lonely sequence tag",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3265023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 42,
-          "comment" : "appending 0's to sequence",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "ff65023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 43,
-          "comment" : "prepending 0's to sequence",
+          "comment" : "dropping value of sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30670000023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 44,
-          "comment" : "appending unused 0's to sequence",
+          "comment" : "using composition for sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306930010230643012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 45,
-          "comment" : "appending null value to sequence",
+          "comment" : "truncated sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3064023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f",
+          "result" : "invalid"
         },
         {
           "tcId" : 46,
-          "comment" : "including garbage",
+          "comment" : "truncated sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a4981773065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30643012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 47,
-          "comment" : "including garbage",
+          "comment" : "sequence [r, s] of size 4198 to check for overflows",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306925003065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30821066023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 48,
-          "comment" : "including garbage",
+          "comment" : "indefinite length",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30673065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820004deadbeef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
+          "result" : "invalid"
         },
         {
           "tcId" : 49,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with truncated delimiter",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a2235498177023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f8200",
+          "result" : "invalid"
         },
         {
           "tcId" : 50,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with additional element",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306922342500023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f8205000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 51,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with truncated element",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306d2232023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70004deadbeef023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82060811220000",
+          "result" : "invalid"
         },
         {
           "tcId" : 52,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with garbage",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d72236498177023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000fe02beef",
+          "result" : "invalid"
         },
         {
           "tcId" : 53,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with nonempty EOC",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3069023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d722352500023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820002beef",
+          "result" : "invalid"
         },
         {
           "tcId" : 54,
-          "comment" : "including garbage",
+          "comment" : "prepend empty sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306d023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d72233023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820004deadbeef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30673000023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 55,
-          "comment" : "including undefined tags",
+          "comment" : "append empty sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306daa00bb00cd003065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f823000",
+          "result" : "invalid"
         },
         {
           "tcId" : 56,
-          "comment" : "including undefined tags",
+          "comment" : "append zero",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306baa02aabb3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3068023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 57,
-          "comment" : "including undefined tags",
+          "comment" : "append garbage with high tag number",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306d2238aa00bb00cd00023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3068023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82bf7f00",
+          "result" : "invalid"
         },
         {
           "tcId" : 58,
-          "comment" : "including undefined tags",
+          "comment" : "append null with explicit tag",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306b2236aa02aabb023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3069023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82a0020500",
+          "result" : "invalid"
         },
         {
           "tcId" : 59,
-          "comment" : "including undefined tags",
+          "comment" : "append null with implicit tag",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306d023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d72239aa00bb00cd00023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82a000",
+          "result" : "invalid"
         },
         {
           "tcId" : 60,
-          "comment" : "including undefined tags",
+          "comment" : "sequence of sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306b023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d72237aa02aabb023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30673065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 61,
-          "comment" : "truncated length of sequence",
+          "comment" : "truncated sequence: removed last 1 elements",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3081",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3032023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7",
+          "result" : "invalid"
         },
         {
           "tcId" : 62,
-          "comment" : "using composition with indefinite length",
+          "comment" : "repeating element in sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30803065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308198023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 63,
-          "comment" : "using composition with indefinite length",
+          "comment" : "flipped bit 0 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30692280023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70000023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306312b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d6023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 64,
-          "comment" : "using composition with indefinite length",
+          "comment" : "flipped bit 32 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3069023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d72280023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306312b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3395f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 65,
-          "comment" : "using composition with wrong tag",
+          "comment" : "flipped bit 48 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30803165023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306312b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abc3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 66,
-          "comment" : "using composition with wrong tag",
+          "comment" : "flipped bit 64 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30692280033012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70000023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306312b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0330abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 67,
-          "comment" : "using composition with wrong tag",
+          "comment" : "length of r uses long form encoding",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3069023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d72280033100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306602813012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 68,
-          "comment" : "Replacing sequence with NULL",
+          "comment" : "length of r contains a leading 0",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "0500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30670282003012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 69,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r uses 49 instead of 48",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "2e65023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023112b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 70,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r uses 47 instead of 48",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "2f65023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065022f12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 71,
-          "comment" : "changing tag value of sequence",
+          "comment" : "uint32 overflow in length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3165023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a0285010000003012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 72,
-          "comment" : "changing tag value of sequence",
+          "comment" : "uint64 overflow in length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3265023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306e028901000000000000003012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 73,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "ff65023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306902847fffffff12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 74,
-          "comment" : "dropping value of sequence",
+          "comment" : "length of r = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306902848000000012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 75,
-          "comment" : "using composition for sequence",
+          "comment" : "length of r = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306930010230643012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30690284ffffffff12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 76,
-          "comment" : "truncate sequence",
+          "comment" : "length of r = 2**40 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3064023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a0285ffffffffff12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 77,
-          "comment" : "truncate sequence",
+          "comment" : "length of r = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30643012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306d0288ffffffffffffffff12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 78,
-          "comment" : "indefinite length",
-          "msg" : "313233343030",
-          "sig" : "3080023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
-          "result" : "invalid",
+          "comment" : "incorrect length of r",
           "flags" : [
-            "BER"
-          ]
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306502ff12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 79,
-          "comment" : "indefinite length with truncated delimiter",
+          "comment" : "replaced r by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f8200",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065028012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 80,
-          "comment" : "indefinite length with additional element",
+          "comment" : "removing r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f8205000000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3033023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 81,
-          "comment" : "indefinite length with truncated element",
+          "comment" : "lonely integer tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82060811220000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "303402023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 82,
-          "comment" : "indefinite length with garbage",
+          "comment" : "lonely integer tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000fe02beef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3033023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d702",
+          "result" : "invalid"
         },
         {
           "tcId" : 83,
-          "comment" : "indefinite length with nonempty EOC",
+          "comment" : "appending 0's to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820002beef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3067023212b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70000023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 84,
-          "comment" : "prepend empty sequence",
+          "comment" : "prepending 0's to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30673000023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30670232000012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 85,
-          "comment" : "append empty sequence",
+          "comment" : "appending unused 0's to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f823000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70000023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 86,
-          "comment" : "sequence of sequence",
+          "comment" : "appending null value to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30673065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3067023212b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70500023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 87,
-          "comment" : "truncated sequence",
+          "comment" : "prepending garbage to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3032023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a2235498177023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 88,
-          "comment" : "repeat element in sequence",
+          "comment" : "prepending garbage to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308198023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306922342500023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 89,
-          "comment" : "removing integer",
+          "comment" : "appending garbage to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3033023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306d2232023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70004deadbeef023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 90,
-          "comment" : "lonely integer tag",
+          "comment" : "truncated length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "303402023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30350281023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 91,
-          "comment" : "lonely integer tag",
+          "comment" : "including undefined tags to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3033023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d702",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306b2236aa02aabb023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 92,
-          "comment" : "appending 0's to integer",
+          "comment" : "using composition with indefinite length for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3067023212b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70000023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30692280023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70000023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 93,
-          "comment" : "appending 0's to integer",
+          "comment" : "using composition with wrong tag for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023300e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30692280033012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70000023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 94,
-          "comment" : "prepending 0's to integer",
-          "msg" : "313233343030",
-          "sig" : "30670232000012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
+          "comment" : "Replacing r with NULL",
           "flags" : [
-            "BER"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30350500023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 95,
-          "comment" : "prepending 0's to integer",
-          "msg" : "313233343030",
-          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70233000000e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
+          "comment" : "changing tag value of r",
           "flags" : [
-            "BER"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3065003012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 96,
-          "comment" : "appending unused 0's to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70000023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065013012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 97,
-          "comment" : "appending null value to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3067023212b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70500023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065033012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 98,
-          "comment" : "appending null value to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023300e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065043012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 99,
-          "comment" : "truncated length of integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30350281023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065ff3012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 100,
-          "comment" : "truncated length of integer",
+          "comment" : "dropping value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3034023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70281",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30350200023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 101,
-          "comment" : "Replacing integer with NULL",
+          "comment" : "using composition for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30350500023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30692234020112022fb30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 102,
-          "comment" : "Replacing integer with NULL",
+          "comment" : "modifying first byte of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3034023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023010b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 103,
-          "comment" : "changing tag value of integer",
+          "comment" : "modifying last byte of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065003012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c54857023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 104,
-          "comment" : "changing tag value of integer",
+          "comment" : "truncated r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065013012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3064022f12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 105,
-          "comment" : "changing tag value of integer",
+          "comment" : "truncated r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065033012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3064022fb30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 106,
-          "comment" : "changing tag value of integer",
+          "comment" : "r of size 4145 to check for overflows",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065043012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308210680282103112b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 107,
-          "comment" : "changing tag value of integer",
+          "comment" : "leading ff in r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065ff3012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30660231ff12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 108,
-          "comment" : "changing tag value of integer",
+          "comment" : "replaced r by infinity",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7003100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3036090180023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 109,
-          "comment" : "changing tag value of integer",
+          "comment" : "replacing r with zero",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7013100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3036020100023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 110,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 0 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7033100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3063023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d700e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f83",
+          "result" : "invalid"
         },
         {
           "tcId" : 111,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 32 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7043100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3063023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d700e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47aff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 112,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 48 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7ff3100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3063023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d700e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fedc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 113,
-          "comment" : "dropping value of integer",
+          "comment" : "flipped bit 64 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30350200023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3063023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d700e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd14fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 114,
-          "comment" : "dropping value of integer",
+          "comment" : "length of s uses long form encoding",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3034023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70200",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d702813100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 115,
-          "comment" : "using composition for integer",
+          "comment" : "length of s contains a leading 0",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30692234020112022fb30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70282003100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 116,
-          "comment" : "using composition for integer",
+          "comment" : "length of s uses 50 instead of 49",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3069023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d722350201000230e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023200e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 117,
-          "comment" : "modify first byte of integer",
+          "comment" : "length of s uses 48 instead of 49",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023010b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023000e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 118,
-          "comment" : "modify first byte of integer",
+          "comment" : "uint32 overflow in length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023102e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70285010000003100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 119,
-          "comment" : "modify last byte of integer",
+          "comment" : "uint64 overflow in length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c54857023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306e023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7028901000000000000003100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 120,
-          "comment" : "modify last byte of integer",
+          "comment" : "length of s = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f02",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3069023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d702847fffffff00e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 121,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3064022f12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3069023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d702848000000000e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 122,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3064022fb30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3069023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70284ffffffff00e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 123,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**40 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3064023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023000e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70285ffffffffff00e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 124,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3064023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70230e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306d023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70288ffffffffffffffff00e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 125,
-          "comment" : "leading ff in integer",
+          "comment" : "incorrect length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30660231ff12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d702ff00e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 126,
-          "comment" : "leading ff in integer",
+          "comment" : "replaced s by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70232ff00e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7028000e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 127,
-          "comment" : "infinity",
+          "comment" : "appending 0's to s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3036090180023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023300e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
+          "result" : "invalid"
         },
         {
           "tcId" : 128,
-          "comment" : "infinity",
+          "comment" : "prepending 0's to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3035023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7090180",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70233000000e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 129,
-          "comment" : "replacing integer with zero",
+          "comment" : "appending null value to s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3036020100023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3067023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023300e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820500",
+          "result" : "invalid"
         },
         {
           "tcId" : 130,
-          "comment" : "replacing integer with zero",
+          "comment" : "prepending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3035023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7020100",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d72236498177023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 131,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "prepending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306602310112b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19a25617aad7485e6312a8589714f647acf7a94cffbe8a724a023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3069023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d722352500023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 132,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "appending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30660231ff12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe1a138f7ca6eeda02a462743d328394f8b71dd11a2a25001f64023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306d023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d72233023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820004deadbeef",
+          "result" : "invalid"
         },
         {
           "tcId" : 133,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "truncated length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30650230ed4cf541094ab8901949ed51aa83fbda99e1d94bb4e401e6250d35d71ceecf7c4571b51b33ba5fcdf542cc6b0e3ab729023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3034023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70281",
+          "result" : "invalid"
         },
         {
           "tcId" : 134,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "including undefined tags to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100ed4cf541094ab8901949ed51aa83fbda99e1d94bb4e401e5ec7083591125fd5b9d8bc2cd7c6b0748e22ee5d5daffe09c023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306b023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d72237aa02aabb023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 135,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "using composition with indefinite length for s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30660231feed4cf541094ab8901949ed51aa83fbda99e1d94bb4e401e65da9e85528b7a19ced57a768eb09b8530856b30041758db6023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3069023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d72280023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
+          "result" : "invalid"
         },
         {
           "tcId" : 136,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "using composition with wrong tag for s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306602310112b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3069023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d72280033100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000",
+          "result" : "invalid"
         },
         {
           "tcId" : 137,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "Replacing s with NULL",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100ed4cf541094ab8901949ed51aa83fbda99e1d94bb4e401e6250d35d71ceecf7c4571b51b33ba5fcdf542cc6b0e3ab729023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3034023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70500",
+          "result" : "invalid"
         },
         {
           "tcId" : 138,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023101e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc5f8fc6adfda650a86aa74b95adbd6874b3cd8dde6cc0798f5",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7003100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 139,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3064023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70230e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc66a35cfdbf1f6aec7fa409df64a7538556300ab11327d460f",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7013100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 140,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70231ff1840da9fc1d2f8f8900cf485d5413b8c2574ee3a8d4ca039ce66e2a219d22358ada554576cda202fb0133b8400bd907e",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7033100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 141,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70231fe1840da9fc1d2f8f8900cf485d5413b8c2574ee3a8d4ca03a07039520259af579558b46a5242978b4c327221933f8670b",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7043100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 142,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023101e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7ff3100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 143,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "dropping value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3064023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d702301840da9fc1d2f8f8900cf485d5413b8c2574ee3a8d4ca039ce66e2a219d22358ada554576cda202fb0133b8400bd907e",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3034023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70200",
+          "result" : "invalid"
         },
         {
           "tcId" : 144,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020100020100",
-          "result" : "invalid",
+          "comment" : "using composition for s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3069023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d722350201000230e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 145,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020100020101",
-          "result" : "invalid",
+          "comment" : "modifying first byte of s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023102e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 146,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201000201ff",
-          "result" : "invalid",
+          "comment" : "modifying last byte of s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3065023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f02",
+          "result" : "invalid"
         },
         {
           "tcId" : 147,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020100023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "truncated s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023000e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f",
+          "result" : "invalid"
         },
         {
           "tcId" : 148,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020100023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "s of size 4146 to check for overflows",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30821068023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70282103200e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f820000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 149,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020100023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "leading ff in s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d70232ff00e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 150,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020100023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "replaced s by infinity",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7090180",
+          "result" : "invalid"
         },
         {
           "tcId" : 151,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020100023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "replacing s with zero",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035023012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 152,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3008020100090380fe01",
-          "result" : "invalid",
+          "comment" : "replaced r by r + n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306602310112b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19a25617aad7485e6312a8589714f647acf7a94cffbe8a724a023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 153,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020101020100",
-          "result" : "invalid",
+          "comment" : "replaced r by r - n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30660231ff12b30abef6b5476fe6b612ae557c0425661e26b44b1bfe1a138f7ca6eeda02a462743d328394f8b71dd11a2a25001f64023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 154,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020101020101",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 256 * n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30670232010012b30abef6b5476fe6b612ae557c0425661e26b44b1bfde13e404c1d1a3f0fdbd49bfd2d7ced1b1ef6d69e61b6eebbd7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 155,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201010201ff",
-          "result" : "invalid",
+          "comment" : "replaced r by -r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30650230ed4cf541094ab8901949ed51aa83fbda99e1d94bb4e401e6250d35d71ceecf7c4571b51b33ba5fcdf542cc6b0e3ab729023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 156,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020101023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "replaced r by n - r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ed4cf541094ab8901949ed51aa83fbda99e1d94bb4e401e5ec7083591125fd5b9d8bc2cd7c6b0748e22ee5d5daffe09c023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 157,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020101023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "replaced r by -n - r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30660231feed4cf541094ab8901949ed51aa83fbda99e1d94bb4e401e65da9e85528b7a19ced57a768eb09b8530856b30041758db6023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 158,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020101023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 2**384",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306602310112b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 159,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020101023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 2**448",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306e023901000000000000000012b30abef6b5476fe6b612ae557c0425661e26b44b1bfe19daf2ca28e3113083ba8e4ae4cc45a0320abd3394f1c548d7023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 160,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020101023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "replaced s by s + n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023101e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc5f8fc6adfda650a86aa74b95adbd6874b3cd8dde6cc0798f5023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 161,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3008020101090380fe01",
-          "result" : "invalid",
+          "comment" : "replaced s by s - n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30650230e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc66a35cfdbf1f6aec7fa409df64a7538556300ab11327d460f023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 162,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff020100",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 256 * n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306702320100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35f8d94e69f521d5bbbff6c685df143cd5abd3c062f48c46be282023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 163,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff020101",
-          "result" : "invalid",
+          "comment" : "replaced s by -s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30660231ff1840da9fc1d2f8f8900cf485d5413b8c2574ee3a8d4ca039ce66e2a219d22358ada554576cda202fb0133b8400bd907e023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 164,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff0201ff",
-          "result" : "invalid",
+          "comment" : "replaced s by -n - s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30660231fe1840da9fc1d2f8f8900cf485d5413b8c2574ee3a8d4ca03a07039520259af579558b46a5242978b4c327221933f8670b023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 165,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30360201ff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 2**384",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023101e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 166,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30360201ff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "replaced s by s - 2**384",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30650230e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 167,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30360201ff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 2**448",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306e0239010000000000000000e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82023100e7bf25603e2d07076ff30b7a2abec473da8b11c572b35fc631991d5de62ddca7525aaba89325dfd04fecc47bff426f82",
+          "result" : "invalid"
         },
         {
           "tcId" : 168,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30360201ff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 169,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30360201ff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 170,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30080201ff090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201000201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 171,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020100023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 172,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020100023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 173,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529730201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020100023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 174,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020100023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 175,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020100023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 176,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 177,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 178,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201010201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 179,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3038023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020101023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 180,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020101023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 181,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020101023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 182,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529720201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020101023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 183,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020101023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 184,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 185,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 186,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff0201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 187,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30360201ff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 188,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3038023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30360201ff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 189,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30360201ff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 190,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30360201ff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 191,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529740201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30360201ff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 192,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 193,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 194,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529730201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 195,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 196,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 197,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3038023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 198,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 199,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 200,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff0201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 201,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 202,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529720201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 203,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 204,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 205,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 206,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3038023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 207,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 208,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 209,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000001000000000201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 210,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529740201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 211,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 212,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 213,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 214,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 215,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3038023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 216,
-          "comment" : "Edge case for Shamir multiplication",
-          "msg" : "3133323237",
-          "sig" : "3066023100ac042e13ab83394692019170707bc21dd3d7b8d233d11b651757085bdd5767eabbb85322984f14437335de0cdf565684023100bd770d3ee4beadbabe7ca46e8c4702783435228d46e2dd360e322fe61c86926fa49c8116ec940f72ac8c30d9beb3e12f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=0",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 217,
-          "comment" : "special case hash",
-          "msg" : "31373530353531383135",
-          "sig" : "3066023100d3298a0193c4316b34e3833ff764a82cff4ef57b5dd79ed6237b51ff76ceab13bf92131f41030515b7e012d2ba857830023100bfc7518d2ad20ed5f58f3be79720f1866f7a23b3bd1bf913d3916819d008497a071046311d3c2fd05fc284c964a39617",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 218,
-          "comment" : "special case hash",
-          "msg" : "3130333633303731",
-          "sig" : "3065023100e14f41a5fc83aa4725a9ea60ab5b0b9de27f519af4b557a601f1fee0243f8eee5180f8c531414f3473f4457430cb7a2602301047ed2bf1f98e3ce93e8fdbdc63cc79f238998fee74e1bb6cd708694950bbffe3945066064da043f04d7083d0a596ec",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=-1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff0201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 219,
-          "comment" : "special case hash",
-          "msg" : "32333632343231333231",
-          "sig" : "3066023100b7c8b5cf631a96ad908d6a8c8d0e0a35fcc22a5a36050230b665932764ae45bd84cb87ebba8e444abd89e4483fc9c4a8023100a11636c095aa9bc69cf24b50a0a9e5377d0ffbba4fab5433159f006ab4563d55e918493020a19691574e4d1e66e3975e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 220,
-          "comment" : "special case hash",
-          "msg" : "34353838303134363536",
-          "sig" : "306402304a7df2df6a32d59b6bfed54f032c3d6f3acd3ac4063704099cd162ab3908e8eeba4e973ee75b5e285dd572062338fe58023035365be327e2463dc759951c5c0be5e3d094cb706912fdf7d26b15d4a5c42ffebeca5ae73a1823f5e65d571b4ccf1a82",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n - 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 221,
-          "comment" : "special case hash",
-          "msg" : "32313436363035363432",
-          "sig" : "30660231009ad363a1bbc67c57c82a378e988cc083cc91f8b32739ec647c0cb348fb5c86472015131a7d9083bf4740af3351755195023100d310dc1509f8c00281efe571768d488027ea760fe32971f6cb7b57cdf90621b7d0086e26443d3761df7aa3a4eccc6c58",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 222,
-          "comment" : "special case hash",
-          "msg" : "333335333030383230",
-          "sig" : "306502310095078af5c2ac230239557f5fcee2e712a7034e95437a9b34c1692a81270edcf8ddd5aba1138a42012663e5f81c9beae2023040ee510a0cceb8518ad4f618599164da0f3ba75eceeac216216ec62bcceae8dc98b5e35b2e7ed47c4b8ebacfe84a74e6",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=p",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 223,
-          "comment" : "special case hash",
-          "msg" : "36333936363033363331",
-          "sig" : "3066023100a538076362043de54864464c14a6c1c3a478443726c1309a36b9e9ea1592b40c3f3f90d195bd298004a71e8f285e093a023100d74f97ef38468515a8c927a450275c14dc16ddbdd92b3a5cae804be20d29c682129247d2e01d37dabe38ffb74808a8b7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=p + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 224,
-          "comment" : "special case hash",
-          "msg" : "33333931363630373935",
-          "sig" : "3065023100bbe835113f8ea4dc469f0283af6603f3d7a3a222b3ab5a93db56007ef2dc07c97988fc7b8b833057fa3fbf97413b6c150230737c316320b61002c2acb184d82e60e46bd2129a9bbf563c80da423121c161decd363518b260aaacf3734c1ef9faa925",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=0",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 225,
-          "comment" : "special case hash",
-          "msg" : "31343436393735393634",
-          "sig" : "30650230679c3640ad8ffe9577d9b59b18ff5598dbfe61122bbab8238d268907c989cd94dc7f601d17486af93f6d18624aa524a3023100e84dd195502bdcdd77b7f51d8c1ea789006905844a0e185474af1a583bab564ee23be0bc49500390dceb3d3948f06730",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 226,
-          "comment" : "special case hash",
-          "msg" : "35313539343738363431",
-          "sig" : "3066023100f6f1afe6febce799cc9b754279f2499f3825c3e789accef46d3f068e2b6781fd50669e80c3c7293a5c0c0af48e068e35023100f59cc8c2222ed63b4553f8149ebecc43b866719b294ef0832a12b3e3dbc825eeab68b5779625b10ae5541412ec295354",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=-1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000001000000000201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 227,
-          "comment" : "special case hash",
-          "msg" : "35323431373932333331",
-          "sig" : "3065023100f46496f6d473f3c091a68aaa3749220c840061cd4f888613ccfeac0aa0411b451edbd4facbe38d2dd9d6d0d0d255ed34023000c3a74fa6666f58c4798f30c3779813e5c6d08ac31a792c2d0f9cb708733f26ad6bf3b1e46815ae536aa151680bdee2",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 228,
-          "comment" : "special case hash",
-          "msg" : "31313437323930323034",
-          "sig" : "3066023100df8b8e4cb1bc4ec69cb1472fa5a81c36642ed47fc6ce560033c4f7cb0bc8459b5788e34caa7d96e6071188e449f0207a0231008b8ee0177962a489938f3feffae55729d9d446fe438c7cb91ea5f632c80aa72a43b9b04e6de7ff34f76f4425107fd697",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n - 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 229,
-          "comment" : "special case hash",
-          "msg" : "3130383738373235363435",
-          "sig" : "30660231008bb6a8ecdc8b483ad7b9c94bb39f63b5fc1378efe8c0204a74631dded7159643821419af33863b0414bd87ecf73ba3fb0231008928449f2d6db2b2c65d44d98beb77eeadcbda83ff33e57eb183e1fc29ad86f0ba29ee66e750e8170ccc434cf70ae199",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 230,
-          "comment" : "special case hash",
-          "msg" : "37333433333036353633",
-          "sig" : "3065023100e3832877c80c4ed439d8eadcf615c0286ff54943e3ae2f66a3b9f886245fea470e6d5812cef80c23e4f568d0215a3bfc02303177a7dbf0ab8f8f5fc1d01b19d6a5e89642899f369dfe213b7cc55d8eaf21dd2885efce52b5959c1f06b7cac5773e5b",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=p",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 231,
-          "comment" : "special case hash",
-          "msg" : "393734343630393738",
-          "sig" : "306502306275738f0880023286a9b6f28ea0a9779e8d644c3dec48293c64f1566b34e15c7119bd9d02fa2357774cabc9e53ef7e6023100d2f0a52b1016082bd5517609ee81c0764dc38a8f32d9a5074e717ee1d832f9ea0e4c6b100b1fd5e7f4bc7468c79d3933",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=p + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 232,
-          "comment" : "special case hash",
-          "msg" : "33323237303836383339",
-          "sig" : "3066023100d316fe5168cf13753c8c3bbef83869a6703dc0d5afa82af49c88ff3555660f57919a6f36e84451c3e8e5783e3b83fe3b023100995f08c8fec7cd82ce27e7509393f5a3803a48fe255fcb160321c6e1890eb36e37bcda158f0fa6899e7d107e52de8c3c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008020100090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 233,
-          "comment" : "special case hash",
-          "msg" : "323332393736343130",
-          "sig" : "306402300b13b8fd10fa7b42169137588ad3f557539a4e9206f3a1f1fe9202b0690defded2be18147f5b2da9285c0e7349735ea302300478ad317b22a247bf9334719b4c8ee84acf134515db77e6141c75d08961e1e51eaca29836744103de0f6a4c798d3eeb",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 234,
-          "comment" : "special case hash",
-          "msg" : "3934303437333831",
-          "sig" : "3065023015804429bcb5277d4f0af73bd54c8a177499a7b64f18afc566c3ce7096bdc6c275e38548edcfa0b78dd7f57b6f393e49023100d5951f243e65b82ba5c0c7552d33b11f1e90fde0c3fd014aac1bb27db2aaf09b667c8b247c4cdd5b0723fba83b4f999e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 235,
-          "comment" : "special case hash",
-          "msg" : "33323230353639313233",
-          "sig" : "30650230359247c95776bb17492b7bf827f5f330fa9f9de7cc10441a1479c81776ce36cdc6a13c5f5149c4e39147a196bb02ed34023100f6ed9252a73de48516f4eabab6368fbff6875128af4e1226d54db558bd76eec369cc9b285bc196d512e531f84864d33f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 236,
-          "comment" : "special case hash",
-          "msg" : "343134303533393934",
-          "sig" : "3065023100a557d1f63a2094f683429ecb35a6533bac897682775c0051e111eed6e076c48867cae005c5e0803800b050311e381cd602302a2f871efcf03cf1c8f509e076aaa2a76f1ea78d1c64804ea5b063b0324b8e98eb5825d04370106020ee15805dbedf81",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201000500",
+          "result" : "invalid"
         },
         {
           "tcId" : 237,
-          "comment" : "special case hash",
-          "msg" : "31393531353638363439",
-          "sig" : "3065023100f22bf91169b4aec84ca84041cb826f7dfc6f33d973f3c72433b8a0ca203aac93f7eed62be9bea01706402d5b5d3b0e6502307841d3bc34aa47e813a55c25203c5ec2342d838d5b4638c2705dcf4bac9c24f765b5d4c28fa3c7fda7a38ed5048c7de3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201000c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 238,
-          "comment" : "special case hash",
-          "msg" : "35393539303731363335",
-          "sig" : "30660231009c196e39a2d61a3c2565f5932f357e242892737e9adfc86c6609f291e5e6fdbb23029ff915a032b0c5390ba9d15f203e023100d721e28e5269d7813e8a9aed53a37e652fec1560ca61f28f55ab4c262cc6214eee8d3c4c2ba9d1ba0ba19e5e3c7484a7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201000c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 239,
-          "comment" : "special case hash",
-          "msg" : "323135333436393533",
-          "sig" : "30660231008ba1e9dec14d300b0e250ea0bcd4419c3d9559622cc7b8375bd73f7d70133242e3d5bf70bc782808734654bacd12daea023100d893d3970f72ccab35555ae91ebcfed3c5bfc5d39181071bc06ba382587a695e02ed482f1a74fe309a399eaee5f5bc52",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201003000",
+          "result" : "invalid"
         },
         {
           "tcId" : 240,
-          "comment" : "special case hash",
-          "msg" : "34383037313039383330",
-          "sig" : "306402302f521d9d83e1bff8d25255a9bdca90e15d78a8c9ea7885b884024a40de9a315bed7f746b5da4ce96b070208e9ae0cfa502304185c6f4225b8c255a4d31abb5c9b6c686a6ee50a8eb7103aaef90245a4722fc8996f266f262109c3b5957ba73289a20",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201003003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 241,
-          "comment" : "special case hash",
-          "msg" : "343932393339363930",
-          "sig" : "3065023100d4900f54c1bc841d38eb2f13e0bafbb12b5667393b07102db90639744f54d78960b344c8fbfbf3540b38d00278e177aa02303a16eff0399700009b6949f3f506c543495bf8e0f3a34feb8edd63648747b531adc4e75398e4da8083b88b34c2fb97a8",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008020101090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 242,
-          "comment" : "special case hash",
-          "msg" : "32313132333535393630",
-          "sig" : "3065023100c0169e2b8b97eeb0650e27653f2e473b97a06e1e888b07c1018c730cabfdeeec4a626c3edee0767d44e8ed07080c2ac4023013f46475f955f9701928067e3982d4ba5a58a379a66f91b74fad9ac8aee30086be6f41c9c2d8fb80e0924dedbe67e968",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 243,
-          "comment" : "special case hash",
-          "msg" : "31323339323735373034",
-          "sig" : "306402302e868871ea8b27a8a746882152051f2b146af4ac9d8473b4b6852f80a1d0c7cab57489aa43f89024388aec0605b0263702306d8c89eed8a5a6252c5cead1c55391c6743d881609e3db24d70ead80a663570020798fbf41d4c624fcb1ce36c536fe38",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 244,
-          "comment" : "special case hash",
-          "msg" : "32303831313838373638",
-          "sig" : "3065023100abe6a51179ee87c957805ecad5ccebca30c6e3a3e6dbe4eb4d130b71df2bf590b9d67c8f49e81bf90ce0909d3c2dab4c02307110582fab495b21bd9dda064fbd7acc09d0544dcf7699be35ad16207ffa10e8904f9241a709487ba2ba7e34430b81c3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 245,
-          "comment" : "special case hash",
-          "msg" : "343534363038393633",
-          "sig" : "3064023050252c19e60e4120b7c28b2c2e0a588e5d107518cd61e5c7999c6d465ea134f752322d8b83f5988fcdc62bd9adb36ccd0230193899352491dabfe4fc942e14ddacb200673729d61602cc0baf5732d262f36e5279865a810ce2f977f57686a0d0137a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201010500",
+          "result" : "invalid"
         },
         {
           "tcId" : 246,
-          "comment" : "special case hash",
-          "msg" : "31333837363837313131",
-          "sig" : "3066023100eb725fdd539d7de8ea02fac8db6ec464f40c272a63e6b2718c4e0266bf1235dae330f747a6052f4319ecbe7bdade9bd0023100ae84507648ba2d1944bb67722ccd2cb94b92b59e89a1ae698c668bb57f481c42b216c23da4b1d8c0e502ef97fda05ad0",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201010c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 247,
-          "comment" : "special case hash",
-          "msg" : "32303331333831383735",
-          "sig" : "3064023025aa56fcbd92f2cf53bddbaa0db537de5843290731c1dd78036fcbded4a8f7187ddfed9f5ca9d98ea7b12d24b8d29d570230028f68372d66164810bf79c30a191116d496fe32314605dc1668289425fb3a15d7532dde1052a49a35866c147abde1d9",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201010c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 248,
-          "comment" : "special case hash",
-          "msg" : "323535333538333333",
-          "sig" : "3065023054bf7adc8548e7cae270e7b097f16b5e315158d21b0e652ce1cfe4b33126ba4a65bf227b4cddcaf22d33d82478937b20023100bfc1b8f1d02846a42f31e1bd10ba334065459f712a3bbc76005d6c6488889f88c0983f4834d0bf2249dbf0a6db760701",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201013000",
+          "result" : "invalid"
         },
         {
           "tcId" : 249,
-          "comment" : "special case hash",
-          "msg" : "34363138383431343732",
-          "sig" : "3066023100d3bb29ac0bd1f6058a5197f766d6ea3216c572ded62af46318c8c7f9547bb246553654279d69989d9af5ef4ccacf64da023100e10281122c2112a2a5a9d87ac58f64fb07c996a2d09292119e8f24d5499b2e8524ebd0570097f6cc7f9c26094a35c857",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201013003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 250,
-          "comment" : "special case hash",
-          "msg" : "31303039323435383534",
-          "sig" : "3066023100bc32e85e3112472408f9324586e525325128a38313c34b79700cb0a3f7262a90a1fcc40eef1f1a3884032a7a21810e0a023100c02f52541360358107a13dbea31f83d80397710901734b7adb78b1fc904454a28a378514ccef80ecc70c1d8e55f11311",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201ff090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 251,
-          "comment" : "special case hash",
-          "msg" : "32373536343636353238",
-          "sig" : "3066023100f04b9e17c71d2d2133ea380d71b6b82c8a8e3332703e9d535b2c2bca9b0ad586d176a6049afa35edd9722edb5c33daa3023100bd44d4a6263380ca6f22e76c26d5f70f41f4d7cae7d4b9c1b8dc2ba5298d9d12408b04614e2f3796cc19c950c8c88a10",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 252,
-          "comment" : "special case hash",
-          "msg" : "313139363937313032",
-          "sig" : "3065023100c8807351d8e261338e750cb9a52f4be4470b63f6f181cbe0e81d43b60824ba4be1bba42b1783897a0d72b0614018b02f023052e3a598c8be982127e961eed2b04f21c86df4ebcab0d955a7c66ec7f818898798ee75367a85022276b912c0a072bff7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 253,
-          "comment" : "special case hash",
-          "msg" : "323333313432313732",
-          "sig" : "306402306152841b6fb460546eeb4158a3e5ffa54f51aa6a208987be899b706055cd59d8ec7c01f4634254fe050e1d4ec525a173023073f0c5f13640d892c28f701428e8fbfb736b6478bbd972c8c684977556ed599a70d313e06b126080e13068d56e1c10be",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 254,
-          "comment" : "special case hash",
-          "msg" : "31363733343831383938",
-          "sig" : "3066023100842f8d2814f5b7163f4b21bd9727246e078ad1e7435dfe1bc5f9e0e7374232e686b9b98b73deab9e43b3b7f25416c2be023100852c106c412300bac3ba265990b428a26076ab3f00fd7657bbd9315fa1cd2a1230a9a60d06b7af87aa0a6cf3f48b344c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 255,
-          "comment" : "special case hash",
-          "msg" : "31343630313539383237",
-          "sig" : "3066023100e13f6d638b9d4fba54aa436a945cfea66dec058fab6f026293265884457b5a86e8e927d699bc64431b71e3d41df200440231009832cd1b4177118ed247b4f31277da15f420179f45c71a237d77f599a45df68247bac3dcef0868ecd1665005c25b7c6c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff0c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 256,
-          "comment" : "special case hash",
-          "msg" : "38393930383539393239",
-          "sig" : "3064023009fff1c2e4ff8643cbfad588620c2bf7aaca5cf4242969142c7145b927bd82ed14f3ae8c6e2ce2da63b990b9f1be6d640230780c816f6c86343b008235ee986abf2136123ed247e4751e4d5467334f08e5e2ca1161254f68c3e6678e2d0b87d1cc7c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff0c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 257,
-          "comment" : "special case hash",
-          "msg" : "34333236343430393831",
-          "sig" : "3066023100ffae6e7d2cea71b5a9c73cbc1285a8d252949772afe1aa27fb137740fc429c2a8c8648c9a5ba678a32f7ae7689b395ca02310089d54cd13a162c34189ff524813690e79768af8ebe794cc941dfe7fdf2cb8dd0b42519f034ea4d4f1c870046d13210e1",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 258,
-          "comment" : "special case hash",
-          "msg" : "32333736343337353537",
-          "sig" : "3066023100efa3c5fc3c8be1007475a2dbd46e3578bb30579445909c2445f850fb8aa60aa5b1749cc3400d8ffd81cb8832b50d27b4023100b36a08db3845b3d2ebd2c335480f12fb83f2a7351841ea3842ec62ad904b098efbf9faa7828b9c185746d9c8bd047d76",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201ff3003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 259,
-          "comment" : "special case hash",
-          "msg" : "383630333937373230",
-          "sig" : "3066023100f577095f7c74594aa1c69aca9bb26e0c7475ae5163058ecc074b03af89e56b12b6a72450589dacf0d7e6b172d0017a0e023100bee756a0b5d0a677bf95f98da512854f3ecb712f94570e1ad230eab17c527b6a8bcc9ae202b657a3611ecffa94ba0d54",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3038023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 260,
-          "comment" : "special case hash",
-          "msg" : "35383037373733393837",
-          "sig" : "306502300ae7688c7de5882eb9c3172f5500015552f998fb53702c6cd4b03404d5a0510a8073db95db544808dbd76659fd20cf12023100bc610fe5f04d8909cc439615fb7e302d3d82992817647c50c1f467090a52b328cbbc0262f18ffb6fd9f3bd60013cea08",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 261,
-          "comment" : "special case hash",
-          "msg" : "353731383636383537",
-          "sig" : "306502305dc8a6d84afaaf900d78c6a91dc5e12e7d17891a52c1468253061d704b8940bef85b9fe807a0e02b56e8dd37c22fbb82023100914258de52932c4604dceb5ce7cc0a92e021edca9b819b84a9f25652f9af13f956a1139ee95c7aa7a079e3ad8317fbdb",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 262,
-          "comment" : "special case hash",
-          "msg" : "38363737333039333632",
-          "sig" : "3066023100da55a6dbb845205c87c995b0bbc8444ffcba6eb1f4eb9d30f721d2dacc198fb1a8296075e68eb3d25ef596a952b8ea19023100829f671dccad6d7b0b8c4b39ff3f42597965d55c645fb880a66fe198d9344c9311f1598930392470379fa5ff43c75d04",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 263,
-          "comment" : "special case hash",
-          "msg" : "32343735353135303630",
-          "sig" : "306402303730dfd0985de77decdd358a544b47f418d3fab42481530d5d514859894c6f23b729af72b44686058de29687b34b3b0c023065bdfaf0ac217a80b82eb09c9f59c5c8cfbf50a6eb979a8f5f63eab9bd38ee0938e4b23102112033b230a14ad2790e3f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529730500",
+          "result" : "invalid"
         },
         {
           "tcId" : 264,
-          "comment" : "special case hash",
-          "msg" : "393733313736383734",
-          "sig" : "3065023055210df2124c170e259af1dafa73e66613aa18ced8eb40a7f66155d50d5f3124edfa55276de4797013177291e8afeff6023100c314d3a310a60647dad3318ed7f0405a64c3f94b5ac98e6be12208c8ad9835fa6b81a0ea59f476608634657b66e00ffd",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529730c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 265,
-          "comment" : "special case hash",
-          "msg" : "33363938303935313438",
-          "sig" : "3065023100f6c9897144b5d84964515eb0c8c3d0d9c6687c957887e93c29b2a21804b40307fb88bfd5cca11c95885d28867cb33a740230656bafca242290f7d7e9801b6cfd4bd1b07e8d7c6c1c59fd3d8e82e9846a1b2855c85420e4ee6ec2d97fec2161eeb243",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529730c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 266,
-          "comment" : "special case hash",
-          "msg" : "3130373530323638353736",
-          "sig" : "3065023100bfbcc5f343e2ab392ce6c1c02d91c00650c47136836a5d0622d476ac2b3274395721b1ab21882ed5cabed093b43b133f0230043e9fc64c6108df73f9eced90f91185f83d89662f5a9d810c1824fbfd97b842f784305fd6b9c28c80d32d52b1538d12",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529733000",
+          "result" : "invalid"
         },
         {
           "tcId" : 267,
-          "comment" : "special case hash",
-          "msg" : "383639313439353538",
-          "sig" : "3066023100b8f793ddd47e657a9081cbed1600fb22b38ad6a155f9c006ba98de1f383b4c0918ceea72253e0f869524b2369cd9bd8c02310096c452ff58f42e0853040a6d5c7e750b57dd4af06e2df8194e8d524e81ac000ee3315bbeabbf6a21f61b8904c55378d9",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3038023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529733003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 268,
-          "comment" : "special case hash",
-          "msg" : "32313734363535343335",
-          "sig" : "30640230263ab1c93567e93b5ec4e380b0d3bb5ea1ce693c14a47afccc539aaf197f099d331ea9e26f1a0057148d46727acb61880230621db07ce94110e2be74fa953a00a8a554225b3f2c0f6c56b4ebd4db2f57ca2565ed3323fd708bb56ac6e28bfb40f2e7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3038023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 269,
-          "comment" : "special case hash",
-          "msg" : "363434353530373932",
-          "sig" : "306502310096f4a2b3529c65e45a0b4c19c582dc8db635d4e74f0b81309696b23be920ba8ec553d4b370df4c59d74dd654bac6df5802301573ba1b280c735a3401d957ecd3b8908e4e0b7d80239ce042594d182faf2ddf811c9056aac4c87f4f85043766a26614",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 270,
-          "comment" : "special case hash",
-          "msg" : "353332383138333338",
-          "sig" : "306602310096a691b19a6294b311a438f8da345e480b1deaa1e940cfbf02177d5f08479976ea58aee31011d50b5542be188c9d63df0231008f67dc9e1588aeb8be180013d41a036f9badfad9fe9340910cbf87243776f54bef7da2ebf3a7643866eb9a3b23fe59b9",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 271,
-          "comment" : "special case hash",
-          "msg" : "31313932303736333832",
-          "sig" : "3066023100cff27948c6d902c73d103d0802eb144dd89c1b0e3b9f9a5e498b0361dc122a0d555160d8c64d61539c1dbbd4bc18971f023100b60827488c9f16ba28378fd59b1a29c65073335a7f236131134674c62c8396f193c76f2395ddaaa4f24b69161eb69b4d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 272,
-          "comment" : "special case hash",
-          "msg" : "31353332383432323230",
-          "sig" : "3066023100e90e22d9e535dfdfd86e098d5d6a0ae08f69d4a3ffaa39f6930bcf5f5ad02ee0d0472ae984edd9f0bbe5e7d63fd4f6ac023100e3f57b0a4629ecaa21f2d34a7a0834d57ba20f99c6e31b43c37811cc23b9957c8f3356f4462214d3c8e58745e50f23f6",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 273,
-          "comment" : "special case hash",
-          "msg" : "313536373137373339",
-          "sig" : "3064023018b70e272a98cc48e1e0af73146f0f972bbfbeb6b985feb2c4acd695a7a41b99c415be9c46aedaf3ddff67a65a89e387023047d6bcea088f622ad35d88bcf46d71827bcba2f57c36d6fb8a4bf2befdc0d4e3ef366d5966c4d076d3cfa43d6626717b",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff0c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 274,
-          "comment" : "special case hash",
-          "msg" : "34333033303931313230",
-          "sig" : "3066023100acfd981c55fd5286cfce173726d51c3d25f65b11b7673729a62167256774f7c894b74662a212c706e00cef096074162f023100f4d471c97797c24d96aec1de85a249ef468d6036cd712563aeb65cea4995f3ee85e769b874f09a08637a44a96084be7a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff0c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 275,
-          "comment" : "special case hash",
-          "msg" : "37373335393135353831",
-          "sig" : "3065023100f15fcbeea8b64dad5e8566a2c37913c82d6be9d9668df469bd0b591c3923a6e12644eaf697d466fa7cd513983d946a40023070063966801079351526999e5c5c2c5f627e4c8bc96784bcbe715fe7c7afcf69785d1c8c7ccd3725e364101638396597",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 276,
-          "comment" : "special case hash",
-          "msg" : "323433393636373430",
-          "sig" : "3066023100d995147939ae6d8f62bb57372227395839e25a0d4308b899d5f506cf9e0a01e8115b7e4b822f037ec95752bd9e892f5e0231009bb4d07333e468f8482a790a2a2e650e2c42da8240ec5e402506b368122f046680cd71e0117897cce3df4a1555fc8876",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3038023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff3003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 277,
-          "comment" : "special case hash",
-          "msg" : "34333237363032383233",
-          "sig" : "3064023043c6ce5184476f3f496afeae3cb96a3f9f038957686c93437b8266a233022371d266e904aa096c3566cb33824b88075e0230680c13245a8bc560b638d26f0c5f261964130256939552d3fffb07b658355611612c268a89541055d3c2bf9e82cf4da3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0.25, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300a090380fe01090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 278,
-          "comment" : "special case hash",
-          "msg" : "32393332303032353932",
-          "sig" : "30630230447539941dc350767fc841083d25d9247a0807e1e22e0bb9d94f504f721981b413d521efbd75e4fe831ee26338cf3de3022f395ab27ea782cee4be53e06c7616bbd41d6926b18d219d75d5979f13cba2f52101019b0ec0a41ffdbf29ef73ddba70",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=nan, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006090142090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 279,
-          "comment" : "special case hash",
-          "msg" : "36343039383737323834",
-          "sig" : "3066023100a0ba8e8b979c20345e34fca98531900164a859923bd6986a9c39236a2f5de053a252997f35e5b84b0d48ba0f8d09aedd023100facd6df04358fcd95fa9018a6fc0828dfe319812ff65929c060b18ad4b9f06e7fc0addd1b695315d71c15e51dc51d719",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=True, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010101010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 280,
-          "comment" : "special case hash",
-          "msg" : "36303735363930343132",
-          "sig" : "3065023100b8378390f71f0bb6663f1846daf6908f8c84f770ae740cc8054122494cf0ffa9437ab26040ca22808fb29a810b70126e0230427636b929a500abc34d9f22977b81e734919afaf3ed2c91eeada7074e0c16bdc52f960eaec9db5a879c1e6414035101",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=False, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010100010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 281,
-          "comment" : "special case hash",
-          "msg" : "32333231363233313335",
-          "sig" : "3066023100f36a9048fd94803d3d6d1b11430b90b94ef8d5d2ad89018c69473ce9cfe0d6105b3c2fb2e7555ccd25f65af8c872bdc602310081254841e7ecbfd0d810afaaf5afd6d6c5d0542bb00cc183b1db01767120afbcc0006ddcba8db7baf65f302723dabc4d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=Null, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300405000500",
+          "result" : "invalid"
         },
         {
           "tcId" : 282,
-          "comment" : "special case hash",
-          "msg" : "36343130313532313731",
-          "sig" : "3066023100d8a4d96409c191baa9540bf35f1d5192f9352d7f0e14f92c0e8e1f19f559b42ed3c6b7bdb6becc56584fb5c09421e2e4023100d966ba13d4245e248eafb46f2a3df92c2037d5969c7db6dbcb0ff4b21850e16a18a29785267239886365cf721a212536",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30040c000c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 283,
-          "comment" : "special case hash",
-          "msg" : "383337323835373438",
-          "sig" : "306402301d5d86fd48e65b0cf0b0b46062241f89cf65785dd818f93f1162771a38a15f20febc261812ecaaf6f4f2b86b3362d7eb02300c76e363de1432513cb9dad6493931381ecd25f142e61968b6f20d7b1270cb9e38a7ae54e4778aff4025eb00c6a67aef",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=\"0\", s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060c01300c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 284,
-          "comment" : "special case hash",
-          "msg" : "33333234373034353235",
-          "sig" : "306402300508eed148f061114be18e8a86188feabf76b873b36eadcca9c2c60e24a2002fe456231decf7a8f6f032c08dbe0ab5a90230694c0ad781b2341e30e1d0739ac99672064f48821a69852c7940cf1d621738199c980d56d2a0b71b3fc6011c6b2444ba",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empty list, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300430003000",
+          "result" : "invalid"
         },
         {
           "tcId" : 285,
-          "comment" : "special case hash",
-          "msg" : "31343033393636383732",
-          "sig" : "30650230726ef88bb7947a043116c111cb519ddeda3e6ffbf724884a1b22c24409cdf2779d93ce610c8c07411c2b001399103d6d02310095dc1d65046caf0e8dad07b224798d6f7807278e737883e7c7bf0b446791d4ee144c26f710134861af4e6771d4082896",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=list containing 0, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300a30030201003003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 286,
-          "comment" : "special case hash",
-          "msg" : "31323237363035313238",
-          "sig" : "3066023100eb0e8e3c639f5eba8eccd9020d0ec62d8ac73f3fddbdfa08fdb2155deb0a536923ebd55e20020cab9f8e39a43a88be11023100c796df399fc35883dd5dae6817d02d3d67a8eec6601585e5e36fd2c134eddb1447ec12b144dddc9aae28a84f22602641",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0.25, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008090380fe01020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 287,
-          "comment" : "special case hash",
-          "msg" : "34393531343838333632",
-          "sig" : "3065023100e8f8c69d0396ea900f9757736d2b19dbc2d2a8c01dccf490c8b9455bd63b34c095867e7cf3b84dc7c3c3d6b51bebf405023058152a7564eeb22a3e26597026d0cd7835725bd512245448cb5016eb48ea759809fd6949d0ee5d579643f72f908c16bb",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=nan, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006090142020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 288,
-          "comment" : "special case hash",
-          "msg" : "32343532313237303139",
-          "sig" : "30650230380b4e48b3ff012af7c08bf871d9f4da0c708b5494a986d3d80b1979e579d0dbee61db9bc3c04c396176410788e15a0f023100e6971c013c965a7e4df10f95620a5092fab096bd5b50828f4bc91c5e479bccf6e0daf287e7ef580fa9ea153fa1a507a2",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=True, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010101020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 289,
-          "comment" : "special case hash",
-          "msg" : "31373331353530373036",
-          "sig" : "30650231008061de12029e2b000d157a455ecf2301222f092df95b9551b78cf0ef3a64f12212b57ec7b16d2c0f258946f51cb1633a02300ac2ca6ad99b29ca29a0dc38b34443ee41020f81ed9087cef7681a00c4fe60653a572944ba37f1fe51d112bfffbdd701",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=False, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010100020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 290,
-          "comment" : "special case hash",
-          "msg" : "31363637303639383738",
-          "sig" : "3066023100e74f2a791eeb7341cff6cc1c24f459e6c0109924f7984639ae387e3ceb58758a1bc3839dea1fc3a3799562225e70a733023100d90e4d0f47343268e56bbcb011bd4734390abc9aa1304b6253e78f5a78b6905aa6bf6a3892a4ae1a875c823ae5a83e87",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=Null, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050500020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 291,
-          "comment" : "special case hash",
-          "msg" : "343431353437363137",
-          "sig" : "306402306a1cd0ff7906be207b56862edcbc0d0bbfb26d43255c99f6ab77639f5e6103a07aa322b22ed43870d1ce6df68aa0a8c10230655558b129aa23184500bd4aab4f0355d3192e9b8860f60b05a1c29261f4486a6ae235a526339b86c05f5fac477b6723",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050c00020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 292,
-          "comment" : "special case hash",
-          "msg" : "343233393434393938",
-          "sig" : "306602310081111fdc5f0de65583c7a5668d26c04ee52e08dac227753132cff1741cb721e112aa793c0d5fa047faf14cb45dd13e1f0231009a25cf1e6c152bc3e216e021561d194979f1c11fe17019ed7bac2c13c4010f209665e3b6f33b86641704d922b407818f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=\"0\", s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060c0130020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 293,
-          "comment" : "special case hash",
-          "msg" : "34383037363230373132",
-          "sig" : "30660231009b66d122a315095b2b66ccb97272c476a2d760e827fdea05732d634df3d066569c984dd941aad5f5dec4c2e1b7b94a0002310096c32403c85bc3d0ee87f96a600182796dce53d54d7467ae660a42b87bb70792f14650ac28a5fa47ce9ca4d3b2c25878",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empty list, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30053000020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 294,
-          "comment" : "special case hash",
-          "msg" : "32313634363636323839",
-          "sig" : "306402302bb062a002088d62a0b7338d0484fedfe2af7e20cebf6a4788264eb27cb4ebc3cc81c816e6a35722cf9b464783094cb8023046cc21b70f2133f85ab0443bebe9c6fc62c6e2ec1fd9c4ddf4a6d5f3f48eb7abf1ee7bdf6725879fd1b7daafb44f6e04",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=list containing 0, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30083003020100020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 295,
-          "comment" : "special case hash",
-          "msg" : "31393432383533383635",
-          "sig" : "3065023033e87061ee9a82eb74d8bb4ae91606563c2e4db8b09183cc00d1119ab4f5033d287a1fc90a2348163fdf68d35006fd7f02310096db97c947ee2e96e6139d3bcbf5a43606bae1ad3ca28290fbad43b281ef115ec1b98bc581ef48094f8c1aa8e36c282a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Edge case for Shamir multiplication",
+          "flags" : [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg" : "3133323237",
+          "sig" : "3066023100ac042e13ab83394692019170707bc21dd3d7b8d233d11b651757085bdd5767eabbb85322984f14437335de0cdf565684023100bd770d3ee4beadbabe7ca46e8c4702783435228d46e2dd360e322fe61c86926fa49c8116ec940f72ac8c30d9beb3e12f",
+          "result" : "valid"
         },
         {
           "tcId" : 296,
           "comment" : "special case hash",
-          "msg" : "32323139333833353231",
-          "sig" : "3064023070f80b438424ba228a7d80f26e22ff6a896243c9d49c75573489ee0de58ec60efd103838143465bd8fe34672ba9496170230115492bd9365b96f38747536318bffb819e7c146df3a5a7a46d6288c7fdf31cff570b22176aa398daba9073ab1e7b9bf",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31373530353531383135",
+          "sig" : "3066023100d3298a0193c4316b34e3833ff764a82cff4ef57b5dd79ed6237b51ff76ceab13bf92131f41030515b7e012d2ba857830023100bfc7518d2ad20ed5f58f3be79720f1866f7a23b3bd1bf913d3916819d008497a071046311d3c2fd05fc284c964a39617",
+          "result" : "valid"
         },
         {
           "tcId" : 297,
           "comment" : "special case hash",
-          "msg" : "393236393333343139",
-          "sig" : "3066023100ff16ca0389ea6948f4305b434fe0aa589f880f5aa937767c31170ee8da6c1ad620c993d40ddf141b7fda37424d51b5cd023100ba0f86985dffc61d6e35a37de06918b11e431b72403161acfb8f05c469f1fcfa6e215c6f7eb5a0a5e0cc9e7be79ce18b",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130333633303731",
+          "sig" : "3065023100e14f41a5fc83aa4725a9ea60ab5b0b9de27f519af4b557a601f1fee0243f8eee5180f8c531414f3473f4457430cb7a2602301047ed2bf1f98e3ce93e8fdbdc63cc79f238998fee74e1bb6cd708694950bbffe3945066064da043f04d7083d0a596ec",
+          "result" : "valid"
         },
         {
           "tcId" : 298,
           "comment" : "special case hash",
-          "msg" : "373639333836333634",
-          "sig" : "3065023100d60c24bee05f5198cd155ad095ffb956bbcfb66b82fc0d3755119915a62f2f923557b85ddc1d12e6a757f23042cb601b02302c4d968b5eac930b51d283b418fcff6df3a9d6d66e3812cd1bf5fde797fd203a7c439b1b381e4fe8b44e6f108764a7dd",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32333632343231333231",
+          "sig" : "3066023100b7c8b5cf631a96ad908d6a8c8d0e0a35fcc22a5a36050230b665932764ae45bd84cb87ebba8e444abd89e4483fc9c4a8023100a11636c095aa9bc69cf24b50a0a9e5377d0ffbba4fab5433159f006ab4563d55e918493020a19691574e4d1e66e3975e",
+          "result" : "valid"
         },
         {
           "tcId" : 299,
           "comment" : "special case hash",
-          "msg" : "32373335393330353733",
-          "sig" : "3066023100bdf634d915a4fae7a155532ca2847c33a6babe7ef8db0af50f485db3dd2c8bffe722394583932f6eb5cd97f6db7561d9023100bb425cae2e5483174b5ed873af4329da4618c14458141850bee3c7bf1ffb3f2030159043277dacc708e9d32f63400083",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34353838303134363536",
+          "sig" : "306402304a7df2df6a32d59b6bfed54f032c3d6f3acd3ac4063704099cd162ab3908e8eeba4e973ee75b5e285dd572062338fe58023035365be327e2463dc759951c5c0be5e3d094cb706912fdf7d26b15d4a5c42ffebeca5ae73a1823f5e65d571b4ccf1a82",
+          "result" : "valid"
         },
         {
           "tcId" : 300,
           "comment" : "special case hash",
-          "msg" : "38333030353634303635",
-          "sig" : "30650230061320a3bcebac33cf399d45d1e1e1b34f37288fe4753f4fddfd496eff427e1d26b1b91d749cc34c12f4ecef837c0e8f023100fd5cf468cda319fe06e773a190c38de6e150a321ac1c416ad875432cdb7a07134c446f13068e71a1a96e35da923974ad",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32313436363035363432",
+          "sig" : "30660231009ad363a1bbc67c57c82a378e988cc083cc91f8b32739ec647c0cb348fb5c86472015131a7d9083bf4740af3351755195023100d310dc1509f8c00281efe571768d488027ea760fe32971f6cb7b57cdf90621b7d0086e26443d3761df7aa3a4eccc6c58",
+          "result" : "valid"
         },
         {
           "tcId" : 301,
           "comment" : "special case hash",
-          "msg" : "34333037363535373338",
-          "sig" : "3065023100d620f063d33efa859b623f6c9a92340e4cdd854ffbe3e5e01379177aee31715ce587b00bd0aea98fddf236d2fc8a7a740230671f4b7c187297dc236c61888b6d9397e97783077cc4101807d79ee62e4a53a78c4b6a3a31b03178668af894a3d8902e",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "333335333030383230",
+          "sig" : "306502310095078af5c2ac230239557f5fcee2e712a7034e95437a9b34c1692a81270edcf8ddd5aba1138a42012663e5f81c9beae2023040ee510a0cceb8518ad4f618599164da0f3ba75eceeac216216ec62bcceae8dc98b5e35b2e7ed47c4b8ebacfe84a74e6",
+          "result" : "valid"
         },
         {
           "tcId" : 302,
           "comment" : "special case hash",
-          "msg" : "39363537303138313735",
-          "sig" : "306502310091c556c5bddd529fe903b86afc0eb8fa1f49425b779a39114ae563bebc947e633ba4ee98948faa8940dfe2562c63e1c50230198b00079d8db072d25b0a49bc8bc36457926f3c101527528df6679f92c76f1b487e6695d4b92fe33b4ee7046a6a5df9",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp384r1",
-        "keySize" : 384,
-        "type" : "ECPublicKey",
-        "uncompressed" : "044bf4e52f958427ebb5915fb8c9595551b4d3a3fdab67badd9d6c3093f425ba43630df71f42f0eb7ceaa94d9f6448a85dd30331588249fd2fdc0b309ec7ed8481bc16f27800c13d7db700fc82e1b1c8545aa0c0d3b56e3bfe789fc18a916887c2",
-        "wx" : "4bf4e52f958427ebb5915fb8c9595551b4d3a3fdab67badd9d6c3093f425ba43630df71f42f0eb7ceaa94d9f6448a85d",
-        "wy" : "0d30331588249fd2fdc0b309ec7ed8481bc16f27800c13d7db700fc82e1b1c8545aa0c0d3b56e3bfe789fc18a916887c2"
-      },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200044bf4e52f958427ebb5915fb8c9595551b4d3a3fdab67badd9d6c3093f425ba43630df71f42f0eb7ceaa94d9f6448a85dd30331588249fd2fdc0b309ec7ed8481bc16f27800c13d7db700fc82e1b1c8545aa0c0d3b56e3bfe789fc18a916887c2",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAES/TlL5WEJ+u1kV+4yVlVUbTTo/2rZ7rd\nnWwwk/QlukNjDfcfQvDrfOqpTZ9kSKhd0wMxWIJJ/S/cCzCex+2EgbwW8ngAwT19\ntwD8guGxyFRaoMDTtW47/nifwYqRaIfC\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-384",
-      "type" : "ECDSAVer",
-      "tests" : [
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36333936363033363331",
+          "sig" : "3066023100a538076362043de54864464c14a6c1c3a478443726c1309a36b9e9ea1592b40c3f3f90d195bd298004a71e8f285e093a023100d74f97ef38468515a8c927a450275c14dc16ddbdd92b3a5cae804be20d29c682129247d2e01d37dabe38ffb74808a8b7",
+          "result" : "valid"
+        },
         {
           "tcId" : 303,
-          "comment" : "k*G has a large x-coordinate",
-          "msg" : "313233343030",
-          "sig" : "304d0218389cb27e0bc8d21fa7e5f24cb74f58851313e696333ad68b023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33333931363630373935",
+          "sig" : "3065023100bbe835113f8ea4dc469f0283af6603f3d7a3a222b3ab5a93db56007ef2dc07c97988fc7b8b833057fa3fbf97413b6c150230737c316320b61002c2acb184d82e60e46bd2129a9bbf563c80da423121c161decd363518b260aaacf3734c1ef9faa925",
+          "result" : "valid"
         },
         {
           "tcId" : 304,
-          "comment" : "r too large",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffe023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
-          "result" : "invalid",
-          "flags" : []
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31343436393735393634",
+          "sig" : "30650230679c3640ad8ffe9577d9b59b18ff5598dbfe61122bbab8238d268907c989cd94dc7f601d17486af93f6d18624aa524a3023100e84dd195502bdcdd77b7f51d8c1ea789006905844a0e185474af1a583bab564ee23be0bc49500390dceb3d3948f06730",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 305,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35313539343738363431",
+          "sig" : "3066023100f6f1afe6febce799cc9b754279f2499f3825c3e789accef46d3f068e2b6781fd50669e80c3c7293a5c0c0af48e068e35023100f59cc8c2222ed63b4553f8149ebecc43b866719b294ef0832a12b3e3dbc825eeab68b5779625b10ae5541412ec295354",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 306,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35323431373932333331",
+          "sig" : "3065023100f46496f6d473f3c091a68aaa3749220c840061cd4f888613ccfeac0aa0411b451edbd4facbe38d2dd9d6d0d0d255ed34023000c3a74fa6666f58c4798f30c3779813e5c6d08ac31a792c2d0f9cb708733f26ad6bf3b1e46815ae536aa151680bdee2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 307,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31313437323930323034",
+          "sig" : "3066023100df8b8e4cb1bc4ec69cb1472fa5a81c36642ed47fc6ce560033c4f7cb0bc8459b5788e34caa7d96e6071188e449f0207a0231008b8ee0177962a489938f3feffae55729d9d446fe438c7cb91ea5f632c80aa72a43b9b04e6de7ff34f76f4425107fd697",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 308,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130383738373235363435",
+          "sig" : "30660231008bb6a8ecdc8b483ad7b9c94bb39f63b5fc1378efe8c0204a74631dded7159643821419af33863b0414bd87ecf73ba3fb0231008928449f2d6db2b2c65d44d98beb77eeadcbda83ff33e57eb183e1fc29ad86f0ba29ee66e750e8170ccc434cf70ae199",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 309,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37333433333036353633",
+          "sig" : "3065023100e3832877c80c4ed439d8eadcf615c0286ff54943e3ae2f66a3b9f886245fea470e6d5812cef80c23e4f568d0215a3bfc02303177a7dbf0ab8f8f5fc1d01b19d6a5e89642899f369dfe213b7cc55d8eaf21dd2885efce52b5959c1f06b7cac5773e5b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 310,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "393734343630393738",
+          "sig" : "306502306275738f0880023286a9b6f28ea0a9779e8d644c3dec48293c64f1566b34e15c7119bd9d02fa2357774cabc9e53ef7e6023100d2f0a52b1016082bd5517609ee81c0764dc38a8f32d9a5074e717ee1d832f9ea0e4c6b100b1fd5e7f4bc7468c79d3933",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 311,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323237303836383339",
+          "sig" : "3066023100d316fe5168cf13753c8c3bbef83869a6703dc0d5afa82af49c88ff3555660f57919a6f36e84451c3e8e5783e3b83fe3b023100995f08c8fec7cd82ce27e7509393f5a3803a48fe255fcb160321c6e1890eb36e37bcda158f0fa6899e7d107e52de8c3c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 312,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "323332393736343130",
+          "sig" : "306402300b13b8fd10fa7b42169137588ad3f557539a4e9206f3a1f1fe9202b0690defded2be18147f5b2da9285c0e7349735ea302300478ad317b22a247bf9334719b4c8ee84acf134515db77e6141c75d08961e1e51eaca29836744103de0f6a4c798d3eeb",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 313,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3934303437333831",
+          "sig" : "3065023015804429bcb5277d4f0af73bd54c8a177499a7b64f18afc566c3ce7096bdc6c275e38548edcfa0b78dd7f57b6f393e49023100d5951f243e65b82ba5c0c7552d33b11f1e90fde0c3fd014aac1bb27db2aaf09b667c8b247c4cdd5b0723fba83b4f999e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 314,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323230353639313233",
+          "sig" : "30650230359247c95776bb17492b7bf827f5f330fa9f9de7cc10441a1479c81776ce36cdc6a13c5f5149c4e39147a196bb02ed34023100f6ed9252a73de48516f4eabab6368fbff6875128af4e1226d54db558bd76eec369cc9b285bc196d512e531f84864d33f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 315,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "343134303533393934",
+          "sig" : "3065023100a557d1f63a2094f683429ecb35a6533bac897682775c0051e111eed6e076c48867cae005c5e0803800b050311e381cd602302a2f871efcf03cf1c8f509e076aaa2a76f1ea78d1c64804ea5b063b0324b8e98eb5825d04370106020ee15805dbedf81",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 316,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31393531353638363439",
+          "sig" : "3065023100f22bf91169b4aec84ca84041cb826f7dfc6f33d973f3c72433b8a0ca203aac93f7eed62be9bea01706402d5b5d3b0e6502307841d3bc34aa47e813a55c25203c5ec2342d838d5b4638c2705dcf4bac9c24f765b5d4c28fa3c7fda7a38ed5048c7de3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 317,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35393539303731363335",
+          "sig" : "30660231009c196e39a2d61a3c2565f5932f357e242892737e9adfc86c6609f291e5e6fdbb23029ff915a032b0c5390ba9d15f203e023100d721e28e5269d7813e8a9aed53a37e652fec1560ca61f28f55ab4c262cc6214eee8d3c4c2ba9d1ba0ba19e5e3c7484a7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 318,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "323135333436393533",
+          "sig" : "30660231008ba1e9dec14d300b0e250ea0bcd4419c3d9559622cc7b8375bd73f7d70133242e3d5bf70bc782808734654bacd12daea023100d893d3970f72ccab35555ae91ebcfed3c5bfc5d39181071bc06ba382587a695e02ed482f1a74fe309a399eaee5f5bc52",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 319,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34383037313039383330",
+          "sig" : "306402302f521d9d83e1bff8d25255a9bdca90e15d78a8c9ea7885b884024a40de9a315bed7f746b5da4ce96b070208e9ae0cfa502304185c6f4225b8c255a4d31abb5c9b6c686a6ee50a8eb7103aaef90245a4722fc8996f266f262109c3b5957ba73289a20",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 320,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "343932393339363930",
+          "sig" : "3065023100d4900f54c1bc841d38eb2f13e0bafbb12b5667393b07102db90639744f54d78960b344c8fbfbf3540b38d00278e177aa02303a16eff0399700009b6949f3f506c543495bf8e0f3a34feb8edd63648747b531adc4e75398e4da8083b88b34c2fb97a8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 321,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32313132333535393630",
+          "sig" : "3065023100c0169e2b8b97eeb0650e27653f2e473b97a06e1e888b07c1018c730cabfdeeec4a626c3edee0767d44e8ed07080c2ac4023013f46475f955f9701928067e3982d4ba5a58a379a66f91b74fad9ac8aee30086be6f41c9c2d8fb80e0924dedbe67e968",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 322,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31323339323735373034",
+          "sig" : "306402302e868871ea8b27a8a746882152051f2b146af4ac9d8473b4b6852f80a1d0c7cab57489aa43f89024388aec0605b0263702306d8c89eed8a5a6252c5cead1c55391c6743d881609e3db24d70ead80a663570020798fbf41d4c624fcb1ce36c536fe38",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 323,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32303831313838373638",
+          "sig" : "3065023100abe6a51179ee87c957805ecad5ccebca30c6e3a3e6dbe4eb4d130b71df2bf590b9d67c8f49e81bf90ce0909d3c2dab4c02307110582fab495b21bd9dda064fbd7acc09d0544dcf7699be35ad16207ffa10e8904f9241a709487ba2ba7e34430b81c3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 324,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "343534363038393633",
+          "sig" : "3064023050252c19e60e4120b7c28b2c2e0a588e5d107518cd61e5c7999c6d465ea134f752322d8b83f5988fcdc62bd9adb36ccd0230193899352491dabfe4fc942e14ddacb200673729d61602cc0baf5732d262f36e5279865a810ce2f977f57686a0d0137a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 325,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31333837363837313131",
+          "sig" : "3066023100eb725fdd539d7de8ea02fac8db6ec464f40c272a63e6b2718c4e0266bf1235dae330f747a6052f4319ecbe7bdade9bd0023100ae84507648ba2d1944bb67722ccd2cb94b92b59e89a1ae698c668bb57f481c42b216c23da4b1d8c0e502ef97fda05ad0",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 326,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32303331333831383735",
+          "sig" : "3064023025aa56fcbd92f2cf53bddbaa0db537de5843290731c1dd78036fcbded4a8f7187ddfed9f5ca9d98ea7b12d24b8d29d570230028f68372d66164810bf79c30a191116d496fe32314605dc1668289425fb3a15d7532dde1052a49a35866c147abde1d9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 327,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "323535333538333333",
+          "sig" : "3065023054bf7adc8548e7cae270e7b097f16b5e315158d21b0e652ce1cfe4b33126ba4a65bf227b4cddcaf22d33d82478937b20023100bfc1b8f1d02846a42f31e1bd10ba334065459f712a3bbc76005d6c6488889f88c0983f4834d0bf2249dbf0a6db760701",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 328,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34363138383431343732",
+          "sig" : "3066023100d3bb29ac0bd1f6058a5197f766d6ea3216c572ded62af46318c8c7f9547bb246553654279d69989d9af5ef4ccacf64da023100e10281122c2112a2a5a9d87ac58f64fb07c996a2d09292119e8f24d5499b2e8524ebd0570097f6cc7f9c26094a35c857",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 329,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31303039323435383534",
+          "sig" : "3066023100bc32e85e3112472408f9324586e525325128a38313c34b79700cb0a3f7262a90a1fcc40eef1f1a3884032a7a21810e0a023100c02f52541360358107a13dbea31f83d80397710901734b7adb78b1fc904454a28a378514ccef80ecc70c1d8e55f11311",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 330,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32373536343636353238",
+          "sig" : "3066023100f04b9e17c71d2d2133ea380d71b6b82c8a8e3332703e9d535b2c2bca9b0ad586d176a6049afa35edd9722edb5c33daa3023100bd44d4a6263380ca6f22e76c26d5f70f41f4d7cae7d4b9c1b8dc2ba5298d9d12408b04614e2f3796cc19c950c8c88a10",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 331,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "313139363937313032",
+          "sig" : "3065023100c8807351d8e261338e750cb9a52f4be4470b63f6f181cbe0e81d43b60824ba4be1bba42b1783897a0d72b0614018b02f023052e3a598c8be982127e961eed2b04f21c86df4ebcab0d955a7c66ec7f818898798ee75367a85022276b912c0a072bff7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 332,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "323333313432313732",
+          "sig" : "306402306152841b6fb460546eeb4158a3e5ffa54f51aa6a208987be899b706055cd59d8ec7c01f4634254fe050e1d4ec525a173023073f0c5f13640d892c28f701428e8fbfb736b6478bbd972c8c684977556ed599a70d313e06b126080e13068d56e1c10be",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 333,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31363733343831383938",
+          "sig" : "3066023100842f8d2814f5b7163f4b21bd9727246e078ad1e7435dfe1bc5f9e0e7374232e686b9b98b73deab9e43b3b7f25416c2be023100852c106c412300bac3ba265990b428a26076ab3f00fd7657bbd9315fa1cd2a1230a9a60d06b7af87aa0a6cf3f48b344c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 334,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31343630313539383237",
+          "sig" : "3066023100e13f6d638b9d4fba54aa436a945cfea66dec058fab6f026293265884457b5a86e8e927d699bc64431b71e3d41df200440231009832cd1b4177118ed247b4f31277da15f420179f45c71a237d77f599a45df68247bac3dcef0868ecd1665005c25b7c6c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 335,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "38393930383539393239",
+          "sig" : "3064023009fff1c2e4ff8643cbfad588620c2bf7aaca5cf4242969142c7145b927bd82ed14f3ae8c6e2ce2da63b990b9f1be6d640230780c816f6c86343b008235ee986abf2136123ed247e4751e4d5467334f08e5e2ca1161254f68c3e6678e2d0b87d1cc7c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 336,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34333236343430393831",
+          "sig" : "3066023100ffae6e7d2cea71b5a9c73cbc1285a8d252949772afe1aa27fb137740fc429c2a8c8648c9a5ba678a32f7ae7689b395ca02310089d54cd13a162c34189ff524813690e79768af8ebe794cc941dfe7fdf2cb8dd0b42519f034ea4d4f1c870046d13210e1",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 337,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32333736343337353537",
+          "sig" : "3066023100efa3c5fc3c8be1007475a2dbd46e3578bb30579445909c2445f850fb8aa60aa5b1749cc3400d8ffd81cb8832b50d27b4023100b36a08db3845b3d2ebd2c335480f12fb83f2a7351841ea3842ec62ad904b098efbf9faa7828b9c185746d9c8bd047d76",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 338,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "383630333937373230",
+          "sig" : "3066023100f577095f7c74594aa1c69aca9bb26e0c7475ae5163058ecc074b03af89e56b12b6a72450589dacf0d7e6b172d0017a0e023100bee756a0b5d0a677bf95f98da512854f3ecb712f94570e1ad230eab17c527b6a8bcc9ae202b657a3611ecffa94ba0d54",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 339,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35383037373733393837",
+          "sig" : "306502300ae7688c7de5882eb9c3172f5500015552f998fb53702c6cd4b03404d5a0510a8073db95db544808dbd76659fd20cf12023100bc610fe5f04d8909cc439615fb7e302d3d82992817647c50c1f467090a52b328cbbc0262f18ffb6fd9f3bd60013cea08",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 340,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "353731383636383537",
+          "sig" : "306502305dc8a6d84afaaf900d78c6a91dc5e12e7d17891a52c1468253061d704b8940bef85b9fe807a0e02b56e8dd37c22fbb82023100914258de52932c4604dceb5ce7cc0a92e021edca9b819b84a9f25652f9af13f956a1139ee95c7aa7a079e3ad8317fbdb",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 341,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "38363737333039333632",
+          "sig" : "3066023100da55a6dbb845205c87c995b0bbc8444ffcba6eb1f4eb9d30f721d2dacc198fb1a8296075e68eb3d25ef596a952b8ea19023100829f671dccad6d7b0b8c4b39ff3f42597965d55c645fb880a66fe198d9344c9311f1598930392470379fa5ff43c75d04",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 342,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32343735353135303630",
+          "sig" : "306402303730dfd0985de77decdd358a544b47f418d3fab42481530d5d514859894c6f23b729af72b44686058de29687b34b3b0c023065bdfaf0ac217a80b82eb09c9f59c5c8cfbf50a6eb979a8f5f63eab9bd38ee0938e4b23102112033b230a14ad2790e3f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 343,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "393733313736383734",
+          "sig" : "3065023055210df2124c170e259af1dafa73e66613aa18ced8eb40a7f66155d50d5f3124edfa55276de4797013177291e8afeff6023100c314d3a310a60647dad3318ed7f0405a64c3f94b5ac98e6be12208c8ad9835fa6b81a0ea59f476608634657b66e00ffd",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 344,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33363938303935313438",
+          "sig" : "3065023100f6c9897144b5d84964515eb0c8c3d0d9c6687c957887e93c29b2a21804b40307fb88bfd5cca11c95885d28867cb33a740230656bafca242290f7d7e9801b6cfd4bd1b07e8d7c6c1c59fd3d8e82e9846a1b2855c85420e4ee6ec2d97fec2161eeb243",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 345,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130373530323638353736",
+          "sig" : "3065023100bfbcc5f343e2ab392ce6c1c02d91c00650c47136836a5d0622d476ac2b3274395721b1ab21882ed5cabed093b43b133f0230043e9fc64c6108df73f9eced90f91185f83d89662f5a9d810c1824fbfd97b842f784305fd6b9c28c80d32d52b1538d12",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 346,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "383639313439353538",
+          "sig" : "3066023100b8f793ddd47e657a9081cbed1600fb22b38ad6a155f9c006ba98de1f383b4c0918ceea72253e0f869524b2369cd9bd8c02310096c452ff58f42e0853040a6d5c7e750b57dd4af06e2df8194e8d524e81ac000ee3315bbeabbf6a21f61b8904c55378d9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 347,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32313734363535343335",
+          "sig" : "30640230263ab1c93567e93b5ec4e380b0d3bb5ea1ce693c14a47afccc539aaf197f099d331ea9e26f1a0057148d46727acb61880230621db07ce94110e2be74fa953a00a8a554225b3f2c0f6c56b4ebd4db2f57ca2565ed3323fd708bb56ac6e28bfb40f2e7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 348,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "363434353530373932",
+          "sig" : "306502310096f4a2b3529c65e45a0b4c19c582dc8db635d4e74f0b81309696b23be920ba8ec553d4b370df4c59d74dd654bac6df5802301573ba1b280c735a3401d957ecd3b8908e4e0b7d80239ce042594d182faf2ddf811c9056aac4c87f4f85043766a26614",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 349,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "353332383138333338",
+          "sig" : "306602310096a691b19a6294b311a438f8da345e480b1deaa1e940cfbf02177d5f08479976ea58aee31011d50b5542be188c9d63df0231008f67dc9e1588aeb8be180013d41a036f9badfad9fe9340910cbf87243776f54bef7da2ebf3a7643866eb9a3b23fe59b9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 350,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31313932303736333832",
+          "sig" : "3066023100cff27948c6d902c73d103d0802eb144dd89c1b0e3b9f9a5e498b0361dc122a0d555160d8c64d61539c1dbbd4bc18971f023100b60827488c9f16ba28378fd59b1a29c65073335a7f236131134674c62c8396f193c76f2395ddaaa4f24b69161eb69b4d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 351,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31353332383432323230",
+          "sig" : "3066023100e90e22d9e535dfdfd86e098d5d6a0ae08f69d4a3ffaa39f6930bcf5f5ad02ee0d0472ae984edd9f0bbe5e7d63fd4f6ac023100e3f57b0a4629ecaa21f2d34a7a0834d57ba20f99c6e31b43c37811cc23b9957c8f3356f4462214d3c8e58745e50f23f6",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 352,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "313536373137373339",
+          "sig" : "3064023018b70e272a98cc48e1e0af73146f0f972bbfbeb6b985feb2c4acd695a7a41b99c415be9c46aedaf3ddff67a65a89e387023047d6bcea088f622ad35d88bcf46d71827bcba2f57c36d6fb8a4bf2befdc0d4e3ef366d5966c4d076d3cfa43d6626717b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 353,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34333033303931313230",
+          "sig" : "3066023100acfd981c55fd5286cfce173726d51c3d25f65b11b7673729a62167256774f7c894b74662a212c706e00cef096074162f023100f4d471c97797c24d96aec1de85a249ef468d6036cd712563aeb65cea4995f3ee85e769b874f09a08637a44a96084be7a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 354,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37373335393135353831",
+          "sig" : "3065023100f15fcbeea8b64dad5e8566a2c37913c82d6be9d9668df469bd0b591c3923a6e12644eaf697d466fa7cd513983d946a40023070063966801079351526999e5c5c2c5f627e4c8bc96784bcbe715fe7c7afcf69785d1c8c7ccd3725e364101638396597",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 355,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "323433393636373430",
+          "sig" : "3066023100d995147939ae6d8f62bb57372227395839e25a0d4308b899d5f506cf9e0a01e8115b7e4b822f037ec95752bd9e892f5e0231009bb4d07333e468f8482a790a2a2e650e2c42da8240ec5e402506b368122f046680cd71e0117897cce3df4a1555fc8876",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 356,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34333237363032383233",
+          "sig" : "3064023043c6ce5184476f3f496afeae3cb96a3f9f038957686c93437b8266a233022371d266e904aa096c3566cb33824b88075e0230680c13245a8bc560b638d26f0c5f261964130256939552d3fffb07b658355611612c268a89541055d3c2bf9e82cf4da3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 357,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32393332303032353932",
+          "sig" : "30630230447539941dc350767fc841083d25d9247a0807e1e22e0bb9d94f504f721981b413d521efbd75e4fe831ee26338cf3de3022f395ab27ea782cee4be53e06c7616bbd41d6926b18d219d75d5979f13cba2f52101019b0ec0a41ffdbf29ef73ddba70",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 358,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36343039383737323834",
+          "sig" : "3066023100a0ba8e8b979c20345e34fca98531900164a859923bd6986a9c39236a2f5de053a252997f35e5b84b0d48ba0f8d09aedd023100facd6df04358fcd95fa9018a6fc0828dfe319812ff65929c060b18ad4b9f06e7fc0addd1b695315d71c15e51dc51d719",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 359,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36303735363930343132",
+          "sig" : "3065023100b8378390f71f0bb6663f1846daf6908f8c84f770ae740cc8054122494cf0ffa9437ab26040ca22808fb29a810b70126e0230427636b929a500abc34d9f22977b81e734919afaf3ed2c91eeada7074e0c16bdc52f960eaec9db5a879c1e6414035101",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 360,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32333231363233313335",
+          "sig" : "3066023100f36a9048fd94803d3d6d1b11430b90b94ef8d5d2ad89018c69473ce9cfe0d6105b3c2fb2e7555ccd25f65af8c872bdc602310081254841e7ecbfd0d810afaaf5afd6d6c5d0542bb00cc183b1db01767120afbcc0006ddcba8db7baf65f302723dabc4d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 361,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36343130313532313731",
+          "sig" : "3066023100d8a4d96409c191baa9540bf35f1d5192f9352d7f0e14f92c0e8e1f19f559b42ed3c6b7bdb6becc56584fb5c09421e2e4023100d966ba13d4245e248eafb46f2a3df92c2037d5969c7db6dbcb0ff4b21850e16a18a29785267239886365cf721a212536",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 362,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "383337323835373438",
+          "sig" : "306402301d5d86fd48e65b0cf0b0b46062241f89cf65785dd818f93f1162771a38a15f20febc261812ecaaf6f4f2b86b3362d7eb02300c76e363de1432513cb9dad6493931381ecd25f142e61968b6f20d7b1270cb9e38a7ae54e4778aff4025eb00c6a67aef",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 363,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33333234373034353235",
+          "sig" : "306402300508eed148f061114be18e8a86188feabf76b873b36eadcca9c2c60e24a2002fe456231decf7a8f6f032c08dbe0ab5a90230694c0ad781b2341e30e1d0739ac99672064f48821a69852c7940cf1d621738199c980d56d2a0b71b3fc6011c6b2444ba",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 364,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31343033393636383732",
+          "sig" : "30650230726ef88bb7947a043116c111cb519ddeda3e6ffbf724884a1b22c24409cdf2779d93ce610c8c07411c2b001399103d6d02310095dc1d65046caf0e8dad07b224798d6f7807278e737883e7c7bf0b446791d4ee144c26f710134861af4e6771d4082896",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 365,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31323237363035313238",
+          "sig" : "3066023100eb0e8e3c639f5eba8eccd9020d0ec62d8ac73f3fddbdfa08fdb2155deb0a536923ebd55e20020cab9f8e39a43a88be11023100c796df399fc35883dd5dae6817d02d3d67a8eec6601585e5e36fd2c134eddb1447ec12b144dddc9aae28a84f22602641",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 366,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34393531343838333632",
+          "sig" : "3065023100e8f8c69d0396ea900f9757736d2b19dbc2d2a8c01dccf490c8b9455bd63b34c095867e7cf3b84dc7c3c3d6b51bebf405023058152a7564eeb22a3e26597026d0cd7835725bd512245448cb5016eb48ea759809fd6949d0ee5d579643f72f908c16bb",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 367,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32343532313237303139",
+          "sig" : "30650230380b4e48b3ff012af7c08bf871d9f4da0c708b5494a986d3d80b1979e579d0dbee61db9bc3c04c396176410788e15a0f023100e6971c013c965a7e4df10f95620a5092fab096bd5b50828f4bc91c5e479bccf6e0daf287e7ef580fa9ea153fa1a507a2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 368,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31373331353530373036",
+          "sig" : "30650231008061de12029e2b000d157a455ecf2301222f092df95b9551b78cf0ef3a64f12212b57ec7b16d2c0f258946f51cb1633a02300ac2ca6ad99b29ca29a0dc38b34443ee41020f81ed9087cef7681a00c4fe60653a572944ba37f1fe51d112bfffbdd701",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 369,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31363637303639383738",
+          "sig" : "3066023100e74f2a791eeb7341cff6cc1c24f459e6c0109924f7984639ae387e3ceb58758a1bc3839dea1fc3a3799562225e70a733023100d90e4d0f47343268e56bbcb011bd4734390abc9aa1304b6253e78f5a78b6905aa6bf6a3892a4ae1a875c823ae5a83e87",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 370,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "343431353437363137",
+          "sig" : "306402306a1cd0ff7906be207b56862edcbc0d0bbfb26d43255c99f6ab77639f5e6103a07aa322b22ed43870d1ce6df68aa0a8c10230655558b129aa23184500bd4aab4f0355d3192e9b8860f60b05a1c29261f4486a6ae235a526339b86c05f5fac477b6723",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 371,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "343233393434393938",
+          "sig" : "306602310081111fdc5f0de65583c7a5668d26c04ee52e08dac227753132cff1741cb721e112aa793c0d5fa047faf14cb45dd13e1f0231009a25cf1e6c152bc3e216e021561d194979f1c11fe17019ed7bac2c13c4010f209665e3b6f33b86641704d922b407818f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 372,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34383037363230373132",
+          "sig" : "30660231009b66d122a315095b2b66ccb97272c476a2d760e827fdea05732d634df3d066569c984dd941aad5f5dec4c2e1b7b94a0002310096c32403c85bc3d0ee87f96a600182796dce53d54d7467ae660a42b87bb70792f14650ac28a5fa47ce9ca4d3b2c25878",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 373,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32313634363636323839",
+          "sig" : "306402302bb062a002088d62a0b7338d0484fedfe2af7e20cebf6a4788264eb27cb4ebc3cc81c816e6a35722cf9b464783094cb8023046cc21b70f2133f85ab0443bebe9c6fc62c6e2ec1fd9c4ddf4a6d5f3f48eb7abf1ee7bdf6725879fd1b7daafb44f6e04",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 374,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31393432383533383635",
+          "sig" : "3065023033e87061ee9a82eb74d8bb4ae91606563c2e4db8b09183cc00d1119ab4f5033d287a1fc90a2348163fdf68d35006fd7f02310096db97c947ee2e96e6139d3bcbf5a43606bae1ad3ca28290fbad43b281ef115ec1b98bc581ef48094f8c1aa8e36c282a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 375,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32323139333833353231",
+          "sig" : "3064023070f80b438424ba228a7d80f26e22ff6a896243c9d49c75573489ee0de58ec60efd103838143465bd8fe34672ba9496170230115492bd9365b96f38747536318bffb819e7c146df3a5a7a46d6288c7fdf31cff570b22176aa398daba9073ab1e7b9bf",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 376,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "393236393333343139",
+          "sig" : "3066023100ff16ca0389ea6948f4305b434fe0aa589f880f5aa937767c31170ee8da6c1ad620c993d40ddf141b7fda37424d51b5cd023100ba0f86985dffc61d6e35a37de06918b11e431b72403161acfb8f05c469f1fcfa6e215c6f7eb5a0a5e0cc9e7be79ce18b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 377,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "373639333836333634",
+          "sig" : "3065023100d60c24bee05f5198cd155ad095ffb956bbcfb66b82fc0d3755119915a62f2f923557b85ddc1d12e6a757f23042cb601b02302c4d968b5eac930b51d283b418fcff6df3a9d6d66e3812cd1bf5fde797fd203a7c439b1b381e4fe8b44e6f108764a7dd",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 378,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32373335393330353733",
+          "sig" : "3066023100bdf634d915a4fae7a155532ca2847c33a6babe7ef8db0af50f485db3dd2c8bffe722394583932f6eb5cd97f6db7561d9023100bb425cae2e5483174b5ed873af4329da4618c14458141850bee3c7bf1ffb3f2030159043277dacc708e9d32f63400083",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 379,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "38333030353634303635",
+          "sig" : "30650230061320a3bcebac33cf399d45d1e1e1b34f37288fe4753f4fddfd496eff427e1d26b1b91d749cc34c12f4ecef837c0e8f023100fd5cf468cda319fe06e773a190c38de6e150a321ac1c416ad875432cdb7a07134c446f13068e71a1a96e35da923974ad",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 380,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34333037363535373338",
+          "sig" : "3065023100d620f063d33efa859b623f6c9a92340e4cdd854ffbe3e5e01379177aee31715ce587b00bd0aea98fddf236d2fc8a7a740230671f4b7c187297dc236c61888b6d9397e97783077cc4101807d79ee62e4a53a78c4b6a3a31b03178668af894a3d8902e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 381,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "39363537303138313735",
+          "sig" : "306502310091c556c5bddd529fe903b86afc0eb8fa1f49425b779a39114ae563bebc947e633ba4ee98948faa8940dfe2562c63e1c50230198b00079d8db072d25b0a49bc8bc36457926f3c101527528df6679f92c76f1b487e6695d4b92fe33b4ee7046a6a5df9",
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
+        "uncompressed" : "044bf4e52f958427ebb5915fb8c9595551b4d3a3fdab67badd9d6c3093f425ba43630df71f42f0eb7ceaa94d9f6448a85dd30331588249fd2fdc0b309ec7ed8481bc16f27800c13d7db700fc82e1b1c8545aa0c0d3b56e3bfe789fc18a916887c2",
+        "wx" : "4bf4e52f958427ebb5915fb8c9595551b4d3a3fdab67badd9d6c3093f425ba43630df71f42f0eb7ceaa94d9f6448a85d",
+        "wy" : "00d30331588249fd2fdc0b309ec7ed8481bc16f27800c13d7db700fc82e1b1c8545aa0c0d3b56e3bfe789fc18a916887c2"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200044bf4e52f958427ebb5915fb8c9595551b4d3a3fdab67badd9d6c3093f425ba43630df71f42f0eb7ceaa94d9f6448a85dd30331588249fd2fdc0b309ec7ed8481bc16f27800c13d7db700fc82e1b1c8545aa0c0d3b56e3bfe789fc18a916887c2",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAES/TlL5WEJ+u1kV+4yVlVUbTTo/2rZ7rd\nnWwwk/QlukNjDfcfQvDrfOqpTZ9kSKhd0wMxWIJJ/S/cCzCex+2EgbwW8ngAwT19\ntwD8guGxyFRaoMDTtW47/nifwYqRaIfC\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 382,
+          "comment" : "k*G has a large x-coordinate",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304d0218389cb27e0bc8d21fa7e5f24cb74f58851313e696333ad68b023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 383,
+          "comment" : "r too large",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffe023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
         "uncompressed" : "043623bb296b88f626d0f92656bf016f115b721277ccb4930739bfbd81f9c1e734630e0685d32e154e0b4a5c62e43851f6768356b4a5764c128c7b1105e3d778a89d1e01da297ede1bc4312c2583e0bbddd21613583dd09ab895c63be479f94576",
         "wx" : "3623bb296b88f626d0f92656bf016f115b721277ccb4930739bfbd81f9c1e734630e0685d32e154e0b4a5c62e43851f6",
         "wy" : "768356b4a5764c128c7b1105e3d778a89d1e01da297ede1bc4312c2583e0bbddd21613583dd09ab895c63be479f94576"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200043623bb296b88f626d0f92656bf016f115b721277ccb4930739bfbd81f9c1e734630e0685d32e154e0b4a5c62e43851f6768356b4a5764c128c7b1105e3d778a89d1e01da297ede1bc4312c2583e0bbddd21613583dd09ab895c63be479f94576",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAENiO7KWuI9ibQ+SZWvwFvEVtyEnfMtJMH\nOb+9gfnB5zRjDgaF0y4VTgtKXGLkOFH2doNWtKV2TBKMexEF49d4qJ0eAdopft4b\nxDEsJYPgu93SFhNYPdCauJXGO+R5+UV2\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200043623bb296b88f626d0f92656bf016f115b721277ccb4930739bfbd81f9c1e734630e0685d32e154e0b4a5c62e43851f6768356b4a5764c128c7b1105e3d778a89d1e01da297ede1bc4312c2583e0bbddd21613583dd09ab895c63be479f94576",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAENiO7KWuI9ibQ+SZWvwFvEVtyEnfMtJMH\nOb+9gfnB5zRjDgaF0y4VTgtKXGLkOFH2doNWtKV2TBKMexEF49d4qJ0eAdopft4b\nxDEsJYPgu93SFhNYPdCauJXGO+R5+UV2\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 305,
+          "tcId" : 384,
           "comment" : "r,s are large",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52971",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04d516cb8ac8e4457b693d5192beeb6ce7d9a46bef48eecf3ea823286f101f98d130f5a26dc6fec23662eff07f14486fd58456932e74894b7f0e3bb0dfd362502b3765dd80a3177209fb221dc9b51aaf4470b245391405bef514176b13a267a720",
-        "wx" : "0d516cb8ac8e4457b693d5192beeb6ce7d9a46bef48eecf3ea823286f101f98d130f5a26dc6fec23662eff07f14486fd5",
-        "wy" : "08456932e74894b7f0e3bb0dfd362502b3765dd80a3177209fb221dc9b51aaf4470b245391405bef514176b13a267a720"
+        "wx" : "00d516cb8ac8e4457b693d5192beeb6ce7d9a46bef48eecf3ea823286f101f98d130f5a26dc6fec23662eff07f14486fd5",
+        "wy" : "008456932e74894b7f0e3bb0dfd362502b3765dd80a3177209fb221dc9b51aaf4470b245391405bef514176b13a267a720"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004d516cb8ac8e4457b693d5192beeb6ce7d9a46bef48eecf3ea823286f101f98d130f5a26dc6fec23662eff07f14486fd58456932e74894b7f0e3bb0dfd362502b3765dd80a3177209fb221dc9b51aaf4470b245391405bef514176b13a267a720",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE1RbLisjkRXtpPVGSvuts59mka+9I7s8+\nqCMobxAfmNEw9aJtxv7CNmLv8H8USG/VhFaTLnSJS38OO7Df02JQKzdl3YCjF3IJ\n+yIdybUar0RwskU5FAW+9RQXaxOiZ6cg\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004d516cb8ac8e4457b693d5192beeb6ce7d9a46bef48eecf3ea823286f101f98d130f5a26dc6fec23662eff07f14486fd58456932e74894b7f0e3bb0dfd362502b3765dd80a3177209fb221dc9b51aaf4470b245391405bef514176b13a267a720",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE1RbLisjkRXtpPVGSvuts59mka+9I7s8+\nqCMobxAfmNEw9aJtxv7CNmLv8H8USG/VhFaTLnSJS38OO7Df02JQKzdl3YCjF3IJ\n+yIdybUar0RwskU5FAW+9RQXaxOiZ6cg\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 306,
+          "tcId" : 385,
           "comment" : "r and s^-1 have a large Hamming weight",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100d1aee55fdc2a716ba2fabcb57020b72e539bf05c7902f98e105bf83d4cc10c2a159a3cf7e01d749d2205f4da6bd8fcf1",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04a8380cd35026e13bf87be693cdb6e75a82d765b4019b529e8d277c4af6c9db27ebb5d3f86e88add9d5b61186f04c83a992a187507c737325d2cc624acef3cd036bfa99e0c1518be65c88bb51f900f94123acabad81d15130d3ade7ff7e4364e1",
-        "wx" : "0a8380cd35026e13bf87be693cdb6e75a82d765b4019b529e8d277c4af6c9db27ebb5d3f86e88add9d5b61186f04c83a9",
-        "wy" : "092a187507c737325d2cc624acef3cd036bfa99e0c1518be65c88bb51f900f94123acabad81d15130d3ade7ff7e4364e1"
+        "wx" : "00a8380cd35026e13bf87be693cdb6e75a82d765b4019b529e8d277c4af6c9db27ebb5d3f86e88add9d5b61186f04c83a9",
+        "wy" : "0092a187507c737325d2cc624acef3cd036bfa99e0c1518be65c88bb51f900f94123acabad81d15130d3ade7ff7e4364e1"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004a8380cd35026e13bf87be693cdb6e75a82d765b4019b529e8d277c4af6c9db27ebb5d3f86e88add9d5b61186f04c83a992a187507c737325d2cc624acef3cd036bfa99e0c1518be65c88bb51f900f94123acabad81d15130d3ade7ff7e4364e1",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqDgM01Am4Tv4e+aTzbbnWoLXZbQBm1Ke\njSd8SvbJ2yfrtdP4boit2dW2EYbwTIOpkqGHUHxzcyXSzGJKzvPNA2v6meDBUYvm\nXIi7UfkA+UEjrKutgdFRMNOt5/9+Q2Th\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004a8380cd35026e13bf87be693cdb6e75a82d765b4019b529e8d277c4af6c9db27ebb5d3f86e88add9d5b61186f04c83a992a187507c737325d2cc624acef3cd036bfa99e0c1518be65c88bb51f900f94123acabad81d15130d3ade7ff7e4364e1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqDgM01Am4Tv4e+aTzbbnWoLXZbQBm1Ke\njSd8SvbJ2yfrtdP4boit2dW2EYbwTIOpkqGHUHxzcyXSzGJKzvPNA2v6meDBUYvm\nXIi7UfkA+UEjrKutgdFRMNOt5/9+Q2Th\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 307,
+          "tcId" : 386,
           "comment" : "r and s^-1 have a large Hamming weight",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100b6b681dc484f4f020fd3f7e626d88edc6ded1b382ef3e143d60887b51394260832d4d8f2ef70458f9fa90e38c2e19e4f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04554f2fd0b700a9f4568752b673d9c0d29dc96c10fe67e38c6d6d339bfafe05f970da8c3d2164e82031307a44bd32251171312b61b59113ff0bd3b8a9a4934df262aa8096f840e9d8bffa5d7491ded87b38c496f9b9e4f0ba1089f8d3ffc88a9f",
         "wx" : "554f2fd0b700a9f4568752b673d9c0d29dc96c10fe67e38c6d6d339bfafe05f970da8c3d2164e82031307a44bd322511",
         "wy" : "71312b61b59113ff0bd3b8a9a4934df262aa8096f840e9d8bffa5d7491ded87b38c496f9b9e4f0ba1089f8d3ffc88a9f"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004554f2fd0b700a9f4568752b673d9c0d29dc96c10fe67e38c6d6d339bfafe05f970da8c3d2164e82031307a44bd32251171312b61b59113ff0bd3b8a9a4934df262aa8096f840e9d8bffa5d7491ded87b38c496f9b9e4f0ba1089f8d3ffc88a9f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEVU8v0LcAqfRWh1K2c9nA0p3JbBD+Z+OM\nbW0zm/r+Bflw2ow9IWToIDEwekS9MiURcTErYbWRE/8L07ippJNN8mKqgJb4QOnY\nv/pddJHe2Hs4xJb5ueTwuhCJ+NP/yIqf\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004554f2fd0b700a9f4568752b673d9c0d29dc96c10fe67e38c6d6d339bfafe05f970da8c3d2164e82031307a44bd32251171312b61b59113ff0bd3b8a9a4934df262aa8096f840e9d8bffa5d7491ded87b38c496f9b9e4f0ba1089f8d3ffc88a9f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEVU8v0LcAqfRWh1K2c9nA0p3JbBD+Z+OM\nbW0zm/r+Bflw2ow9IWToIDEwekS9MiURcTErYbWRE/8L07ippJNN8mKqgJb4QOnY\nv/pddJHe2Hs4xJb5ueTwuhCJ+NP/yIqf\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 308,
+          "tcId" : 387,
           "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3006020102020101",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0444ee3335fa77d2fb02e4bd7074f45e598a879c0fa822ec718c21dc13b83440edc4e3c10a1858423e03044c9eff22591cd027c49933e5510557d6b4b2c6f66fe5dcb9302a3b13fdc68048c3fcac88ba152b6a9833c87fdc6280afc5d11ab7c107",
         "wx" : "44ee3335fa77d2fb02e4bd7074f45e598a879c0fa822ec718c21dc13b83440edc4e3c10a1858423e03044c9eff22591c",
-        "wy" : "0d027c49933e5510557d6b4b2c6f66fe5dcb9302a3b13fdc68048c3fcac88ba152b6a9833c87fdc6280afc5d11ab7c107"
+        "wy" : "00d027c49933e5510557d6b4b2c6f66fe5dcb9302a3b13fdc68048c3fcac88ba152b6a9833c87fdc6280afc5d11ab7c107"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000444ee3335fa77d2fb02e4bd7074f45e598a879c0fa822ec718c21dc13b83440edc4e3c10a1858423e03044c9eff22591cd027c49933e5510557d6b4b2c6f66fe5dcb9302a3b13fdc68048c3fcac88ba152b6a9833c87fdc6280afc5d11ab7c107",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERO4zNfp30vsC5L1wdPReWYqHnA+oIuxx\njCHcE7g0QO3E48EKGFhCPgMETJ7/Ilkc0CfEmTPlUQVX1rSyxvZv5dy5MCo7E/3G\ngEjD/KyIuhUrapgzyH/cYoCvxdEat8EH\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000444ee3335fa77d2fb02e4bd7074f45e598a879c0fa822ec718c21dc13b83440edc4e3c10a1858423e03044c9eff22591cd027c49933e5510557d6b4b2c6f66fe5dcb9302a3b13fdc68048c3fcac88ba152b6a9833c87fdc6280afc5d11ab7c107",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERO4zNfp30vsC5L1wdPReWYqHnA+oIuxx\njCHcE7g0QO3E48EKGFhCPgMETJ7/Ilkc0CfEmTPlUQVX1rSyxvZv5dy5MCo7E/3G\ngEjD/KyIuhUrapgzyH/cYoCvxdEat8EH\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 309,
+          "tcId" : 388,
           "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3006020102020102",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04e2f87f72e3c66c73037fe77607d42ad2d9c4cc159893b4b9b8b0365d3a7766dbe8678b02e2b68f58e5a4f7681061a390e38f2142818542bef6b2bc3a2c4f43c95e5259d6bd5401531378c7ca125a1f6cc609d4fadfc5c9a99358ee77ff780c8d",
-        "wx" : "0e2f87f72e3c66c73037fe77607d42ad2d9c4cc159893b4b9b8b0365d3a7766dbe8678b02e2b68f58e5a4f7681061a390",
-        "wy" : "0e38f2142818542bef6b2bc3a2c4f43c95e5259d6bd5401531378c7ca125a1f6cc609d4fadfc5c9a99358ee77ff780c8d"
+        "wx" : "00e2f87f72e3c66c73037fe77607d42ad2d9c4cc159893b4b9b8b0365d3a7766dbe8678b02e2b68f58e5a4f7681061a390",
+        "wy" : "00e38f2142818542bef6b2bc3a2c4f43c95e5259d6bd5401531378c7ca125a1f6cc609d4fadfc5c9a99358ee77ff780c8d"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004e2f87f72e3c66c73037fe77607d42ad2d9c4cc159893b4b9b8b0365d3a7766dbe8678b02e2b68f58e5a4f7681061a390e38f2142818542bef6b2bc3a2c4f43c95e5259d6bd5401531378c7ca125a1f6cc609d4fadfc5c9a99358ee77ff780c8d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4vh/cuPGbHMDf+d2B9Qq0tnEzBWYk7S5\nuLA2XTp3ZtvoZ4sC4raPWOWk92gQYaOQ448hQoGFQr72srw6LE9DyV5SWda9VAFT\nE3jHyhJaH2zGCdT638XJqZNY7nf/eAyN\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004e2f87f72e3c66c73037fe77607d42ad2d9c4cc159893b4b9b8b0365d3a7766dbe8678b02e2b68f58e5a4f7681061a390e38f2142818542bef6b2bc3a2c4f43c95e5259d6bd5401531378c7ca125a1f6cc609d4fadfc5c9a99358ee77ff780c8d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE4vh/cuPGbHMDf+d2B9Qq0tnEzBWYk7S5\nuLA2XTp3ZtvoZ4sC4raPWOWk92gQYaOQ448hQoGFQr72srw6LE9DyV5SWda9VAFT\nE3jHyhJaH2zGCdT638XJqZNY7nf/eAyN\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 310,
+          "tcId" : 389,
           "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3006020102020103",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "0460e89510c308089a747f06374c5388416535753b33514480bf8251ff4014754ebaf48aa655dc41ca89f373257a7e50b14dc4c2bed99597c146d577f4333843855da27e395fc81aa90205795bd555b3451dc4b9536e234799185123c4792cfb1d",
+        "wx" : "60e89510c308089a747f06374c5388416535753b33514480bf8251ff4014754ebaf48aa655dc41ca89f373257a7e50b1",
+        "wy" : "4dc4c2bed99597c146d577f4333843855da27e395fc81aa90205795bd555b3451dc4b9536e234799185123c4792cfb1d"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000460e89510c308089a747f06374c5388416535753b33514480bf8251ff4014754ebaf48aa655dc41ca89f373257a7e50b14dc4c2bed99597c146d577f4333843855da27e395fc81aa90205795bd555b3451dc4b9536e234799185123c4792cfb1d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEYOiVEMMICJp0fwY3TFOIQWU1dTszUUSA\nv4JR/0AUdU669IqmVdxByonzcyV6flCxTcTCvtmVl8FG1Xf0MzhDhV2ifjlfyBqp\nAgV5W9VVs0UdxLlTbiNHmRhRI8R5LPsd\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 390,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020103020101",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "040a82d7df701a1f0c02a8265fc471d4851a3f08b5c82897766c18400a270c11d4fedd7b5b085e532674b395b3653f6385ae089577be259cdbe030a661868d7b3b5413218a48439a6753f92316dccf692f2520058048958a6ed4085583ce78f45f",
+        "wx" : "0a82d7df701a1f0c02a8265fc471d4851a3f08b5c82897766c18400a270c11d4fedd7b5b085e532674b395b3653f6385",
+        "wy" : "00ae089577be259cdbe030a661868d7b3b5413218a48439a6753f92316dccf692f2520058048958a6ed4085583ce78f45f"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200040a82d7df701a1f0c02a8265fc471d4851a3f08b5c82897766c18400a270c11d4fedd7b5b085e532674b395b3653f6385ae089577be259cdbe030a661868d7b3b5413218a48439a6753f92316dccf692f2520058048958a6ed4085583ce78f45f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAECoLX33AaHwwCqCZfxHHUhRo/CLXIKJd2\nbBhACicMEdT+3XtbCF5TJnSzlbNlP2OFrgiVd74lnNvgMKZhho17O1QTIYpIQ5pn\nU/kjFtzPaS8lIAWASJWKbtQIVYPOePRf\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 391,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020103020103",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "041301dee63fca91b6de8835480c3d86297b1e6a0a7339fc5011a50c33f350e9938743df496aeaa1e3170ba1e2f0c449187b6812948761816232e414e23b0f9904d171da5cc0492a341e2b4f9477da0a311cdac7c7d01037ed7dddb3376892fd44",
+        "wx" : "1301dee63fca91b6de8835480c3d86297b1e6a0a7339fc5011a50c33f350e9938743df496aeaa1e3170ba1e2f0c44918",
+        "wy" : "7b6812948761816232e414e23b0f9904d171da5cc0492a341e2b4f9477da0a311cdac7c7d01037ed7dddb3376892fd44"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200041301dee63fca91b6de8835480c3d86297b1e6a0a7339fc5011a50c33f350e9938743df496aeaa1e3170ba1e2f0c449187b6812948761816232e414e23b0f9904d171da5cc0492a341e2b4f9477da0a311cdac7c7d01037ed7dddb3376892fd44",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEEwHe5j/KkbbeiDVIDD2GKXseagpzOfxQ\nEaUMM/NQ6ZOHQ99Jauqh4xcLoeLwxEkYe2gSlIdhgWIy5BTiOw+ZBNFx2lzASSo0\nHitPlHfaCjEc2sfH0BA37X3dszdokv1E\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 392,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020103020104",
+          "result" : "valid"
         },
         {
-          "tcId" : 311,
+          "tcId" : 393,
           "comment" : "r is larger than n",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52975020103",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52976020104",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
-        "uncompressed" : "0405e67c44fc0cbc9a8eb343b4d6f596c7d00cac5da8594caf45b7209397496214c42d856a015ce589bc9ba865a4fab5ab88a01c7b5d09efaf878fcb9102fb3875a8381af234d1c593076e452225a56f51674f347126d3009b44dcbb003a64d95f",
-        "wx" : "5e67c44fc0cbc9a8eb343b4d6f596c7d00cac5da8594caf45b7209397496214c42d856a015ce589bc9ba865a4fab5ab",
-        "wy" : "088a01c7b5d09efaf878fcb9102fb3875a8381af234d1c593076e452225a56f51674f347126d3009b44dcbb003a64d95f"
+        "uncompressed" : "04cce27e78386d68492fc58dd5f191a690c2ebc0a452442fe0dd331f458f18c8fcd922e148f8f251bf1b85e149ccb3f19295395c884ff97f670631e84b7e0b0dab503ba9c7080eda0e1c66b04e160728067cfe88fbcbbb0f52cfb733cd951fcf26",
+        "wx" : "00cce27e78386d68492fc58dd5f191a690c2ebc0a452442fe0dd331f458f18c8fcd922e148f8f251bf1b85e149ccb3f192",
+        "wy" : "0095395c884ff97f670631e84b7e0b0dab503ba9c7080eda0e1c66b04e160728067cfe88fbcbbb0f52cfb733cd951fcf26"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000405e67c44fc0cbc9a8eb343b4d6f596c7d00cac5da8594caf45b7209397496214c42d856a015ce589bc9ba865a4fab5ab88a01c7b5d09efaf878fcb9102fb3875a8381af234d1c593076e452225a56f51674f347126d3009b44dcbb003a64d95f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEBeZ8RPwMvJqOs0O01vWWx9AMrF2oWUyv\nRbcgk5dJYhTELYVqAVzlibybqGWk+rWriKAce10J76+Hj8uRAvs4dag4GvI00cWT\nB25FIiWlb1FnTzRxJtMAm0TcuwA6ZNlf\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004cce27e78386d68492fc58dd5f191a690c2ebc0a452442fe0dd331f458f18c8fcd922e148f8f251bf1b85e149ccb3f19295395c884ff97f670631e84b7e0b0dab503ba9c7080eda0e1c66b04e160728067cfe88fbcbbb0f52cfb733cd951fcf26",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEzOJ+eDhtaEkvxY3V8ZGmkMLrwKRSRC/g\n3TMfRY8YyPzZIuFI+PJRvxuF4UnMs/GSlTlciE/5f2cGMehLfgsNq1A7qccIDtoO\nHGawThYHKAZ8/oj7y7sPUs+3M82VH88m\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 312,
+          "tcId" : 394,
           "comment" : "s is larger than n",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
-          "sig" : "3036020102023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accd7fffa",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3036020103023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accd7fffa",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "040bb03fce3c01ebcf0873abd134a8682f5fb8dbffa22da674047e5c3e71e43de582ed6abb908c2e4faa5d96186278b6c1ba3b22123e68ccc56f17dd79ff15565706f71a0b6123c77af3cd88f0af024cc5259781516edcaf5fe990646e7b66999d",
         "wx" : "0bb03fce3c01ebcf0873abd134a8682f5fb8dbffa22da674047e5c3e71e43de582ed6abb908c2e4faa5d96186278b6c1",
-        "wy" : "0ba3b22123e68ccc56f17dd79ff15565706f71a0b6123c77af3cd88f0af024cc5259781516edcaf5fe990646e7b66999d"
+        "wy" : "00ba3b22123e68ccc56f17dd79ff15565706f71a0b6123c77af3cd88f0af024cc5259781516edcaf5fe990646e7b66999d"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200040bb03fce3c01ebcf0873abd134a8682f5fb8dbffa22da674047e5c3e71e43de582ed6abb908c2e4faa5d96186278b6c1ba3b22123e68ccc56f17dd79ff15565706f71a0b6123c77af3cd88f0af024cc5259781516edcaf5fe990646e7b66999d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEC7A/zjwB688Ic6vRNKhoL1+42/+iLaZ0\nBH5cPnHkPeWC7Wq7kIwuT6pdlhhieLbBujsiEj5ozMVvF915/xVWVwb3GgthI8d6\n882I8K8CTMUll4FRbtyvX+mQZG57Zpmd\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200040bb03fce3c01ebcf0873abd134a8682f5fb8dbffa22da674047e5c3e71e43de582ed6abb908c2e4faa5d96186278b6c1ba3b22123e68ccc56f17dd79ff15565706f71a0b6123c77af3cd88f0af024cc5259781516edcaf5fe990646e7b66999d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEC7A/zjwB688Ic6vRNKhoL1+42/+iLaZ0\nBH5cPnHkPeWC7Wq7kIwuT6pdlhhieLbBujsiEj5ozMVvF915/xVWVwb3GgthI8d6\n882I8K8CTMUll4FRbtyvX+mQZG57Zpmd\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 313,
+          "tcId" : 395,
           "comment" : "small r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3036020201000230489122448912244891224489122448912244891224489122347ce79bc437f4d071aaa92c7d6c882ae8734dc18cb0d553",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0458f246090d5e49863bc0bf2d501ff72f551c5f1c5e679eb49064fd02e221a2707326ec2d140bcc817afaad5065761566497c823fd736882cbf78fb92b1a5589b67e8067497c710a4cbb39dee2c5431bc45cfb96c9f8454385c9f2b3ef2d3d31a",
         "wx" : "58f246090d5e49863bc0bf2d501ff72f551c5f1c5e679eb49064fd02e221a2707326ec2d140bcc817afaad5065761566",
         "wy" : "497c823fd736882cbf78fb92b1a5589b67e8067497c710a4cbb39dee2c5431bc45cfb96c9f8454385c9f2b3ef2d3d31a"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000458f246090d5e49863bc0bf2d501ff72f551c5f1c5e679eb49064fd02e221a2707326ec2d140bcc817afaad5065761566497c823fd736882cbf78fb92b1a5589b67e8067497c710a4cbb39dee2c5431bc45cfb96c9f8454385c9f2b3ef2d3d31a",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEWPJGCQ1eSYY7wL8tUB/3L1UcXxxeZ560\nkGT9AuIhonBzJuwtFAvMgXr6rVBldhVmSXyCP9c2iCy/ePuSsaVYm2foBnSXxxCk\ny7Od7ixUMbxFz7lsn4RUOFyfKz7y09Ma\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000458f246090d5e49863bc0bf2d501ff72f551c5f1c5e679eb49064fd02e221a2707326ec2d140bcc817afaad5065761566497c823fd736882cbf78fb92b1a5589b67e8067497c710a4cbb39dee2c5431bc45cfb96c9f8454385c9f2b3ef2d3d31a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEWPJGCQ1eSYY7wL8tUB/3L1UcXxxeZ560\nkGT9AuIhonBzJuwtFAvMgXr6rVBldhVmSXyCP9c2iCy/ePuSsaVYm2foBnSXxxCk\ny7Od7ixUMbxFz7lsn4RUOFyfKz7y09Ma\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 314,
+          "tcId" : 396,
           "comment" : "smallish r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "303c02072d9b4d347952cd023100ce751512561b6f57c75342848a3ff98ccf9c3f0219b6b68d00449e6c971a85d2e2ce73554b59219d54d2083b46327351",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04fc6984dd6830d1485fb2581a45a791d8dca2c727c73d3d44c89f0082c1868af5ca74b4ca4ae22802640a9ebfe8c7ae12998d63a5b5ad1b72b899f0b132e4952aaa19d41fdeea48b1ed6b8358dd1db207fd66e01453ad40f67b836adc802d5fe8",
-        "wx" : "0fc6984dd6830d1485fb2581a45a791d8dca2c727c73d3d44c89f0082c1868af5ca74b4ca4ae22802640a9ebfe8c7ae12",
-        "wy" : "0998d63a5b5ad1b72b899f0b132e4952aaa19d41fdeea48b1ed6b8358dd1db207fd66e01453ad40f67b836adc802d5fe8"
+        "wx" : "00fc6984dd6830d1485fb2581a45a791d8dca2c727c73d3d44c89f0082c1868af5ca74b4ca4ae22802640a9ebfe8c7ae12",
+        "wy" : "00998d63a5b5ad1b72b899f0b132e4952aaa19d41fdeea48b1ed6b8358dd1db207fd66e01453ad40f67b836adc802d5fe8"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004fc6984dd6830d1485fb2581a45a791d8dca2c727c73d3d44c89f0082c1868af5ca74b4ca4ae22802640a9ebfe8c7ae12998d63a5b5ad1b72b899f0b132e4952aaa19d41fdeea48b1ed6b8358dd1db207fd66e01453ad40f67b836adc802d5fe8",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE/GmE3Wgw0UhfslgaRaeR2NyixyfHPT1E\nyJ8AgsGGivXKdLTKSuIoAmQKnr/ox64SmY1jpbWtG3K4mfCxMuSVKqoZ1B/e6kix\n7WuDWN0dsgf9ZuAUU61A9nuDatyALV/o\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004fc6984dd6830d1485fb2581a45a791d8dca2c727c73d3d44c89f0082c1868af5ca74b4ca4ae22802640a9ebfe8c7ae12998d63a5b5ad1b72b899f0b132e4952aaa19d41fdeea48b1ed6b8358dd1db207fd66e01453ad40f67b836adc802d5fe8",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE/GmE3Wgw0UhfslgaRaeR2NyixyfHPT1E\nyJ8AgsGGivXKdLTKSuIoAmQKnr/ox64SmY1jpbWtG3K4mfCxMuSVKqoZ1B/e6kix\n7WuDWN0dsgf9ZuAUU61A9nuDatyALV/o\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 315,
+          "tcId" : 397,
           "comment" : "100-bit r and small s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3041020d1033e67e37b32b445580bf4efb02302ad52ad52ad52ad52ad52ad52ad52ad52ad52ad52ad52ad5215c51b320e460542f9cc38968ccdf4263684004eb79a452",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "041b8def5922303d647e8eb07e3bad92f924b79b769eef168e7541de1f4e0d28ae9733eb98cf8a1fb6dd52ca02c8c75b51c7aa4bf679d49d8114122074da8f6044a427371796a5654a6106162d5f686abb73ebd896ab08c7062687f12171fbe4a3",
         "wx" : "1b8def5922303d647e8eb07e3bad92f924b79b769eef168e7541de1f4e0d28ae9733eb98cf8a1fb6dd52ca02c8c75b51",
-        "wy" : "0c7aa4bf679d49d8114122074da8f6044a427371796a5654a6106162d5f686abb73ebd896ab08c7062687f12171fbe4a3"
+        "wy" : "00c7aa4bf679d49d8114122074da8f6044a427371796a5654a6106162d5f686abb73ebd896ab08c7062687f12171fbe4a3"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200041b8def5922303d647e8eb07e3bad92f924b79b769eef168e7541de1f4e0d28ae9733eb98cf8a1fb6dd52ca02c8c75b51c7aa4bf679d49d8114122074da8f6044a427371796a5654a6106162d5f686abb73ebd896ab08c7062687f12171fbe4a3",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEG43vWSIwPWR+jrB+O62S+SS3m3ae7xaO\ndUHeH04NKK6XM+uYz4oftt1SygLIx1tRx6pL9nnUnYEUEiB02o9gRKQnNxeWpWVK\nYQYWLV9oartz69iWqwjHBiaH8SFx++Sj\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200041b8def5922303d647e8eb07e3bad92f924b79b769eef168e7541de1f4e0d28ae9733eb98cf8a1fb6dd52ca02c8c75b51c7aa4bf679d49d8114122074da8f6044a427371796a5654a6106162d5f686abb73ebd896ab08c7062687f12171fbe4a3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEG43vWSIwPWR+jrB+O62S+SS3m3ae7xaO\ndUHeH04NKK6XM+uYz4oftt1SygLIx1tRx6pL9nnUnYEUEiB02o9gRKQnNxeWpWVK\nYQYWLV9oartz69iWqwjHBiaH8SFx++Sj\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 316,
+          "tcId" : 398,
           "comment" : "small r and 100 bit s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "303602020100023077a172dfe37a2c53f0b92ab60f0a8f085f49dbfd930719d6f9e587ea68ae57cb49cd35a88cf8c6acec02f057a3807a5b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "041734a039a88a16c2ff4aa97d2399121f56f52ef01ed5e50887f736f65b6e51d6e8786abb4e063da5d1ba812dff998403ccd698e6c296d5cd69178f8a82481a865da331627f1c4b324fbc02b36e8b5ed58a31f728e904d203a388755302195765",
         "wx" : "1734a039a88a16c2ff4aa97d2399121f56f52ef01ed5e50887f736f65b6e51d6e8786abb4e063da5d1ba812dff998403",
-        "wy" : "0ccd698e6c296d5cd69178f8a82481a865da331627f1c4b324fbc02b36e8b5ed58a31f728e904d203a388755302195765"
+        "wy" : "00ccd698e6c296d5cd69178f8a82481a865da331627f1c4b324fbc02b36e8b5ed58a31f728e904d203a388755302195765"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200041734a039a88a16c2ff4aa97d2399121f56f52ef01ed5e50887f736f65b6e51d6e8786abb4e063da5d1ba812dff998403ccd698e6c296d5cd69178f8a82481a865da331627f1c4b324fbc02b36e8b5ed58a31f728e904d203a388755302195765",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEFzSgOaiKFsL/Sql9I5kSH1b1LvAe1eUI\nh/c29ltuUdboeGq7TgY9pdG6gS3/mYQDzNaY5sKW1c1pF4+Kgkgahl2jMWJ/HEsy\nT7wCs26LXtWKMfco6QTSA6OIdVMCGVdl\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200041734a039a88a16c2ff4aa97d2399121f56f52ef01ed5e50887f736f65b6e51d6e8786abb4e063da5d1ba812dff998403ccd698e6c296d5cd69178f8a82481a865da331627f1c4b324fbc02b36e8b5ed58a31f728e904d203a388755302195765",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEFzSgOaiKFsL/Sql9I5kSH1b1LvAe1eUI\nh/c29ltuUdboeGq7TgY9pdG6gS3/mYQDzNaY5sKW1c1pF4+Kgkgahl2jMWJ/HEsy\nT7wCs26LXtWKMfco6QTSA6OIdVMCGVdl\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 317,
+          "tcId" : 399,
           "comment" : "100-bit r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3041020d062522bbd3ecbe7c39e93e7c24023077a172dfe37a2c53f0b92ab60f0a8f085f49dbfd930719d6f9e587ea68ae57cb49cd35a88cf8c6acec02f057a3807a5b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0452ca47dda99172cb8321495acf988548295988ec973c1b4ea9462c53e5768a704a936410ee847b5dbf1e9d0c131da6c787a47027e6655792eb002d4228ee72f7c814c9a0cecbff267948f81c9903ac10eb35f6cb86369224ed609811cdf390f4",
         "wx" : "52ca47dda99172cb8321495acf988548295988ec973c1b4ea9462c53e5768a704a936410ee847b5dbf1e9d0c131da6c7",
-        "wy" : "087a47027e6655792eb002d4228ee72f7c814c9a0cecbff267948f81c9903ac10eb35f6cb86369224ed609811cdf390f4"
+        "wy" : "0087a47027e6655792eb002d4228ee72f7c814c9a0cecbff267948f81c9903ac10eb35f6cb86369224ed609811cdf390f4"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000452ca47dda99172cb8321495acf988548295988ec973c1b4ea9462c53e5768a704a936410ee847b5dbf1e9d0c131da6c787a47027e6655792eb002d4228ee72f7c814c9a0cecbff267948f81c9903ac10eb35f6cb86369224ed609811cdf390f4",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEUspH3amRcsuDIUlaz5iFSClZiOyXPBtO\nqUYsU+V2inBKk2QQ7oR7Xb8enQwTHabHh6RwJ+ZlV5LrAC1CKO5y98gUyaDOy/8m\neUj4HJkDrBDrNfbLhjaSJO1gmBHN85D0\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000452ca47dda99172cb8321495acf988548295988ec973c1b4ea9462c53e5768a704a936410ee847b5dbf1e9d0c131da6c787a47027e6655792eb002d4228ee72f7c814c9a0cecbff267948f81c9903ac10eb35f6cb86369224ed609811cdf390f4",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEUspH3amRcsuDIUlaz5iFSClZiOyXPBtO\nqUYsU+V2inBKk2QQ7oR7Xb8enQwTHabHh6RwJ+ZlV5LrAC1CKO5y98gUyaDOy/8m\neUj4HJkDrBDrNfbLhjaSJO1gmBHN85D0\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 318,
+          "tcId" : 400,
           "comment" : "r and s^-1 are close to n",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc528f3023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
+        "uncompressed" : "0491aa326dabe04a6ad266de30873518f978f634c740705152539787b5b42dd9683c4185ace936684683b4c136b5f2ff20cacda42b735cbee78e7b6a43f50b851b85e998c365909f763d3e64210eded159ebf21818dec0e207b877b99ff595beaf",
+        "wx" : "0091aa326dabe04a6ad266de30873518f978f634c740705152539787b5b42dd9683c4185ace936684683b4c136b5f2ff20",
+        "wy" : "00cacda42b735cbee78e7b6a43f50b851b85e998c365909f763d3e64210eded159ebf21818dec0e207b877b99ff595beaf"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000491aa326dabe04a6ad266de30873518f978f634c740705152539787b5b42dd9683c4185ace936684683b4c136b5f2ff20cacda42b735cbee78e7b6a43f50b851b85e998c365909f763d3e64210eded159ebf21818dec0e207b877b99ff595beaf",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEkaoybavgSmrSZt4whzUY+Xj2NMdAcFFS\nU5eHtbQt2Wg8QYWs6TZoRoO0wTa18v8gys2kK3NcvueOe2pD9QuFG4XpmMNlkJ92\nPT5kIQ7e0Vnr8hgY3sDiB7h3uZ/1lb6v\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 401,
+          "comment" : "r and s are 64-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30160209009c44febf31c3594d020900839ed28247c2b06b",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04b1f52ae15400a0e0a4b39aae9a11e675cfc918d0c672189a86f68c0f306b115b6b470b931d19b2bbfcddada74f30a72c43cdc9522c0f73082251b4293982bc3e90960384f957f594d0ebe6eefe72af1ce7387f46ca5824ba0515559c05444f59",
+        "wx" : "00b1f52ae15400a0e0a4b39aae9a11e675cfc918d0c672189a86f68c0f306b115b6b470b931d19b2bbfcddada74f30a72c",
+        "wy" : "43cdc9522c0f73082251b4293982bc3e90960384f957f594d0ebe6eefe72af1ce7387f46ca5824ba0515559c05444f59"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004b1f52ae15400a0e0a4b39aae9a11e675cfc918d0c672189a86f68c0f306b115b6b470b931d19b2bbfcddada74f30a72c43cdc9522c0f73082251b4293982bc3e90960384f957f594d0ebe6eefe72af1ce7387f46ca5824ba0515559c05444f59",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEsfUq4VQAoOCks5qumhHmdc/JGNDGchia\nhvaMDzBrEVtrRwuTHRmyu/zdradPMKcsQ83JUiwPcwgiUbQpOYK8PpCWA4T5V/WU\n0Ovm7v5yrxznOH9GylgkugUVVZwFRE9Z\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 402,
+          "comment" : "r and s are 100-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "301e020d09df8b682430beef6f5fd7c7d0020d0fd0a62e13778f4222a0d61c8a",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "044314072bfccfe420f64cf79393bf38c773c4390f7df826c6a59043b3e0d55e8e69d37678c72a5e68a114e04ae5a2de765a4b87638874c3b3ff687ba7fcd08238d46385e2aa6d65e2e53a6d5e205fcfd9b744f4087c6292b665dcb691ca5e86d4",
+        "wx" : "4314072bfccfe420f64cf79393bf38c773c4390f7df826c6a59043b3e0d55e8e69d37678c72a5e68a114e04ae5a2de76",
+        "wy" : "5a4b87638874c3b3ff687ba7fcd08238d46385e2aa6d65e2e53a6d5e205fcfd9b744f4087c6292b665dcb691ca5e86d4"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200044314072bfccfe420f64cf79393bf38c773c4390f7df826c6a59043b3e0d55e8e69d37678c72a5e68a114e04ae5a2de765a4b87638874c3b3ff687ba7fcd08238d46385e2aa6d65e2e53a6d5e205fcfd9b744f4087c6292b665dcb691ca5e86d4",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEQxQHK/zP5CD2TPeTk784x3PEOQ99+CbG\npZBDs+DVXo5p03Z4xypeaKEU4Erlot52WkuHY4h0w7P/aHun/NCCONRjheKqbWXi\n5TptXiBfz9m3RPQIfGKStmXctpHKXobU\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 403,
+          "comment" : "r and s are 128-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260211008a598e563a89f526c32ebec8de26367a02110084f633e2042630e99dd0f1e16f7a04bf",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04eb99d6bf52d08c1118ce27b0e4c09ce0d6893d5a9da2757b7f03057fcc17bd8afb4c48a60e757ff61d5e54e31d6536a9059ec79354b3949d53461e6adf7671ddf20402e1c9337464775ee56d507832728124c514e1dca506fe5fa72f7e1778ff",
+        "wx" : "00eb99d6bf52d08c1118ce27b0e4c09ce0d6893d5a9da2757b7f03057fcc17bd8afb4c48a60e757ff61d5e54e31d6536a9",
+        "wy" : "059ec79354b3949d53461e6adf7671ddf20402e1c9337464775ee56d507832728124c514e1dca506fe5fa72f7e1778ff"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004eb99d6bf52d08c1118ce27b0e4c09ce0d6893d5a9da2757b7f03057fcc17bd8afb4c48a60e757ff61d5e54e31d6536a9059ec79354b3949d53461e6adf7671ddf20402e1c9337464775ee56d507832728124c514e1dca506fe5fa72f7e1778ff",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE65nWv1LQjBEYziew5MCc4NaJPVqdonV7\nfwMFf8wXvYr7TEimDnV/9h1eVOMdZTapBZ7Hk1SzlJ1TRh5q33Zx3fIEAuHJM3Rk\nd17lbVB4MnKBJMUU4dylBv5fpy9+F3j/\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 404,
+          "comment" : "r and s are 160-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302e021500aa6eeb5823f7fa31b466bb473797f0d0314c0be0021500e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
         "uncompressed" : "04bd3d91f003e18adbea73079d4eba23b91fc17fcec14c9eb15a193fbc9ca39c8c747cd7a2c9623e05dd587ccbb8ab4c443adb0a0706aa5ea7a68042082fccefc979612a7a1a3d694b00793b03f89bff866a8b97c8e77990c29360ce795036c764",
-        "wx" : "0bd3d91f003e18adbea73079d4eba23b91fc17fcec14c9eb15a193fbc9ca39c8c747cd7a2c9623e05dd587ccbb8ab4c44",
+        "wx" : "00bd3d91f003e18adbea73079d4eba23b91fc17fcec14c9eb15a193fbc9ca39c8c747cd7a2c9623e05dd587ccbb8ab4c44",
         "wy" : "3adb0a0706aa5ea7a68042082fccefc979612a7a1a3d694b00793b03f89bff866a8b97c8e77990c29360ce795036c764"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004bd3d91f003e18adbea73079d4eba23b91fc17fcec14c9eb15a193fbc9ca39c8c747cd7a2c9623e05dd587ccbb8ab4c443adb0a0706aa5ea7a68042082fccefc979612a7a1a3d694b00793b03f89bff866a8b97c8e77990c29360ce795036c764",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvT2R8APhitvqcwedTrojuR/Bf87BTJ6x\nWhk/vJyjnIx0fNeiyWI+Bd1YfMu4q0xEOtsKBwaqXqemgEIIL8zvyXlhKnoaPWlL\nAHk7A/ib/4Zqi5fI53mQwpNgznlQNsdk\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004bd3d91f003e18adbea73079d4eba23b91fc17fcec14c9eb15a193fbc9ca39c8c747cd7a2c9623e05dd587ccbb8ab4c443adb0a0706aa5ea7a68042082fccefc979612a7a1a3d694b00793b03f89bff866a8b97c8e77990c29360ce795036c764",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvT2R8APhitvqcwedTrojuR/Bf87BTJ6x\nWhk/vJyjnIx0fNeiyWI+Bd1YfMu4q0xEOtsKBwaqXqemgEIIL8zvyXlhKnoaPWlL\nAHk7A/ib/4Zqi5fI53mQwpNgznlQNsdk\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 319,
+          "tcId" : 405,
           "comment" : "s == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3035023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326020101",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 320,
+          "tcId" : 406,
           "comment" : "s == 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3035023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326020100",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
-        "uncompressed" : "04f896353cc3a8afdd543ec3aef062ca97bc32ed1724ea38b940b8c0ea0e23b34187afbe70daf8dbaa5b511557e5d2bddac4bd265da67ceeafca636f6f4c0472f22a9d02e2289184f73bbb700ae8fc921eff4920f290bfcb49fbb232cc13a21028",
-        "wx" : "0f896353cc3a8afdd543ec3aef062ca97bc32ed1724ea38b940b8c0ea0e23b34187afbe70daf8dbaa5b511557e5d2bdda",
-        "wy" : "0c4bd265da67ceeafca636f6f4c0472f22a9d02e2289184f73bbb700ae8fc921eff4920f290bfcb49fbb232cc13a21028"
+        "uncompressed" : "045abbf618a084f67138c418a896d61af3af1826040835b73e7619846b495eba6f7eeaa2e9cc61c85f6100fedc25c16743b065a427bc503139529e4faa63dda553aed2696fd02c2b6ceb2d941d2c4363cf9ac7a6759d50e8b9d07fe286f17cef5c",
+        "wx" : "5abbf618a084f67138c418a896d61af3af1826040835b73e7619846b495eba6f7eeaa2e9cc61c85f6100fedc25c16743",
+        "wy" : "00b065a427bc503139529e4faa63dda553aed2696fd02c2b6ceb2d941d2c4363cf9ac7a6759d50e8b9d07fe286f17cef5c"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004f896353cc3a8afdd543ec3aef062ca97bc32ed1724ea38b940b8c0ea0e23b34187afbe70daf8dbaa5b511557e5d2bddac4bd265da67ceeafca636f6f4c0472f22a9d02e2289184f73bbb700ae8fc921eff4920f290bfcb49fbb232cc13a21028",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+JY1PMOor91UPsOu8GLKl7wy7Rck6ji5\nQLjA6g4js0GHr75w2vjbqltRFVfl0r3axL0mXaZ87q/KY29vTARy8iqdAuIokYT3\nO7twCuj8kh7/SSDykL/LSfuyMswTohAo\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200045abbf618a084f67138c418a896d61af3af1826040835b73e7619846b495eba6f7eeaa2e9cc61c85f6100fedc25c16743b065a427bc503139529e4faa63dda553aed2696fd02c2b6ceb2d941d2c4363cf9ac7a6759d50e8b9d07fe286f17cef5c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEWrv2GKCE9nE4xBioltYa868YJgQINbc+\ndhmEa0leum9+6qLpzGHIX2EA/twlwWdDsGWkJ7xQMTlSnk+qY92lU67SaW/QLCts\n6y2UHSxDY8+ax6Z1nVDoudB/4obxfO9c\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 321,
+          "tcId" : 407,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec63260230427f8227a67d9422557647d27945a90ae1d2ec2931f90113cd5b407099e3d8f5a889d62069e64c0e1c4efe29690b0992",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "043942027bc7f33c10b159293f2abd0af935642a546ea20de9d85c36a0f4ed40cfada782a297bb2046d633fa53e26adc5230656a4f1804feca511d41372483af36387f658c44fdc5e7f02487ab70e1bf9d185918d7820fee0ea57a4fe006abbe70",
+        "wx" : "3942027bc7f33c10b159293f2abd0af935642a546ea20de9d85c36a0f4ed40cfada782a297bb2046d633fa53e26adc52",
+        "wy" : "30656a4f1804feca511d41372483af36387f658c44fdc5e7f02487ab70e1bf9d185918d7820fee0ea57a4fe006abbe70"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200043942027bc7f33c10b159293f2abd0af935642a546ea20de9d85c36a0f4ed40cfada782a297bb2046d633fa53e26adc5230656a4f1804feca511d41372483af36387f658c44fdc5e7f02487ab70e1bf9d185918d7820fee0ea57a4fe006abbe70",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOUICe8fzPBCxWSk/Kr0K+TVkKlRuog3p\n2Fw2oPTtQM+tp4Kil7sgRtYz+lPiatxSMGVqTxgE/spRHUE3JIOvNjh/ZYxE/cXn\n8CSHq3Dhv50YWRjXgg/uDqV6T+AGq75w\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 408,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec63260230369cf68bb2919c11d0f82315e1ee68a7ee8c17858bd334bf84536b2b74756a77e4eee10ecc5a6416a8263b5429afcba4",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04d5db4d230cadf5bc6350f74d0bc5015b14d377934c879f74caf483dac49ef9fcf7a6676aaac5b405896d5be6ae0653e5e3509606e26f71415a7f8ce37698e1c82286cdcdf3a7def73c347e32b45b32b6deeb34c4038373a30a7f8275f6daf541",
+        "wx" : "00d5db4d230cadf5bc6350f74d0bc5015b14d377934c879f74caf483dac49ef9fcf7a6676aaac5b405896d5be6ae0653e5",
+        "wy" : "00e3509606e26f71415a7f8ce37698e1c82286cdcdf3a7def73c347e32b45b32b6deeb34c4038373a30a7f8275f6daf541"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004d5db4d230cadf5bc6350f74d0bc5015b14d377934c879f74caf483dac49ef9fcf7a6676aaac5b405896d5be6ae0653e5e3509606e26f71415a7f8ce37698e1c82286cdcdf3a7def73c347e32b45b32b6deeb34c4038373a30a7f8275f6daf541",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE1dtNIwyt9bxjUPdNC8UBWxTTd5NMh590\nyvSD2sSe+fz3pmdqqsW0BYltW+auBlPl41CWBuJvcUFaf4zjdpjhyCKGzc3zp973\nPDR+MrRbMrbe6zTEA4Nzowp/gnX22vVB\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 409,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec632602302111832a45fc5967f7bf78ccdfe98d4e707484aad43f67cf5ac8aa2afbde0d1d8b7fe5cfc5012feb033dffdec623dfbf",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04629e253d5ef8c23319bbe9a56af387d92f867ef9f81c6d9f0ee7f5ac28412b0227eac75d982814e8e24d82b8308cc9c14ef3b9286c9882d7e853f7032f01dbe88206a7f92ec7c776cdfd2117ccb2ad2165fb8650de299107037edb69109001db",
+        "wx" : "629e253d5ef8c23319bbe9a56af387d92f867ef9f81c6d9f0ee7f5ac28412b0227eac75d982814e8e24d82b8308cc9c1",
+        "wy" : "4ef3b9286c9882d7e853f7032f01dbe88206a7f92ec7c776cdfd2117ccb2ad2165fb8650de299107037edb69109001db"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004629e253d5ef8c23319bbe9a56af387d92f867ef9f81c6d9f0ee7f5ac28412b0227eac75d982814e8e24d82b8308cc9c14ef3b9286c9882d7e853f7032f01dbe88206a7f92ec7c776cdfd2117ccb2ad2165fb8650de299107037edb69109001db",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEYp4lPV74wjMZu+mlavOH2S+Gfvn4HG2f\nDuf1rChBKwIn6sddmCgU6OJNgrgwjMnBTvO5KGyYgtfoU/cDLwHb6IIGp/kux8d2\nzf0hF8yyrSFl+4ZQ3imRBwN+22kQkAHb\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 410,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023020cd002ab7dca06b798fecef3f06a222c2d2a65e9ec92f74659a8d82fe7d75e9af739f0b532e17d6c5f622c4b591442b",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "043eb89e36a222831fba4be0b7ca40b7df6e4d795f921089b48989af0add1fa6c6e846946c25e4d195f9ac5dbb34147e412b3081be4324036a3bc79e9b6cd78d0d48500f0fce1e5a0fa31d833f86d1afe2f7adfeb5cb9662c74763c85f0f9d339a",
+        "wx" : "3eb89e36a222831fba4be0b7ca40b7df6e4d795f921089b48989af0add1fa6c6e846946c25e4d195f9ac5dbb34147e41",
+        "wy" : "2b3081be4324036a3bc79e9b6cd78d0d48500f0fce1e5a0fa31d833f86d1afe2f7adfeb5cb9662c74763c85f0f9d339a"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200043eb89e36a222831fba4be0b7ca40b7df6e4d795f921089b48989af0add1fa6c6e846946c25e4d195f9ac5dbb34147e412b3081be4324036a3bc79e9b6cd78d0d48500f0fce1e5a0fa31d833f86d1afe2f7adfeb5cb9662c74763c85f0f9d339a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEPrieNqIigx+6S+C3ykC3325NeV+SEIm0\niYmvCt0fpsboRpRsJeTRlfmsXbs0FH5BKzCBvkMkA2o7x56bbNeNDUhQDw/OHloP\nox2DP4bRr+L3rf61y5Zix0djyF8PnTOa\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 411,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec632602303276fe55314e426a8ed83c4c38dc27c8fe8cbba0b39bad7cfc35e963adf10ab37251ea6829b8d255a77dd0b655cf9ff8",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "0466d0d1cec3fe7f8a46e766d1f7f44b2436f48164e12139313887c5992cfe5944059ba97eb10df411182f4242cb0d0bd4a3e39ee77a4c472aeb3f110b088b5eb92b7d2885bce326eb8f002e2ce3c858910717841499eeb7f739441ba0ffb3c02f",
+        "wx" : "66d0d1cec3fe7f8a46e766d1f7f44b2436f48164e12139313887c5992cfe5944059ba97eb10df411182f4242cb0d0bd4",
+        "wy" : "00a3e39ee77a4c472aeb3f110b088b5eb92b7d2885bce326eb8f002e2ce3c858910717841499eeb7f739441ba0ffb3c02f"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000466d0d1cec3fe7f8a46e766d1f7f44b2436f48164e12139313887c5992cfe5944059ba97eb10df411182f4242cb0d0bd4a3e39ee77a4c472aeb3f110b088b5eb92b7d2885bce326eb8f002e2ce3c858910717841499eeb7f739441ba0ffb3c02f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEZtDRzsP+f4pG52bR9/RLJDb0gWThITkx\nOIfFmSz+WUQFm6l+sQ30ERgvQkLLDQvUo+Oe53pMRyrrPxELCIteuSt9KIW84ybr\njwAuLOPIWJEHF4QUme639zlEG6D/s8Av\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 412,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec632602301a80b4a3d6c88775821e26784463080eb7de510762ab0d98223e532364c7089b07af73746ae4cf076c5277dcc80cf8c2",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "045ea90d3b95fe4c25b3623cba85867df605039be9c78b0489dcafb2c613ce6887c53fccc95fd342156466d0f8c05ba628c81f3c6e5b5a400feffb76814c47f2ae486ac575359ee6dbea6e3a0fbad3747558934a5a1079883d02aa06bb071001b9",
+        "wx" : "5ea90d3b95fe4c25b3623cba85867df605039be9c78b0489dcafb2c613ce6887c53fccc95fd342156466d0f8c05ba628",
+        "wy" : "00c81f3c6e5b5a400feffb76814c47f2ae486ac575359ee6dbea6e3a0fbad3747558934a5a1079883d02aa06bb071001b9"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200045ea90d3b95fe4c25b3623cba85867df605039be9c78b0489dcafb2c613ce6887c53fccc95fd342156466d0f8c05ba628c81f3c6e5b5a400feffb76814c47f2ae486ac575359ee6dbea6e3a0fbad3747558934a5a1079883d02aa06bb071001b9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEXqkNO5X+TCWzYjy6hYZ99gUDm+nHiwSJ\n3K+yxhPOaIfFP8zJX9NCFWRm0PjAW6YoyB88bltaQA/v+3aBTEfyrkhqxXU1nubb\n6m46D7rTdHVYk0paEHmIPQKqBrsHEAG5\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 413,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023074e780e38b3a7cd6cfe17d5c9ac615895bd97dd4076b5f8218ae758b83d195fba64eb9aead39a790ca0f8b8387376265",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04c8793c0b7d239c26195cbea62a97b350d74e64609e3946eca0061b19fe480332be3ba3e4b62de5c5032d7437015adf15af8878a280a6469441d0ab04d0d331ffbc1389b9bf81991660b7b8c2ee20b2a0ed31b94742b5a7413fbb758be5927f7e",
+        "wx" : "00c8793c0b7d239c26195cbea62a97b350d74e64609e3946eca0061b19fe480332be3ba3e4b62de5c5032d7437015adf15",
+        "wy" : "00af8878a280a6469441d0ab04d0d331ffbc1389b9bf81991660b7b8c2ee20b2a0ed31b94742b5a7413fbb758be5927f7e"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004c8793c0b7d239c26195cbea62a97b350d74e64609e3946eca0061b19fe480332be3ba3e4b62de5c5032d7437015adf15af8878a280a6469441d0ab04d0d331ffbc1389b9bf81991660b7b8c2ee20b2a0ed31b94742b5a7413fbb758be5927f7e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEyHk8C30jnCYZXL6mKpezUNdOZGCeOUbs\noAYbGf5IAzK+O6Pkti3lxQMtdDcBWt8Vr4h4ooCmRpRB0KsE0NMx/7wTibm/gZkW\nYLe4wu4gsqDtMblHQrWnQT+7dYvlkn9+\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 414,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec632602306ee5f8daae12c862e1f7f8b59294ac90448c4461e29b36ed623a719dd69bb17b3a4b7c29b9eb5c39ca6168bf6b597c6a",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "0457d1385205e0cb872d619c2aec0b3442cf449959d33c1c4e76b55f9378e914fb07c4f26929832c3862de9be4b3d5fe18f10779e7e09e2f0ea1ca2df8f801167bf384f061a2c272720e0a6f4b313341f29da004e91b83a738b14e7c3b3235a549",
+        "wx" : "57d1385205e0cb872d619c2aec0b3442cf449959d33c1c4e76b55f9378e914fb07c4f26929832c3862de9be4b3d5fe18",
+        "wy" : "00f10779e7e09e2f0ea1ca2df8f801167bf384f061a2c272720e0a6f4b313341f29da004e91b83a738b14e7c3b3235a549"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000457d1385205e0cb872d619c2aec0b3442cf449959d33c1c4e76b55f9378e914fb07c4f26929832c3862de9be4b3d5fe18f10779e7e09e2f0ea1ca2df8f801167bf384f061a2c272720e0a6f4b313341f29da004e91b83a738b14e7c3b3235a549",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEV9E4UgXgy4ctYZwq7As0Qs9EmVnTPBxO\ndrVfk3jpFPsHxPJpKYMsOGLem+Sz1f4Y8Qd55+CeLw6hyi34+AEWe/OE8GGiwnJy\nDgpvSzEzQfKdoATpG4OnOLFOfDsyNaVJ\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 415,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec632602305426ca20a25b0cfb1ef230c62f91e98005f346e229233f1803e8944bf421fef150a4a109e48cefaa4ea23eea627fca41",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04a982d9378c598e40330f1f1254494315e65a50754c701c46fbd2253b50673c6a794b72743e412aa92201df95e81af63cd05e4c775885dfa050743dbf3b5d020be409bababce230b80d7aea32f38973a0b659aba3808fe7f9d2ae67ef9639d971",
+        "wx" : "00a982d9378c598e40330f1f1254494315e65a50754c701c46fbd2253b50673c6a794b72743e412aa92201df95e81af63c",
+        "wy" : "00d05e4c775885dfa050743dbf3b5d020be409bababce230b80d7aea32f38973a0b659aba3808fe7f9d2ae67ef9639d971"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004a982d9378c598e40330f1f1254494315e65a50754c701c46fbd2253b50673c6a794b72743e412aa92201df95e81af63cd05e4c775885dfa050743dbf3b5d020be409bababce230b80d7aea32f38973a0b659aba3808fe7f9d2ae67ef9639d971",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqYLZN4xZjkAzDx8SVElDFeZaUHVMcBxG\n+9IlO1BnPGp5S3J0PkEqqSIB35XoGvY80F5Md1iF36BQdD2/O10CC+QJurq84jC4\nDXrqMvOJc6C2WaujgI/n+dKuZ++WOdlx\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 416,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023039fd1a0ae3964735554c61daf085c66bcc2e9e5350131086023aa99549fc5f9057c848e75a1b8e58069fe0b9b23fa3c9",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04daf193bd2f16d613aff2254bdc2dcd1eeb036d6506a50e07a26f83d3830629fad4433d3232628f5f24ede60bb6eb3e1ee299714cc03e73b5e1a7fa0e1adfb2709a55883d9e97036007b31b7661f6fef6a1dbe418b633a5f3639f7d529da97285",
+        "wx" : "00daf193bd2f16d613aff2254bdc2dcd1eeb036d6506a50e07a26f83d3830629fad4433d3232628f5f24ede60bb6eb3e1e",
+        "wy" : "00e299714cc03e73b5e1a7fa0e1adfb2709a55883d9e97036007b31b7661f6fef6a1dbe418b633a5f3639f7d529da97285"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004daf193bd2f16d613aff2254bdc2dcd1eeb036d6506a50e07a26f83d3830629fad4433d3232628f5f24ede60bb6eb3e1ee299714cc03e73b5e1a7fa0e1adfb2709a55883d9e97036007b31b7661f6fef6a1dbe418b633a5f3639f7d529da97285",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE2vGTvS8W1hOv8iVL3C3NHusDbWUGpQ4H\nom+D04MGKfrUQz0yMmKPXyTt5gu26z4e4plxTMA+c7Xhp/oOGt+ycJpViD2elwNg\nB7MbdmH2/vah2+QYtjOl82OffVKdqXKF\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 417,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec63260230707a37cfb7367c2e551ea1f0caeac6c0fdd2b562e1bd8f1c7c51a5dd78f21da8cb179bd832cac3d3aee21fda54729e66",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "0409d4064490c7736106946b7fc6d88957c69d6f2f62e4388262603a43c129ceabe8d601ab2a700394b3b950840364bb6c7907bc45387fa1200b7cfae3171488d104738c60d22cacb71ed34a72bf1d315f7370aa181b265810c083996fe3a6b0fc",
+        "wx" : "09d4064490c7736106946b7fc6d88957c69d6f2f62e4388262603a43c129ceabe8d601ab2a700394b3b950840364bb6c",
+        "wy" : "7907bc45387fa1200b7cfae3171488d104738c60d22cacb71ed34a72bf1d315f7370aa181b265810c083996fe3a6b0fc"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000409d4064490c7736106946b7fc6d88957c69d6f2f62e4388262603a43c129ceabe8d601ab2a700394b3b950840364bb6c7907bc45387fa1200b7cfae3171488d104738c60d22cacb71ed34a72bf1d315f7370aa181b265810c083996fe3a6b0fc",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAECdQGRJDHc2EGlGt/xtiJV8adby9i5DiC\nYmA6Q8Epzqvo1gGrKnADlLO5UIQDZLtseQe8RTh/oSALfPrjFxSI0QRzjGDSLKy3\nHtNKcr8dMV9zcKoYGyZYEMCDmW/jprD8\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 418,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023015c99e2ae11f429e74fe2e758bc53ffea26eb6368dd60d10daf860f9c79fa8cc6cb98fee9b87dd38353e970539a50a9e",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04650323415ec7cb87c02b670ba5dff00e6741d50c78f044ba179891e1e1e00cecc56803566872a288dcecfea93ae74955084ff6f9ad4f7ae7ec9c808259a5b640984000f7d86b412b4d04506fdce4d06cfd9b176d07cd869be6741de771438020",
+        "wx" : "650323415ec7cb87c02b670ba5dff00e6741d50c78f044ba179891e1e1e00cecc56803566872a288dcecfea93ae74955",
+        "wy" : "084ff6f9ad4f7ae7ec9c808259a5b640984000f7d86b412b4d04506fdce4d06cfd9b176d07cd869be6741de771438020"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004650323415ec7cb87c02b670ba5dff00e6741d50c78f044ba179891e1e1e00cecc56803566872a288dcecfea93ae74955084ff6f9ad4f7ae7ec9c808259a5b640984000f7d86b412b4d04506fdce4d06cfd9b176d07cd869be6741de771438020",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEZQMjQV7Hy4fAK2cLpd/wDmdB1Qx48ES6\nF5iR4eHgDOzFaANWaHKiiNzs/qk650lVCE/2+a1PeufsnICCWaW2QJhAAPfYa0Er\nTQRQb9zk0Gz9mxdtB82Gm+Z0HedxQ4Ag\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 419,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec63260230148c732596feaabb01be1be3a220740e84bbfabe6d82ad0db1c396fa047603beeb95a1cd37fc708a9451d3cc29a45b32",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04dcbe590865766687b59e391cd0e7774c8c71b48a150fd71aa85f12ae56a574a7d6c815eba1c1ac2ba98c0246e7a77ffc8adc0f6009441969497b33ec3ba5ca9056265ca6af4a732540ea71f4a0cb64c4a8296585be4cffa7f70bb779997300ff",
+        "wx" : "00dcbe590865766687b59e391cd0e7774c8c71b48a150fd71aa85f12ae56a574a7d6c815eba1c1ac2ba98c0246e7a77ffc",
+        "wy" : "008adc0f6009441969497b33ec3ba5ca9056265ca6af4a732540ea71f4a0cb64c4a8296585be4cffa7f70bb779997300ff"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004dcbe590865766687b59e391cd0e7774c8c71b48a150fd71aa85f12ae56a574a7d6c815eba1c1ac2ba98c0246e7a77ffc8adc0f6009441969497b33ec3ba5ca9056265ca6af4a732540ea71f4a0cb64c4a8296585be4cffa7f70bb779997300ff",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE3L5ZCGV2Zoe1njkc0Od3TIxxtIoVD9ca\nqF8SrlaldKfWyBXrocGsK6mMAkbnp3/8itwPYAlEGWlJezPsO6XKkFYmXKavSnMl\nQOpx9KDLZMSoKWWFvkz/p/cLt3mZcwD/\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 420,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec632602306b3cc62a449ae5ef68bec8672f186d5418cc18d039af91b45f8a8fae4210ef06d3f0d226f89945b314d9df72e01a02bb",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04334ab85078a211761e6fe39b56b715047f6aa5f187f2eef32c66b10dc7aae5af2d43e3feb356332354f6e3231e723dcef5dd6d0a40fe6c13e5008e310c848139ad58eaa1e9ba242ab383d433111ff11a494a57ab9f0924a257e751418aaaa66f",
+        "wx" : "334ab85078a211761e6fe39b56b715047f6aa5f187f2eef32c66b10dc7aae5af2d43e3feb356332354f6e3231e723dce",
+        "wy" : "00f5dd6d0a40fe6c13e5008e310c848139ad58eaa1e9ba242ab383d433111ff11a494a57ab9f0924a257e751418aaaa66f"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004334ab85078a211761e6fe39b56b715047f6aa5f187f2eef32c66b10dc7aae5af2d43e3feb356332354f6e3231e723dcef5dd6d0a40fe6c13e5008e310c848139ad58eaa1e9ba242ab383d433111ff11a494a57ab9f0924a257e751418aaaa66f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEM0q4UHiiEXYeb+ObVrcVBH9qpfGH8u7z\nLGaxDceq5a8tQ+P+s1YzI1T24yMecj3O9d1tCkD+bBPlAI4xDISBOa1Y6qHpuiQq\ns4PUMxEf8RpJSlernwkkolfnUUGKqqZv\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 421,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec632602307db7901f053b9cefacfda88dd7791c01fd569ed9a5243385eccae12ba992af55832a2e5dc8065e018399a70730035bd8",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04f896353cc3a8afdd543ec3aef062ca97bc32ed1724ea38b940b8c0ea0e23b34187afbe70daf8dbaa5b511557e5d2bddac4bd265da67ceeafca636f6f4c0472f22a9d02e2289184f73bbb700ae8fc921eff4920f290bfcb49fbb232cc13a21028",
+        "wx" : "00f896353cc3a8afdd543ec3aef062ca97bc32ed1724ea38b940b8c0ea0e23b34187afbe70daf8dbaa5b511557e5d2bdda",
+        "wy" : "00c4bd265da67ceeafca636f6f4c0472f22a9d02e2289184f73bbb700ae8fc921eff4920f290bfcb49fbb232cc13a21028"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004f896353cc3a8afdd543ec3aef062ca97bc32ed1724ea38b940b8c0ea0e23b34187afbe70daf8dbaa5b511557e5d2bddac4bd265da67ceeafca636f6f4c0472f22a9d02e2289184f73bbb700ae8fc921eff4920f290bfcb49fbb232cc13a21028",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+JY1PMOor91UPsOu8GLKl7wy7Rck6ji5\nQLjA6g4js0GHr75w2vjbqltRFVfl0r3axL0mXaZ87q/KY29vTARy8iqdAuIokYT3\nO7twCuj8kh7/SSDykL/LSfuyMswTohAo\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 422,
           "comment" : "point at infinity during verify",
+          "flags" : [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307fffffffffffffffffffffffffffffffffffffffffffffffe3b1a6c0fa1b96efac0d06d9245853bd76760cb5666294b9023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
+        "uncompressed" : "04370d9e2e31c712c8028092f802319d7fdf5b3319a8518d08bed3891508c7060cfe2236e18fa14fe077093ceae633e5430fd79aacf9d16ecc19b12d60fba4998dfc682702ec7c8bdd4a590035773b8c9c570ac7dcd414e03252f7a0e6f53b5863",
+        "wx" : "370d9e2e31c712c8028092f802319d7fdf5b3319a8518d08bed3891508c7060cfe2236e18fa14fe077093ceae633e543",
+        "wy" : "0fd79aacf9d16ecc19b12d60fba4998dfc682702ec7c8bdd4a590035773b8c9c570ac7dcd414e03252f7a0e6f53b5863"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004370d9e2e31c712c8028092f802319d7fdf5b3319a8518d08bed3891508c7060cfe2236e18fa14fe077093ceae633e5430fd79aacf9d16ecc19b12d60fba4998dfc682702ec7c8bdd4a590035773b8c9c570ac7dcd414e03252f7a0e6f53b5863",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAENw2eLjHHEsgCgJL4AjGdf99bMxmoUY0I\nvtOJFQjHBgz+Ijbhj6FP4HcJPOrmM+VDD9earPnRbswZsS1g+6SZjfxoJwLsfIvd\nSlkANXc7jJxXCsfc1BTgMlL3oOb1O1hj\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 423,
+          "comment" : "edge case for signature malleability",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306402307fffffffffffffffffffffffffffffffffffffffffffffffe3b1a6c0fa1b96efac0d06d9245853bd76760cb5666294b902307fffffffffffffffffffffffffffffffffffffffffffffffe3b1a6c0fa1b96efac0d06d9245853bd76760cb5666294b9",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04941e6cfa356e572dcccaeb594b06955d99dc4bf07958fc98ffa17de11c7521bf2c7aa8ff260952fcb7aac078ede67b4790a78a0296b041a10f003df1998da4cc4a1614ebcbf5d239431f33d90d3023edc1802e8db6dabcbae67cc314da2aabab",
+        "wx" : "00941e6cfa356e572dcccaeb594b06955d99dc4bf07958fc98ffa17de11c7521bf2c7aa8ff260952fcb7aac078ede67b47",
+        "wy" : "0090a78a0296b041a10f003df1998da4cc4a1614ebcbf5d239431f33d90d3023edc1802e8db6dabcbae67cc314da2aabab"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004941e6cfa356e572dcccaeb594b06955d99dc4bf07958fc98ffa17de11c7521bf2c7aa8ff260952fcb7aac078ede67b4790a78a0296b041a10f003df1998da4cc4a1614ebcbf5d239431f33d90d3023edc1802e8db6dabcbae67cc314da2aabab",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAElB5s+jVuVy3MyutZSwaVXZncS/B5WPyY\n/6F94Rx1Ib8seqj/JglS/LeqwHjt5ntHkKeKApawQaEPAD3xmY2kzEoWFOvL9dI5\nQx8z2Q0wI+3BgC6Nttq8uuZ8wxTaKqur\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-384",
+      "tests" : [
+        {
+          "tcId" : 424,
+          "comment" : "edge case for signature malleability",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306402307fffffffffffffffffffffffffffffffffffffffffffffffe3b1a6c0fa1b96efac0d06d9245853bd76760cb5666294b902307fffffffffffffffffffffffffffffffffffffffffffffffe3b1a6c0fa1b96efac0d06d9245853bd76760cb5666294ba",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
         "uncompressed" : "043ecfd58a3ce583866e0471d16eb3c10a411ec3b8671f3a04769b1ed8464a71cf1c76d8d9b7e3670bbe712d6f554a9383d980d8bedf57470d6b45cc1ad0c6426dc70a0e4be901106a36663bfcab04fcb86008777b92445120d5e3641d97396362",
         "wx" : "3ecfd58a3ce583866e0471d16eb3c10a411ec3b8671f3a04769b1ed8464a71cf1c76d8d9b7e3670bbe712d6f554a9383",
-        "wy" : "0d980d8bedf57470d6b45cc1ad0c6426dc70a0e4be901106a36663bfcab04fcb86008777b92445120d5e3641d97396362"
+        "wy" : "00d980d8bedf57470d6b45cc1ad0c6426dc70a0e4be901106a36663bfcab04fcb86008777b92445120d5e3641d97396362"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200043ecfd58a3ce583866e0471d16eb3c10a411ec3b8671f3a04769b1ed8464a71cf1c76d8d9b7e3670bbe712d6f554a9383d980d8bedf57470d6b45cc1ad0c6426dc70a0e4be901106a36663bfcab04fcb86008777b92445120d5e3641d97396362",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEPs/Vijzlg4ZuBHHRbrPBCkEew7hnHzoE\ndpse2EZKcc8cdtjZt+NnC75xLW9VSpOD2YDYvt9XRw1rRcwa0MZCbccKDkvpARBq\nNmY7/KsE/LhgCHd7kkRRINXjZB2XOWNi\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200043ecfd58a3ce583866e0471d16eb3c10a411ec3b8671f3a04769b1ed8464a71cf1c76d8d9b7e3670bbe712d6f554a9383d980d8bedf57470d6b45cc1ad0c6426dc70a0e4be901106a36663bfcab04fcb86008777b92445120d5e3641d97396362",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEPs/Vijzlg4ZuBHHRbrPBCkEew7hnHzoE\ndpse2EZKcc8cdtjZt+NnC75xLW9VSpOD2YDYvt9XRw1rRcwa0MZCbccKDkvpARBq\nNmY7/KsE/LhgCHd7kkRRINXjZB2XOWNi\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 322,
+          "tcId" : 425,
           "comment" : "u1 == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023100f9b127f0d81ebcd17b7ba0ea131c660d340b05ce557c82160e0f793de07d38179023942871acb7002dfafdfffc8deace",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "044150ccd0fa45aa2ef6b5042ddbb1b87c5ffd1115a8fe5995641948acda82a7b190762d84352cd74d1ca01e79f68f9cb4eb11be9d494c181c156e23e77e532bdf0a20c3cc74ba8c29b1f3eb2bd99129ee0d70ff0d593f0d7a6d6887e7c55930d2",
         "wx" : "4150ccd0fa45aa2ef6b5042ddbb1b87c5ffd1115a8fe5995641948acda82a7b190762d84352cd74d1ca01e79f68f9cb4",
-        "wy" : "0eb11be9d494c181c156e23e77e532bdf0a20c3cc74ba8c29b1f3eb2bd99129ee0d70ff0d593f0d7a6d6887e7c55930d2"
+        "wy" : "00eb11be9d494c181c156e23e77e532bdf0a20c3cc74ba8c29b1f3eb2bd99129ee0d70ff0d593f0d7a6d6887e7c55930d2"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200044150ccd0fa45aa2ef6b5042ddbb1b87c5ffd1115a8fe5995641948acda82a7b190762d84352cd74d1ca01e79f68f9cb4eb11be9d494c181c156e23e77e532bdf0a20c3cc74ba8c29b1f3eb2bd99129ee0d70ff0d593f0d7a6d6887e7c55930d2",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEQVDM0PpFqi72tQQt27G4fF/9ERWo/lmV\nZBlIrNqCp7GQdi2ENSzXTRygHnn2j5y06xG+nUlMGBwVbiPnflMr3wogw8x0uowp\nsfPrK9mRKe4NcP8NWT8Nem1oh+fFWTDS\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200044150ccd0fa45aa2ef6b5042ddbb1b87c5ffd1115a8fe5995641948acda82a7b190762d84352cd74d1ca01e79f68f9cb4eb11be9d494c181c156e23e77e532bdf0a20c3cc74ba8c29b1f3eb2bd99129ee0d70ff0d593f0d7a6d6887e7c55930d2",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEQVDM0PpFqi72tQQt27G4fF/9ERWo/lmV\nZBlIrNqCp7GQdi2ENSzXTRygHnn2j5y06xG+nUlMGBwVbiPnflMr3wogw8x0uowp\nsfPrK9mRKe4NcP8NWT8Nem1oh+fFWTDS\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 323,
+          "tcId" : 426,
           "comment" : "u1 == n - 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec63260230064ed80f27e1432e84845f15ece399f2cbf4fa31aa837de9b953d44413b9f5c7c7f67989d703f07abef11b6ad0373ea5",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04e78fe2c11beac7090ee0af7fed469a8ccebd3cccc4ee9fccc8ef3fc0455b69aaa082dc13e1d84f34026cb6f0af9e992ff34ebba71bf3a4050bf28e4084b5c5f5d4098ec46f10a31b02fb4bf20cc9362f6f02a66e802f817507535fac3ec0b099",
-        "wx" : "0e78fe2c11beac7090ee0af7fed469a8ccebd3cccc4ee9fccc8ef3fc0455b69aaa082dc13e1d84f34026cb6f0af9e992f",
-        "wy" : "0f34ebba71bf3a4050bf28e4084b5c5f5d4098ec46f10a31b02fb4bf20cc9362f6f02a66e802f817507535fac3ec0b099"
+        "wx" : "00e78fe2c11beac7090ee0af7fed469a8ccebd3cccc4ee9fccc8ef3fc0455b69aaa082dc13e1d84f34026cb6f0af9e992f",
+        "wy" : "00f34ebba71bf3a4050bf28e4084b5c5f5d4098ec46f10a31b02fb4bf20cc9362f6f02a66e802f817507535fac3ec0b099"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004e78fe2c11beac7090ee0af7fed469a8ccebd3cccc4ee9fccc8ef3fc0455b69aaa082dc13e1d84f34026cb6f0af9e992ff34ebba71bf3a4050bf28e4084b5c5f5d4098ec46f10a31b02fb4bf20cc9362f6f02a66e802f817507535fac3ec0b099",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE54/iwRvqxwkO4K9/7UaajM69PMzE7p/M\nyO8/wEVbaaqggtwT4dhPNAJstvCvnpkv8067pxvzpAUL8o5AhLXF9dQJjsRvEKMb\nAvtL8gzJNi9vAqZugC+BdQdTX6w+wLCZ\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004e78fe2c11beac7090ee0af7fed469a8ccebd3cccc4ee9fccc8ef3fc0455b69aaa082dc13e1d84f34026cb6f0af9e992ff34ebba71bf3a4050bf28e4084b5c5f5d4098ec46f10a31b02fb4bf20cc9362f6f02a66e802f817507535fac3ec0b099",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE54/iwRvqxwkO4K9/7UaajM69PMzE7p/M\nyO8/wEVbaaqggtwT4dhPNAJstvCvnpkv8067pxvzpAUL8o5AhLXF9dQJjsRvEKMb\nAvtL8gzJNi9vAqZugC+BdQdTX6w+wLCZ\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 324,
+          "tcId" : 427,
           "comment" : "u2 == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04ee24ab8a34d05af684939357f32759cc5a14f3c717529a20aea8e0c5965d8a41e68925f688471994b72021ba51b28c090a55693c92ad0cbae9edcf515e2b4c060b888d82c81e4a3b6a173b62ed04a46fa95db1a2f3949980fba2e371263c4fa9",
-        "wx" : "0ee24ab8a34d05af684939357f32759cc5a14f3c717529a20aea8e0c5965d8a41e68925f688471994b72021ba51b28c09",
+        "wx" : "00ee24ab8a34d05af684939357f32759cc5a14f3c717529a20aea8e0c5965d8a41e68925f688471994b72021ba51b28c09",
         "wy" : "0a55693c92ad0cbae9edcf515e2b4c060b888d82c81e4a3b6a173b62ed04a46fa95db1a2f3949980fba2e371263c4fa9"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004ee24ab8a34d05af684939357f32759cc5a14f3c717529a20aea8e0c5965d8a41e68925f688471994b72021ba51b28c090a55693c92ad0cbae9edcf515e2b4c060b888d82c81e4a3b6a173b62ed04a46fa95db1a2f3949980fba2e371263c4fa9",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE7iSrijTQWvaEk5NX8ydZzFoU88cXUpog\nrqjgxZZdikHmiSX2iEcZlLcgIbpRsowJClVpPJKtDLrp7c9RXitMBguIjYLIHko7\nahc7Yu0EpG+pXbGi85SZgPui43EmPE+p\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004ee24ab8a34d05af684939357f32759cc5a14f3c717529a20aea8e0c5965d8a41e68925f688471994b72021ba51b28c090a55693c92ad0cbae9edcf515e2b4c060b888d82c81e4a3b6a173b62ed04a46fa95db1a2f3949980fba2e371263c4fa9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE7iSrijTQWvaEk5NX8ydZzFoU88cXUpog\nrqjgxZZdikHmiSX2iEcZlLcgIbpRsowJClVpPJKtDLrp7c9RXitMBguIjYLIHko7\nahc7Yu0EpG+pXbGi85SZgPui43EmPE+p\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 325,
+          "tcId" : 428,
           "comment" : "u2 == n - 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa84ecde56a2cf73ea3abc092185cb1a51f34810f1ddd8c64d",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "043d2e916055c92e1b36133f5937b37c1b0102834eb77008a3ba9c3da446e9065971d68ba913091851e10cff5b4cd875c139aa7aadfc2caf7107b17ae1aea8b299d61bf15aca0cb3fd6f1ffde8192bfe58f0822bbbc1f55bddf6b4fe9c8f2b0eac",
         "wx" : "3d2e916055c92e1b36133f5937b37c1b0102834eb77008a3ba9c3da446e9065971d68ba913091851e10cff5b4cd875c1",
         "wy" : "39aa7aadfc2caf7107b17ae1aea8b299d61bf15aca0cb3fd6f1ffde8192bfe58f0822bbbc1f55bddf6b4fe9c8f2b0eac"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200043d2e916055c92e1b36133f5937b37c1b0102834eb77008a3ba9c3da446e9065971d68ba913091851e10cff5b4cd875c139aa7aadfc2caf7107b17ae1aea8b299d61bf15aca0cb3fd6f1ffde8192bfe58f0822bbbc1f55bddf6b4fe9c8f2b0eac",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEPS6RYFXJLhs2Ez9ZN7N8GwECg063cAij\nupw9pEbpBllx1oupEwkYUeEM/1tM2HXBOap6rfwsr3EHsXrhrqiymdYb8VrKDLP9\nbx/96Bkr/ljwgiu7wfVb3fa0/pyPKw6s\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200043d2e916055c92e1b36133f5937b37c1b0102834eb77008a3ba9c3da446e9065971d68ba913091851e10cff5b4cd875c139aa7aadfc2caf7107b17ae1aea8b299d61bf15aca0cb3fd6f1ffde8192bfe58f0822bbbc1f55bddf6b4fe9c8f2b0eac",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEPS6RYFXJLhs2Ez9ZN7N8GwECg063cAij\nupw9pEbpBllx1oupEwkYUeEM/1tM2HXBOap6rfwsr3EHsXrhrqiymdYb8VrKDLP9\nbx/96Bkr/ljwgiu7wfVb3fa0/pyPKw6s\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 326,
+          "tcId" : 429,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0230533b0d50480a3ef07e7e8af8b1097759bc03ac9a1c7ed6075a052869f57f12b285613162d08ee7aab9fe54aaa984a39a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04ae596697427aa250156c05ac4338e48980a7f093ea1f1fe67098b43f6539c1b20ae74338f9bf270d33663c50abe8fd001ca6a52732db74ab15d2f249a3d839080f898367dfd64992cdce2708deaad523a2a236b43400424241c91a35b530fa50",
-        "wx" : "0ae596697427aa250156c05ac4338e48980a7f093ea1f1fe67098b43f6539c1b20ae74338f9bf270d33663c50abe8fd00",
+        "wx" : "00ae596697427aa250156c05ac4338e48980a7f093ea1f1fe67098b43f6539c1b20ae74338f9bf270d33663c50abe8fd00",
         "wy" : "1ca6a52732db74ab15d2f249a3d839080f898367dfd64992cdce2708deaad523a2a236b43400424241c91a35b530fa50"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004ae596697427aa250156c05ac4338e48980a7f093ea1f1fe67098b43f6539c1b20ae74338f9bf270d33663c50abe8fd001ca6a52732db74ab15d2f249a3d839080f898367dfd64992cdce2708deaad523a2a236b43400424241c91a35b530fa50",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAErllml0J6olAVbAWsQzjkiYCn8JPqHx/m\ncJi0P2U5wbIK50M4+b8nDTNmPFCr6P0AHKalJzLbdKsV0vJJo9g5CA+Jg2ff1kmS\nzc4nCN6q1SOioja0NABCQkHJGjW1MPpQ\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004ae596697427aa250156c05ac4338e48980a7f093ea1f1fe67098b43f6539c1b20ae74338f9bf270d33663c50abe8fd001ca6a52732db74ab15d2f249a3d839080f898367dfd64992cdce2708deaad523a2a236b43400424241c91a35b530fa50",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAErllml0J6olAVbAWsQzjkiYCn8JPqHx/m\ncJi0P2U5wbIK50M4+b8nDTNmPFCr6P0AHKalJzLbdKsV0vJJo9g5CA+Jg2ff1kmS\nzc4nCN6q1SOioja0NABCQkHJGjW1MPpQ\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 327,
+          "tcId" : 430,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100d49a253986bbaa8ce9c3d3808313d39c3b950a478372edc009bc0566b73be7b05dad0737e16960257cc16db6ec6c620f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0488738f9981dd4d1fabb60ad83c2dd6dfc9da302209ae3e53498a883b6e39a38bead9b02709f352d3e6b6578154eab2529388a05c6b9f3a4028abb9950a51f5264ecd7580a423fdec9472faeeb57f92e31c46bef2a781fe5edad026009f198262",
-        "wx" : "088738f9981dd4d1fabb60ad83c2dd6dfc9da302209ae3e53498a883b6e39a38bead9b02709f352d3e6b6578154eab252",
-        "wy" : "09388a05c6b9f3a4028abb9950a51f5264ecd7580a423fdec9472faeeb57f92e31c46bef2a781fe5edad026009f198262"
+        "wx" : "0088738f9981dd4d1fabb60ad83c2dd6dfc9da302209ae3e53498a883b6e39a38bead9b02709f352d3e6b6578154eab252",
+        "wy" : "009388a05c6b9f3a4028abb9950a51f5264ecd7580a423fdec9472faeeb57f92e31c46bef2a781fe5edad026009f198262"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000488738f9981dd4d1fabb60ad83c2dd6dfc9da302209ae3e53498a883b6e39a38bead9b02709f352d3e6b6578154eab2529388a05c6b9f3a4028abb9950a51f5264ecd7580a423fdec9472faeeb57f92e31c46bef2a781fe5edad026009f198262",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEiHOPmYHdTR+rtgrYPC3W38naMCIJrj5T\nSYqIO245o4vq2bAnCfNS0+a2V4FU6rJSk4igXGufOkAoq7mVClH1Jk7NdYCkI/3s\nlHL67rV/kuMcRr7yp4H+XtrQJgCfGYJi\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000488738f9981dd4d1fabb60ad83c2dd6dfc9da302209ae3e53498a883b6e39a38bead9b02709f352d3e6b6578154eab2529388a05c6b9f3a4028abb9950a51f5264ecd7580a423fdec9472faeeb57f92e31c46bef2a781fe5edad026009f198262",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEiHOPmYHdTR+rtgrYPC3W38naMCIJrj5T\nSYqIO245o4vq2bAnCfNS0+a2V4FU6rJSk4igXGufOkAoq7mVClH1Jk7NdYCkI/3s\nlHL67rV/kuMcRr7yp4H+XtrQJgCfGYJi\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 328,
+          "tcId" : 431,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd0230285090b0d6a6820bbba394efbee5c24a2281e825d2f6c55fb7a85b8251db00f75ab07cc993ceaf664f3c116baf34b021",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04f421541311c94fdd79fc298f8ab1a3adfd08029fdad439a94d4cea11f7e799bc439609f2fb7be3f349d55e484d0a0d36b35330bbdbec1e75f2984483d96bf210d722c1830292ffc35a2f6a21a4b50519f565f024bbccc97228a2f8ad8fadc0d5",
-        "wx" : "0f421541311c94fdd79fc298f8ab1a3adfd08029fdad439a94d4cea11f7e799bc439609f2fb7be3f349d55e484d0a0d36",
-        "wy" : "0b35330bbdbec1e75f2984483d96bf210d722c1830292ffc35a2f6a21a4b50519f565f024bbccc97228a2f8ad8fadc0d5"
+        "wx" : "00f421541311c94fdd79fc298f8ab1a3adfd08029fdad439a94d4cea11f7e799bc439609f2fb7be3f349d55e484d0a0d36",
+        "wy" : "00b35330bbdbec1e75f2984483d96bf210d722c1830292ffc35a2f6a21a4b50519f565f024bbccc97228a2f8ad8fadc0d5"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004f421541311c94fdd79fc298f8ab1a3adfd08029fdad439a94d4cea11f7e799bc439609f2fb7be3f349d55e484d0a0d36b35330bbdbec1e75f2984483d96bf210d722c1830292ffc35a2f6a21a4b50519f565f024bbccc97228a2f8ad8fadc0d5",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE9CFUExHJT915/CmPirGjrf0IAp/a1Dmp\nTUzqEffnmbxDlgny+3vj80nVXkhNCg02s1Mwu9vsHnXymESD2WvyENciwYMCkv/D\nWi9qIaS1BRn1ZfAku8zJciii+K2PrcDV\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004f421541311c94fdd79fc298f8ab1a3adfd08029fdad439a94d4cea11f7e799bc439609f2fb7be3f349d55e484d0a0d36b35330bbdbec1e75f2984483d96bf210d722c1830292ffc35a2f6a21a4b50519f565f024bbccc97228a2f8ad8fadc0d5",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE9CFUExHJT915/CmPirGjrf0IAp/a1Dmp\nTUzqEffnmbxDlgny+3vj80nVXkhNCg02s1Mwu9vsHnXymESD2WvyENciwYMCkv/D\nWi9qIaS1BRn1ZfAku8zJciii+K2PrcDV\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 329,
+          "tcId" : 432,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100b39af4a81ee4ae79064ed80f27e1432e84845f15ece399f2a43d2505a0a8c72c5731f4fd967420b1000e3f75502ed7b7",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04399be4cfc439f94f2421cbd34c2cd90bae53eb60ddfafca52f7275d165d14fa659b636713b5d4b39e62fd48bae141d0e1b23e3b4f0c202ed7b59db78a35c12ac698c603eab144fd09ac2ed8f4495f607e4d2c87a23ce2ec33e410ca47ecc2555",
         "wx" : "399be4cfc439f94f2421cbd34c2cd90bae53eb60ddfafca52f7275d165d14fa659b636713b5d4b39e62fd48bae141d0e",
         "wy" : "1b23e3b4f0c202ed7b59db78a35c12ac698c603eab144fd09ac2ed8f4495f607e4d2c87a23ce2ec33e410ca47ecc2555"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004399be4cfc439f94f2421cbd34c2cd90bae53eb60ddfafca52f7275d165d14fa659b636713b5d4b39e62fd48bae141d0e1b23e3b4f0c202ed7b59db78a35c12ac698c603eab144fd09ac2ed8f4495f607e4d2c87a23ce2ec33e410ca47ecc2555",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOZvkz8Q5+U8kIcvTTCzZC65T62Dd+vyl\nL3J10WXRT6ZZtjZxO11LOeYv1IuuFB0OGyPjtPDCAu17Wdt4o1wSrGmMYD6rFE/Q\nmsLtj0SV9gfk0sh6I84uwz5BDKR+zCVV\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004399be4cfc439f94f2421cbd34c2cd90bae53eb60ddfafca52f7275d165d14fa659b636713b5d4b39e62fd48bae141d0e1b23e3b4f0c202ed7b59db78a35c12ac698c603eab144fd09ac2ed8f4495f607e4d2c87a23ce2ec33e410ca47ecc2555",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOZvkz8Q5+U8kIcvTTCzZC65T62Dd+vyl\nL3J10WXRT6ZZtjZxO11LOeYv1IuuFB0OGyPjtPDCAu17Wdt4o1wSrGmMYD6rFE/Q\nmsLtj0SV9gfk0sh6I84uwz5BDKR+zCVV\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 330,
+          "tcId" : 433,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100af4a81ee4ae79064ed80f27e1432e84845f15ece399f2cbf28df829ccd30f5ef62ec23957b837d73fe4e156edccd4465",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "041578bbff72137c4bca33d7385a892be94cb059f9091ddfe890345f712a9fba5fc77084cec11084ed048491604a07f66c76bbaa872f0710d82a08d9dddd833c7be7c7e8e265f49145157eb4e8e8280076a37ee5873271db510034da19da24415b",
         "wx" : "1578bbff72137c4bca33d7385a892be94cb059f9091ddfe890345f712a9fba5fc77084cec11084ed048491604a07f66c",
         "wy" : "76bbaa872f0710d82a08d9dddd833c7be7c7e8e265f49145157eb4e8e8280076a37ee5873271db510034da19da24415b"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200041578bbff72137c4bca33d7385a892be94cb059f9091ddfe890345f712a9fba5fc77084cec11084ed048491604a07f66c76bbaa872f0710d82a08d9dddd833c7be7c7e8e265f49145157eb4e8e8280076a37ee5873271db510034da19da24415b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEFXi7/3ITfEvKM9c4Wokr6UywWfkJHd/o\nkDRfcSqful/HcITOwRCE7QSEkWBKB/Zsdruqhy8HENgqCNnd3YM8e+fH6OJl9JFF\nFX606OgoAHajfuWHMnHbUQA02hnaJEFb\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200041578bbff72137c4bca33d7385a892be94cb059f9091ddfe890345f712a9fba5fc77084cec11084ed048491604a07f66c76bbaa872f0710d82a08d9dddd833c7be7c7e8e265f49145157eb4e8e8280076a37ee5873271db510034da19da24415b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEFXi7/3ITfEvKM9c4Wokr6UywWfkJHd/o\nkDRfcSqful/HcITOwRCE7QSEkWBKB/Zsdruqhy8HENgqCNnd3YM8e+fH6OJl9JFF\nFX606OgoAHajfuWHMnHbUQA02hnaJEFb\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 331,
+          "tcId" : 434,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02305e9503dc95cf20c9db01e4fc2865d0908be2bd9c733e597e8a5bb7b7a62abdff6dbe3978ae56536d0fb01172ecd55f57",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0433ba451c85e729058f83041077a4695eb47df93e718b09a4618c753ac803cd75c1a91290c2ff5a635389d07149571dab1fc7d8a71776851ff244ff632fe6f92e1652e5284893c4244fe775d8efc589d823dd03f3919027f004537bd8ee09f3a3",
         "wx" : "33ba451c85e729058f83041077a4695eb47df93e718b09a4618c753ac803cd75c1a91290c2ff5a635389d07149571dab",
         "wy" : "1fc7d8a71776851ff244ff632fe6f92e1652e5284893c4244fe775d8efc589d823dd03f3919027f004537bd8ee09f3a3"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000433ba451c85e729058f83041077a4695eb47df93e718b09a4618c753ac803cd75c1a91290c2ff5a635389d07149571dab1fc7d8a71776851ff244ff632fe6f92e1652e5284893c4244fe775d8efc589d823dd03f3919027f004537bd8ee09f3a3",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEM7pFHIXnKQWPgwQQd6RpXrR9+T5xiwmk\nYYx1OsgDzXXBqRKQwv9aY1OJ0HFJVx2rH8fYpxd2hR/yRP9jL+b5LhZS5ShIk8Qk\nT+d12O/Fidgj3QPzkZAn8ARTe9juCfOj\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000433ba451c85e729058f83041077a4695eb47df93e718b09a4618c753ac803cd75c1a91290c2ff5a635389d07149571dab1fc7d8a71776851ff244ff632fe6f92e1652e5284893c4244fe775d8efc589d823dd03f3919027f004537bd8ee09f3a3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEM7pFHIXnKQWPgwQQd6RpXrR9+T5xiwmk\nYYx1OsgDzXXBqRKQwv9aY1OJ0HFJVx2rH8fYpxd2hR/yRP9jL+b5LhZS5ShIk8Qk\nT+d12O/Fidgj3QPzkZAn8ARTe9juCfOj\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 332,
+          "tcId" : 435,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02301ee4ae79064ed80f27e1432e84845f15ece399f2cbf4fa31a3ae8edab84dc3330a39f70938e3912bd59753de5aed3088",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04040771e3390216fed2c6208bdf5bfea83ab1915b166e626569f12efd410a39b7e7c76f70f0012843a26debf4ccc33ddae5bc5f7e62d054eac31cd022afdb71b7c638f24c30cbad0ef35ed2fc9917f356e9c3f04391b21d1035274b81537fcbf3",
-        "wx" : "40771e3390216fed2c6208bdf5bfea83ab1915b166e626569f12efd410a39b7e7c76f70f0012843a26debf4ccc33dda",
-        "wy" : "0e5bc5f7e62d054eac31cd022afdb71b7c638f24c30cbad0ef35ed2fc9917f356e9c3f04391b21d1035274b81537fcbf3"
+        "wx" : "040771e3390216fed2c6208bdf5bfea83ab1915b166e626569f12efd410a39b7e7c76f70f0012843a26debf4ccc33dda",
+        "wy" : "00e5bc5f7e62d054eac31cd022afdb71b7c638f24c30cbad0ef35ed2fc9917f356e9c3f04391b21d1035274b81537fcbf3"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004040771e3390216fed2c6208bdf5bfea83ab1915b166e626569f12efd410a39b7e7c76f70f0012843a26debf4ccc33ddae5bc5f7e62d054eac31cd022afdb71b7c638f24c30cbad0ef35ed2fc9917f356e9c3f04391b21d1035274b81537fcbf3",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEBAdx4zkCFv7SxiCL31v+qDqxkVsWbmJl\nafEu/UEKObfnx29w8AEoQ6Jt6/TMwz3a5bxffmLQVOrDHNAir9txt8Y48kwwy60O\n817S/JkX81bpw/BDkbIdEDUnS4FTf8vz\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004040771e3390216fed2c6208bdf5bfea83ab1915b166e626569f12efd410a39b7e7c76f70f0012843a26debf4ccc33ddae5bc5f7e62d054eac31cd022afdb71b7c638f24c30cbad0ef35ed2fc9917f356e9c3f04391b21d1035274b81537fcbf3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEBAdx4zkCFv7SxiCL31v+qDqxkVsWbmJl\nafEu/UEKObfnx29w8AEoQ6Jt6/TMwz3a5bxffmLQVOrDHNAir9txt8Y48kwwy60O\n817S/JkX81bpw/BDkbIdEDUnS4FTf8vz\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 333,
+          "tcId" : 436,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100bb51cd3ba8eb201f53ddb4e34e08c0ff7dff9378106784d798d5a3440bd6dc34be3a0eaef8776619a0c97fefb15720b3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0498d3f16e1c510a933e648e78d01588319f002e9475df8942a2a89db0666bb7c88b32bb248140e44ac4ab28111b2b792399a926f4a66fbe28ff65c09f8306893aec094b89d0fe529e3577c5ecf30a7944caaf530f4575eb113fcf4c200d2dd4bd",
-        "wx" : "098d3f16e1c510a933e648e78d01588319f002e9475df8942a2a89db0666bb7c88b32bb248140e44ac4ab28111b2b7923",
-        "wy" : "099a926f4a66fbe28ff65c09f8306893aec094b89d0fe529e3577c5ecf30a7944caaf530f4575eb113fcf4c200d2dd4bd"
+        "wx" : "0098d3f16e1c510a933e648e78d01588319f002e9475df8942a2a89db0666bb7c88b32bb248140e44ac4ab28111b2b7923",
+        "wy" : "0099a926f4a66fbe28ff65c09f8306893aec094b89d0fe529e3577c5ecf30a7944caaf530f4575eb113fcf4c200d2dd4bd"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000498d3f16e1c510a933e648e78d01588319f002e9475df8942a2a89db0666bb7c88b32bb248140e44ac4ab28111b2b792399a926f4a66fbe28ff65c09f8306893aec094b89d0fe529e3577c5ecf30a7944caaf530f4575eb113fcf4c200d2dd4bd",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEmNPxbhxRCpM+ZI540BWIMZ8ALpR134lC\noqidsGZrt8iLMrskgUDkSsSrKBEbK3kjmakm9KZvvij/ZcCfgwaJOuwJS4nQ/lKe\nNXfF7PMKeUTKr1MPRXXrET/PTCANLdS9\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000498d3f16e1c510a933e648e78d01588319f002e9475df8942a2a89db0666bb7c88b32bb248140e44ac4ab28111b2b792399a926f4a66fbe28ff65c09f8306893aec094b89d0fe529e3577c5ecf30a7944caaf530f4575eb113fcf4c200d2dd4bd",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEmNPxbhxRCpM+ZI540BWIMZ8ALpR134lC\noqidsGZrt8iLMrskgUDkSsSrKBEbK3kjmakm9KZvvij/ZcCfgwaJOuwJS4nQ/lKe\nNXfF7PMKeUTKr1MPRXXrET/PTCANLdS9\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 334,
+          "tcId" : 437,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100e707e267ea635384a6da09823149f5cb7acbb29e910d2630c5fb5afbc42aa8436349b214a3b8fb9481ec999e005091f8",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04d1fd602feef80be9e55a19d1a9799c72a899110c6ac21fb3c21357069809d591a8775b64d1867a8cfff124f6a5e3a4f5f9548064f01b9af8868705493a37a037193b48f53b7c7973023f53e6ceff6830ca2f7a14ef51536d453af43b3058d8a9",
-        "wx" : "0d1fd602feef80be9e55a19d1a9799c72a899110c6ac21fb3c21357069809d591a8775b64d1867a8cfff124f6a5e3a4f5",
-        "wy" : "0f9548064f01b9af8868705493a37a037193b48f53b7c7973023f53e6ceff6830ca2f7a14ef51536d453af43b3058d8a9"
+        "wx" : "00d1fd602feef80be9e55a19d1a9799c72a899110c6ac21fb3c21357069809d591a8775b64d1867a8cfff124f6a5e3a4f5",
+        "wy" : "00f9548064f01b9af8868705493a37a037193b48f53b7c7973023f53e6ceff6830ca2f7a14ef51536d453af43b3058d8a9"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004d1fd602feef80be9e55a19d1a9799c72a899110c6ac21fb3c21357069809d591a8775b64d1867a8cfff124f6a5e3a4f5f9548064f01b9af8868705493a37a037193b48f53b7c7973023f53e6ceff6830ca2f7a14ef51536d453af43b3058d8a9",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE0f1gL+74C+nlWhnRqXmccqiZEQxqwh+z\nwhNXBpgJ1ZGod1tk0YZ6jP/xJPal46T1+VSAZPAbmviGhwVJOjegNxk7SPU7fHlz\nAj9T5s7/aDDKL3oU71FTbUU69DswWNip\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004d1fd602feef80be9e55a19d1a9799c72a899110c6ac21fb3c21357069809d591a8775b64d1867a8cfff124f6a5e3a4f5f9548064f01b9af8868705493a37a037193b48f53b7c7973023f53e6ceff6830ca2f7a14ef51536d453af43b3058d8a9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE0f1gL+74C+nlWhnRqXmccqiZEQxqwh+z\nwhNXBpgJ1ZGod1tk0YZ6jP/xJPal46T1+VSAZPAbmviGhwVJOjegNxk7SPU7fHlz\nAj9T5s7/aDDKL3oU71FTbUU69DswWNip\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 335,
+          "tcId" : 438,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100acc4f2afb7f5c10f818175074ef688a643fc5365e38129f86d5e2517feb81b2cd2b8dc4f7821bfd032edc4c0234085d9",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0482f37604f66664c2883dba6d98397c281045cbf59f1d16dddb1381126a246553a8b4d2aaea48ad9185a1645f65567d318a4d7b19f1d2e4434c9a8ecad396304abc82221bbab0679935071c72fd975e7b021c04b1d16ea36fc2d051ef5a8e117c",
-        "wx" : "082f37604f66664c2883dba6d98397c281045cbf59f1d16dddb1381126a246553a8b4d2aaea48ad9185a1645f65567d31",
-        "wy" : "08a4d7b19f1d2e4434c9a8ecad396304abc82221bbab0679935071c72fd975e7b021c04b1d16ea36fc2d051ef5a8e117c"
+        "wx" : "0082f37604f66664c2883dba6d98397c281045cbf59f1d16dddb1381126a246553a8b4d2aaea48ad9185a1645f65567d31",
+        "wy" : "008a4d7b19f1d2e4434c9a8ecad396304abc82221bbab0679935071c72fd975e7b021c04b1d16ea36fc2d051ef5a8e117c"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000482f37604f66664c2883dba6d98397c281045cbf59f1d16dddb1381126a246553a8b4d2aaea48ad9185a1645f65567d318a4d7b19f1d2e4434c9a8ecad396304abc82221bbab0679935071c72fd975e7b021c04b1d16ea36fc2d051ef5a8e117c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgvN2BPZmZMKIPbptmDl8KBBFy/WfHRbd\n2xOBEmokZVOotNKq6kitkYWhZF9lVn0xik17GfHS5ENMmo7K05YwSryCIhu6sGeZ\nNQcccv2XXnsCHASx0W6jb8LQUe9ajhF8\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000482f37604f66664c2883dba6d98397c281045cbf59f1d16dddb1381126a246553a8b4d2aaea48ad9185a1645f65567d318a4d7b19f1d2e4434c9a8ecad396304abc82221bbab0679935071c72fd975e7b021c04b1d16ea36fc2d051ef5a8e117c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgvN2BPZmZMKIPbptmDl8KBBFy/WfHRbd\n2xOBEmokZVOotNKq6kitkYWhZF9lVn0xik17GfHS5ENMmo7K05YwSryCIhu6sGeZ\nNQcccv2XXnsCHASx0W6jb8LQUe9ajhF8\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 336,
+          "tcId" : 439,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02310083276c0793f0a19742422f8af671ccf965fa7d18d541bef4c05b90e303f891d39008439e0fda4bfad5ee9a6ace7e340c",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04f052dfc27bf8a6d36f3739f239b981f5b53fe08d999ec683b01e43e7596156206ba08b8b9f59229e2fbdce05f1e40f9990f0fdfb7029f9b3e8c6144dad0339208b7cdcb3820a554259db9d27afdd18f4a750296c59bad6b62df076f90d53be0d",
-        "wx" : "0f052dfc27bf8a6d36f3739f239b981f5b53fe08d999ec683b01e43e7596156206ba08b8b9f59229e2fbdce05f1e40f99",
-        "wy" : "090f0fdfb7029f9b3e8c6144dad0339208b7cdcb3820a554259db9d27afdd18f4a750296c59bad6b62df076f90d53be0d"
+        "wx" : "00f052dfc27bf8a6d36f3739f239b981f5b53fe08d999ec683b01e43e7596156206ba08b8b9f59229e2fbdce05f1e40f99",
+        "wy" : "0090f0fdfb7029f9b3e8c6144dad0339208b7cdcb3820a554259db9d27afdd18f4a750296c59bad6b62df076f90d53be0d"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004f052dfc27bf8a6d36f3739f239b981f5b53fe08d999ec683b01e43e7596156206ba08b8b9f59229e2fbdce05f1e40f9990f0fdfb7029f9b3e8c6144dad0339208b7cdcb3820a554259db9d27afdd18f4a750296c59bad6b62df076f90d53be0d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8FLfwnv4ptNvNznyObmB9bU/4I2ZnsaD\nsB5D51lhViBroIuLn1kini+9zgXx5A+ZkPD9+3Ap+bPoxhRNrQM5IIt83LOCClVC\nWdudJ6/dGPSnUClsWbrWti3wdvkNU74N\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004f052dfc27bf8a6d36f3739f239b981f5b53fe08d999ec683b01e43e7596156206ba08b8b9f59229e2fbdce05f1e40f9990f0fdfb7029f9b3e8c6144dad0339208b7cdcb3820a554259db9d27afdd18f4a750296c59bad6b62df076f90d53be0d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8FLfwnv4ptNvNznyObmB9bU/4I2ZnsaD\nsB5D51lhViBroIuLn1kini+9zgXx5A+ZkPD9+3Ap+bPoxhRNrQM5IIt83LOCClVC\nWdudJ6/dGPSnUClsWbrWti3wdvkNU74N\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 337,
+          "tcId" : 440,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100942848586b534105ddd1ca77df72e1251140f412e97b62afbf85d4822309176b5965453dee3fab709e14156b3dfcecca",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04f877bd6e2a9273e322a3298ea3add13d1104b32172283669ca6688f0cb591524a7f15dd41496681eda98939aae729fede85ca37c81ef19e3dc9ab16908a3720d86875a51a6a6d932e37492a6ec7a344eabc482377f14891fbd1da7faeffa1178",
-        "wx" : "0f877bd6e2a9273e322a3298ea3add13d1104b32172283669ca6688f0cb591524a7f15dd41496681eda98939aae729fed",
-        "wy" : "0e85ca37c81ef19e3dc9ab16908a3720d86875a51a6a6d932e37492a6ec7a344eabc482377f14891fbd1da7faeffa1178"
+        "wx" : "00f877bd6e2a9273e322a3298ea3add13d1104b32172283669ca6688f0cb591524a7f15dd41496681eda98939aae729fed",
+        "wy" : "00e85ca37c81ef19e3dc9ab16908a3720d86875a51a6a6d932e37492a6ec7a344eabc482377f14891fbd1da7faeffa1178"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004f877bd6e2a9273e322a3298ea3add13d1104b32172283669ca6688f0cb591524a7f15dd41496681eda98939aae729fede85ca37c81ef19e3dc9ab16908a3720d86875a51a6a6d932e37492a6ec7a344eabc482377f14891fbd1da7faeffa1178",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+He9biqSc+MioymOo63RPREEsyFyKDZp\nymaI8MtZFSSn8V3UFJZoHtqYk5qucp/t6FyjfIHvGePcmrFpCKNyDYaHWlGmptky\n43SSpux6NE6rxII3fxSJH70dp/rv+hF4\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004f877bd6e2a9273e322a3298ea3add13d1104b32172283669ca6688f0cb591524a7f15dd41496681eda98939aae729fede85ca37c81ef19e3dc9ab16908a3720d86875a51a6a6d932e37492a6ec7a344eabc482377f14891fbd1da7faeffa1178",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+He9biqSc+MioymOo63RPREEsyFyKDZp\nymaI8MtZFSSn8V3UFJZoHtqYk5qucp/t6FyjfIHvGePcmrFpCKNyDYaHWlGmptky\n43SSpux6NE6rxII3fxSJH70dp/rv+hF4\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 338,
+          "tcId" : 441,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02307fffffffffffffffffffffffffffffffffffffffffffffffed2119d5fc12649fc808af3b6d9037d3a44eb32399970dd0",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0414249bbcfeeceab06c75654d361c0df8d56b320ea3bc1d4627ec0a2f4b8fa3577445694664f569a91f480741381e494a28479f2186d715a56788f67073056aa0cb0b6a7f7893e77b9a6976ef6663d80226896d7f43bb502e1b4d49558a27dd8b",
         "wx" : "14249bbcfeeceab06c75654d361c0df8d56b320ea3bc1d4627ec0a2f4b8fa3577445694664f569a91f480741381e494a",
         "wy" : "28479f2186d715a56788f67073056aa0cb0b6a7f7893e77b9a6976ef6663d80226896d7f43bb502e1b4d49558a27dd8b"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000414249bbcfeeceab06c75654d361c0df8d56b320ea3bc1d4627ec0a2f4b8fa3577445694664f569a91f480741381e494a28479f2186d715a56788f67073056aa0cb0b6a7f7893e77b9a6976ef6663d80226896d7f43bb502e1b4d49558a27dd8b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEFCSbvP7s6rBsdWVNNhwN+NVrMg6jvB1G\nJ+wKL0uPo1d0RWlGZPVpqR9IB0E4HklKKEefIYbXFaVniPZwcwVqoMsLan94k+d7\nmml272Zj2AImiW1/Q7tQLhtNSVWKJ92L\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000414249bbcfeeceab06c75654d361c0df8d56b320ea3bc1d4627ec0a2f4b8fa3577445694664f569a91f480741381e494a28479f2186d715a56788f67073056aa0cb0b6a7f7893e77b9a6976ef6663d80226896d7f43bb502e1b4d49558a27dd8b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEFCSbvP7s6rBsdWVNNhwN+NVrMg6jvB1G\nJ+wKL0uPo1d0RWlGZPVpqR9IB0E4HklKKEefIYbXFaVniPZwcwVqoMsLan94k+d7\nmml272Zj2AImiW1/Q7tQLhtNSVWKJ92L\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 339,
+          "tcId" : 442,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023079b95c013b0472de04d8faeec3b779c39fe729ea84fb554cd091c7178c2f054eabbc62c3e1cfbac2c2e69d7aa45d9072",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0450a438c98ee94025ce13e27d36b8280d4843585836eb47011a070cd77729245684a0db31fde980620349c796832b2c6cbdb72dba9f3f9cc878559f50b6bd1290f10a6bccbc1eeef7708b1b72059022987979e35221c51259f337c7288a2f86bc",
         "wx" : "50a438c98ee94025ce13e27d36b8280d4843585836eb47011a070cd77729245684a0db31fde980620349c796832b2c6c",
-        "wy" : "0bdb72dba9f3f9cc878559f50b6bd1290f10a6bccbc1eeef7708b1b72059022987979e35221c51259f337c7288a2f86bc"
+        "wy" : "00bdb72dba9f3f9cc878559f50b6bd1290f10a6bccbc1eeef7708b1b72059022987979e35221c51259f337c7288a2f86bc"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000450a438c98ee94025ce13e27d36b8280d4843585836eb47011a070cd77729245684a0db31fde980620349c796832b2c6cbdb72dba9f3f9cc878559f50b6bd1290f10a6bccbc1eeef7708b1b72059022987979e35221c51259f337c7288a2f86bc",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEUKQ4yY7pQCXOE+J9NrgoDUhDWFg260cB\nGgcM13cpJFaEoNsx/emAYgNJx5aDKyxsvbctup8/nMh4VZ9Qtr0SkPEKa8y8Hu73\ncIsbcgWQIph5eeNSIcUSWfM3xyiKL4a8\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000450a438c98ee94025ce13e27d36b8280d4843585836eb47011a070cd77729245684a0db31fde980620349c796832b2c6cbdb72dba9f3f9cc878559f50b6bd1290f10a6bccbc1eeef7708b1b72059022987979e35221c51259f337c7288a2f86bc",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEUKQ4yY7pQCXOE+J9NrgoDUhDWFg260cB\nGgcM13cpJFaEoNsx/emAYgNJx5aDKyxsvbctup8/nMh4VZ9Qtr0SkPEKa8y8Hu73\ncIsbcgWQIph5eeNSIcUSWfM3xyiKL4a8\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 340,
+          "tcId" : 443,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100bfd40d0caa4d9d42381f3d72a25683f52b03a1ed96fb72d03f08dcb9a8bc8f23c1a459deab03bcd39396c0d1e9053c81",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "044d3fc5dcfaf741113cda3ce2f8dff4c912143e4d36314c361d7ed5656b68448bcca114ba9e8124281234660b7726ddcd680ddfef7ea07bfbcede10803d38d7211631ca11466078819eb66e11921ab7ffa3c4560c732e77595fd408e917dd9afc",
         "wx" : "4d3fc5dcfaf741113cda3ce2f8dff4c912143e4d36314c361d7ed5656b68448bcca114ba9e8124281234660b7726ddcd",
         "wy" : "680ddfef7ea07bfbcede10803d38d7211631ca11466078819eb66e11921ab7ffa3c4560c732e77595fd408e917dd9afc"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200044d3fc5dcfaf741113cda3ce2f8dff4c912143e4d36314c361d7ed5656b68448bcca114ba9e8124281234660b7726ddcd680ddfef7ea07bfbcede10803d38d7211631ca11466078819eb66e11921ab7ffa3c4560c732e77595fd408e917dd9afc",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAETT/F3Pr3QRE82jzi+N/0yRIUPk02MUw2\nHX7VZWtoRIvMoRS6noEkKBI0Zgt3Jt3NaA3f736ge/vO3hCAPTjXIRYxyhFGYHiB\nnrZuEZIat/+jxFYMcy53WV/UCOkX3Zr8\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200044d3fc5dcfaf741113cda3ce2f8dff4c912143e4d36314c361d7ed5656b68448bcca114ba9e8124281234660b7726ddcd680ddfef7ea07bfbcede10803d38d7211631ca11466078819eb66e11921ab7ffa3c4560c732e77595fd408e917dd9afc",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAETT/F3Pr3QRE82jzi+N/0yRIUPk02MUw2\nHX7VZWtoRIvMoRS6noEkKBI0Zgt3Jt3NaA3f736ge/vO3hCAPTjXIRYxyhFGYHiB\nnrZuEZIat/+jxFYMcy53WV/UCOkX3Zr8\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 341,
+          "tcId" : 444,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02304c7d219db9af94ce7fffffffffffffffffffffffffffffffef15cf1058c8d8ba1e634c4122db95ec1facd4bb13ebf09a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0463d65cdfeb1f1a42000f43bd1ddd130537a7b6f635e8d2bd81a97da168221183da433ca78429fd2b33c5f94895a9c13aa9d1d5ea328725653a5a9d00f85a5516236f3b1428a8629287d3b0487a2e82dd57f93bb2aa3d9783dc74131e13756034",
         "wx" : "63d65cdfeb1f1a42000f43bd1ddd130537a7b6f635e8d2bd81a97da168221183da433ca78429fd2b33c5f94895a9c13a",
-        "wy" : "0a9d1d5ea328725653a5a9d00f85a5516236f3b1428a8629287d3b0487a2e82dd57f93bb2aa3d9783dc74131e13756034"
+        "wy" : "00a9d1d5ea328725653a5a9d00f85a5516236f3b1428a8629287d3b0487a2e82dd57f93bb2aa3d9783dc74131e13756034"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000463d65cdfeb1f1a42000f43bd1ddd130537a7b6f635e8d2bd81a97da168221183da433ca78429fd2b33c5f94895a9c13aa9d1d5ea328725653a5a9d00f85a5516236f3b1428a8629287d3b0487a2e82dd57f93bb2aa3d9783dc74131e13756034",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEY9Zc3+sfGkIAD0O9Hd0TBTentvY16NK9\ngal9oWgiEYPaQzynhCn9KzPF+UiVqcE6qdHV6jKHJWU6Wp0A+FpVFiNvOxQoqGKS\nh9OwSHougt1X+Tuyqj2Xg9x0Ex4TdWA0\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000463d65cdfeb1f1a42000f43bd1ddd130537a7b6f635e8d2bd81a97da168221183da433ca78429fd2b33c5f94895a9c13aa9d1d5ea328725653a5a9d00f85a5516236f3b1428a8629287d3b0487a2e82dd57f93bb2aa3d9783dc74131e13756034",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEY9Zc3+sfGkIAD0O9Hd0TBTentvY16NK9\ngal9oWgiEYPaQzynhCn9KzPF+UiVqcE6qdHV6jKHJWU6Wp0A+FpVFiNvOxQoqGKS\nh9OwSHougt1X+Tuyqj2Xg9x0Ex4TdWA0\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 342,
+          "tcId" : 445,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100d219db9af94ce7ffffffffffffffffffffffffffffffffffd189bdb6d9ef7be8504ca374756ea5b8f15e44067d209b9b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04d22c9c348b9745711f57debac3a07df90a527c06bd02a8454f41437d54224e071698f03fdc64b1d652414edc3f2239c49ae9812a4b92f099d6659a659691768d57e530ed3c91d5455781605850997a58221f22a2451c3932470606c23f3ab1b8",
-        "wx" : "0d22c9c348b9745711f57debac3a07df90a527c06bd02a8454f41437d54224e071698f03fdc64b1d652414edc3f2239c4",
-        "wy" : "09ae9812a4b92f099d6659a659691768d57e530ed3c91d5455781605850997a58221f22a2451c3932470606c23f3ab1b8"
+        "wx" : "00d22c9c348b9745711f57debac3a07df90a527c06bd02a8454f41437d54224e071698f03fdc64b1d652414edc3f2239c4",
+        "wy" : "009ae9812a4b92f099d6659a659691768d57e530ed3c91d5455781605850997a58221f22a2451c3932470606c23f3ab1b8"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004d22c9c348b9745711f57debac3a07df90a527c06bd02a8454f41437d54224e071698f03fdc64b1d652414edc3f2239c49ae9812a4b92f099d6659a659691768d57e530ed3c91d5455781605850997a58221f22a2451c3932470606c23f3ab1b8",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE0iycNIuXRXEfV966w6B9+QpSfAa9AqhF\nT0FDfVQiTgcWmPA/3GSx1lJBTtw/IjnEmumBKkuS8JnWZZpllpF2jVflMO08kdVF\nV4FgWFCZelgiHyKiRRw5MkcGBsI/OrG4\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004d22c9c348b9745711f57debac3a07df90a527c06bd02a8454f41437d54224e071698f03fdc64b1d652414edc3f2239c49ae9812a4b92f099d6659a659691768d57e530ed3c91d5455781605850997a58221f22a2451c3932470606c23f3ab1b8",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE0iycNIuXRXEfV966w6B9+QpSfAa9AqhF\nT0FDfVQiTgcWmPA/3GSx1lJBTtw/IjnEmumBKkuS8JnWZZpllpF2jVflMO08kdVF\nV4FgWFCZelgiHyKiRRw5MkcGBsI/OrG4\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 343,
+          "tcId" : 446,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100a433b735f299cfffffffffffffffffffffffffffffffffffdbb02debbfa7c9f1487f3936a22ca3f6f5d06ea22d7c0dc3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0431f05c0c29e9da49aa2fbbedee770c68d10f85e7f77e72ac3cfa9c8623a2bb42eeb2f24ac8f2aef7ab0c4b47823140035bb32fc1ec04bbff5eab96e070c938ba1b53fe63970f649ae02e2a4ada420a249b6f7c525e2c4b9b0d5562ae26f2278c",
         "wx" : "31f05c0c29e9da49aa2fbbedee770c68d10f85e7f77e72ac3cfa9c8623a2bb42eeb2f24ac8f2aef7ab0c4b4782314003",
         "wy" : "5bb32fc1ec04bbff5eab96e070c938ba1b53fe63970f649ae02e2a4ada420a249b6f7c525e2c4b9b0d5562ae26f2278c"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000431f05c0c29e9da49aa2fbbedee770c68d10f85e7f77e72ac3cfa9c8623a2bb42eeb2f24ac8f2aef7ab0c4b47823140035bb32fc1ec04bbff5eab96e070c938ba1b53fe63970f649ae02e2a4ada420a249b6f7c525e2c4b9b0d5562ae26f2278c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEMfBcDCnp2kmqL7vt7ncMaNEPhef3fnKs\nPPqchiOiu0LusvJKyPKu96sMS0eCMUADW7MvwewEu/9eq5bgcMk4uhtT/mOXD2Sa\n4C4qStpCCiSbb3xSXixLmw1VYq4m8ieM\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000431f05c0c29e9da49aa2fbbedee770c68d10f85e7f77e72ac3cfa9c8623a2bb42eeb2f24ac8f2aef7ab0c4b47823140035bb32fc1ec04bbff5eab96e070c938ba1b53fe63970f649ae02e2a4ada420a249b6f7c525e2c4b9b0d5562ae26f2278c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEMfBcDCnp2kmqL7vt7ncMaNEPhef3fnKs\nPPqchiOiu0LusvJKyPKu96sMS0eCMUADW7MvwewEu/9eq5bgcMk4uhtT/mOXD2Sa\n4C4qStpCCiSbb3xSXixLmw1VYq4m8ieM\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 344,
+          "tcId" : 447,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100b9af94ce7fffffffffffffffffffffffffffffffffffffffd6efeefc876c9f23217b443c80637ef939e911219f96c179",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04bc26eec95e26c980bc0334264cbcfc26b897c3571c96ce9ab2a67b49bb0f26a6272fdc27806d7a4c572ae0f78149f1f3c8af5f41b99d2066018165513fb3b55e4255dcd0659647ed55e1e2602cae4efbd6eae1dfe2ff63e2c748d4acc7430139",
-        "wx" : "0bc26eec95e26c980bc0334264cbcfc26b897c3571c96ce9ab2a67b49bb0f26a6272fdc27806d7a4c572ae0f78149f1f3",
-        "wy" : "0c8af5f41b99d2066018165513fb3b55e4255dcd0659647ed55e1e2602cae4efbd6eae1dfe2ff63e2c748d4acc7430139"
+        "wx" : "00bc26eec95e26c980bc0334264cbcfc26b897c3571c96ce9ab2a67b49bb0f26a6272fdc27806d7a4c572ae0f78149f1f3",
+        "wy" : "00c8af5f41b99d2066018165513fb3b55e4255dcd0659647ed55e1e2602cae4efbd6eae1dfe2ff63e2c748d4acc7430139"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004bc26eec95e26c980bc0334264cbcfc26b897c3571c96ce9ab2a67b49bb0f26a6272fdc27806d7a4c572ae0f78149f1f3c8af5f41b99d2066018165513fb3b55e4255dcd0659647ed55e1e2602cae4efbd6eae1dfe2ff63e2c748d4acc7430139",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvCbuyV4myYC8AzQmTLz8JriXw1ccls6a\nsqZ7SbsPJqYnL9wngG16TFcq4PeBSfHzyK9fQbmdIGYBgWVRP7O1XkJV3NBllkft\nVeHiYCyuTvvW6uHf4v9j4sdI1KzHQwE5\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004bc26eec95e26c980bc0334264cbcfc26b897c3571c96ce9ab2a67b49bb0f26a6272fdc27806d7a4c572ae0f78149f1f3c8af5f41b99d2066018165513fb3b55e4255dcd0659647ed55e1e2602cae4efbd6eae1dfe2ff63e2c748d4acc7430139",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEvCbuyV4myYC8AzQmTLz8JriXw1ccls6a\nsqZ7SbsPJqYnL9wngG16TFcq4PeBSfHzyK9fQbmdIGYBgWVRP7O1XkJV3NBllkft\nVeHiYCyuTvvW6uHf4v9j4sdI1KzHQwE5\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 345,
+          "tcId" : 448,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100a276276276276276276276276276276276276276276276273d7228d4f84b769be0fd57b97e4c1ebcae9a5f635e80e9df",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "046fa0964dd054250af176891c0c822b013b70f059c347172cafc6b36cd16cf3b0f9d19f2598bd0d580ac16c46acb167d4375bef701c002dcc040fd54824b14cc2df0154eb20e74464e1fe7b833426dd7d636bf2d79603fdde5ddaab23ab0cf426",
         "wx" : "6fa0964dd054250af176891c0c822b013b70f059c347172cafc6b36cd16cf3b0f9d19f2598bd0d580ac16c46acb167d4",
         "wy" : "375bef701c002dcc040fd54824b14cc2df0154eb20e74464e1fe7b833426dd7d636bf2d79603fdde5ddaab23ab0cf426"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200046fa0964dd054250af176891c0c822b013b70f059c347172cafc6b36cd16cf3b0f9d19f2598bd0d580ac16c46acb167d4375bef701c002dcc040fd54824b14cc2df0154eb20e74464e1fe7b833426dd7d636bf2d79603fdde5ddaab23ab0cf426",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEb6CWTdBUJQrxdokcDIIrATtw8FnDRxcs\nr8azbNFs87D50Z8lmL0NWArBbEassWfUN1vvcBwALcwED9VIJLFMwt8BVOsg50Rk\n4f57gzQm3X1ja/LXlgP93l3aqyOrDPQm\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200046fa0964dd054250af176891c0c822b013b70f059c347172cafc6b36cd16cf3b0f9d19f2598bd0d580ac16c46acb167d4375bef701c002dcc040fd54824b14cc2df0154eb20e74464e1fe7b833426dd7d636bf2d79603fdde5ddaab23ab0cf426",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEb6CWTdBUJQrxdokcDIIrATtw8FnDRxcs\nr8azbNFs87D50Z8lmL0NWArBbEassWfUN1vvcBwALcwED9VIJLFMwt8BVOsg50Rk\n4f57gzQm3X1ja/LXlgP93l3aqyOrDPQm\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 346,
+          "tcId" : 449,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023073333333333333333333333333333333333333333333333316e4d9f42d4eca22df403a0c578b86f0a9a93fe89995c7ed",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04baa4e712ee0786a5ab0e5a5dafdcdcf87b38830ab2ec86faedda9fdf65332f6a9688269412f050356530d4664a7fb8cdecc46a901b016e6bb8a336ad9aa6f19abf9ada69705d1c905beafb95a44f52af43de4bf80c050cf996b7796dfcee8e1b",
-        "wx" : "0baa4e712ee0786a5ab0e5a5dafdcdcf87b38830ab2ec86faedda9fdf65332f6a9688269412f050356530d4664a7fb8cd",
-        "wy" : "0ecc46a901b016e6bb8a336ad9aa6f19abf9ada69705d1c905beafb95a44f52af43de4bf80c050cf996b7796dfcee8e1b"
+        "wx" : "00baa4e712ee0786a5ab0e5a5dafdcdcf87b38830ab2ec86faedda9fdf65332f6a9688269412f050356530d4664a7fb8cd",
+        "wy" : "00ecc46a901b016e6bb8a336ad9aa6f19abf9ada69705d1c905beafb95a44f52af43de4bf80c050cf996b7796dfcee8e1b"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004baa4e712ee0786a5ab0e5a5dafdcdcf87b38830ab2ec86faedda9fdf65332f6a9688269412f050356530d4664a7fb8cdecc46a901b016e6bb8a336ad9aa6f19abf9ada69705d1c905beafb95a44f52af43de4bf80c050cf996b7796dfcee8e1b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEuqTnEu4HhqWrDlpdr9zc+Hs4gwqy7Ib6\n7dqf32UzL2qWiCaUEvBQNWUw1GZKf7jN7MRqkBsBbmu4ozatmqbxmr+a2mlwXRyQ\nW+r7laRPUq9D3kv4DAUM+Za3eW387o4b\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004baa4e712ee0786a5ab0e5a5dafdcdcf87b38830ab2ec86faedda9fdf65332f6a9688269412f050356530d4664a7fb8cdecc46a901b016e6bb8a336ad9aa6f19abf9ada69705d1c905beafb95a44f52af43de4bf80c050cf996b7796dfcee8e1b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEuqTnEu4HhqWrDlpdr9zc+Hs4gwqy7Ib6\n7dqf32UzL2qWiCaUEvBQNWUw1GZKf7jN7MRqkBsBbmu4ozatmqbxmr+a2mlwXRyQ\nW+r7laRPUq9D3kv4DAUM+Za3eW387o4b\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 347,
+          "tcId" : 450,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02307fffffffffffffffffffffffffffffffffffffffffffffffda4233abf824c93f90115e76db206fa7489d6647332e1ba3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0481e78a52ae0695583f7a601ab9b6fbfaf434f2befa1f8c833d59deb627a927c2f42d48eb617fe042f584e105c23c2317cf22d565f5f3b425ef7937df629b6864dac71264b288c1a987210f523071319ce3f64411910ac23765c4266e615112bc",
-        "wx" : "081e78a52ae0695583f7a601ab9b6fbfaf434f2befa1f8c833d59deb627a927c2f42d48eb617fe042f584e105c23c2317",
-        "wy" : "0cf22d565f5f3b425ef7937df629b6864dac71264b288c1a987210f523071319ce3f64411910ac23765c4266e615112bc"
+        "wx" : "0081e78a52ae0695583f7a601ab9b6fbfaf434f2befa1f8c833d59deb627a927c2f42d48eb617fe042f584e105c23c2317",
+        "wy" : "00cf22d565f5f3b425ef7937df629b6864dac71264b288c1a987210f523071319ce3f64411910ac23765c4266e615112bc"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000481e78a52ae0695583f7a601ab9b6fbfaf434f2befa1f8c833d59deb627a927c2f42d48eb617fe042f584e105c23c2317cf22d565f5f3b425ef7937df629b6864dac71264b288c1a987210f523071319ce3f64411910ac23765c4266e615112bc",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgeeKUq4GlVg/emAaubb7+vQ08r76H4yD\nPVnetiepJ8L0LUjrYX/gQvWE4QXCPCMXzyLVZfXztCXveTffYptoZNrHEmSyiMGp\nhyEPUjBxMZzj9kQRkQrCN2XEJm5hURK8\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000481e78a52ae0695583f7a601ab9b6fbfaf434f2befa1f8c833d59deb627a927c2f42d48eb617fe042f584e105c23c2317cf22d565f5f3b425ef7937df629b6864dac71264b288c1a987210f523071319ce3f64411910ac23765c4266e615112bc",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgeeKUq4GlVg/emAaubb7+vQ08r76H4yD\nPVnetiepJ8L0LUjrYX/gQvWE4QXCPCMXzyLVZfXztCXveTffYptoZNrHEmSyiMGp\nhyEPUjBxMZzj9kQRkQrCN2XEJm5hURK8\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 348,
+          "tcId" : 451,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02303fffffffffffffffffffffffffffffffffffffffffffffffe3b1a6c0fa1b96efac0d06d9245853bd76760cb5666294bb",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0441fa8765b19d3108031e28c9a781a385c9c10b2bfd42e6437e5c4bd711cf2a031750847d17a82f9376a30ae182a6d6e71c20af96324147d4155a4d0c867ca8e36eba204fbed2087e0fcbdc8baabe07bb3123f9f7259e771cd9f1ad17d1a23787",
         "wx" : "41fa8765b19d3108031e28c9a781a385c9c10b2bfd42e6437e5c4bd711cf2a031750847d17a82f9376a30ae182a6d6e7",
         "wy" : "1c20af96324147d4155a4d0c867ca8e36eba204fbed2087e0fcbdc8baabe07bb3123f9f7259e771cd9f1ad17d1a23787"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000441fa8765b19d3108031e28c9a781a385c9c10b2bfd42e6437e5c4bd711cf2a031750847d17a82f9376a30ae182a6d6e71c20af96324147d4155a4d0c867ca8e36eba204fbed2087e0fcbdc8baabe07bb3123f9f7259e771cd9f1ad17d1a23787",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEQfqHZbGdMQgDHijJp4GjhcnBCyv9QuZD\nflxL1xHPKgMXUIR9F6gvk3ajCuGCptbnHCCvljJBR9QVWk0Mhnyo4266IE++0gh+\nD8vci6q+B7sxI/n3JZ53HNnxrRfRojeH\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000441fa8765b19d3108031e28c9a781a385c9c10b2bfd42e6437e5c4bd711cf2a031750847d17a82f9376a30ae182a6d6e71c20af96324147d4155a4d0c867ca8e36eba204fbed2087e0fcbdc8baabe07bb3123f9f7259e771cd9f1ad17d1a23787",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEQfqHZbGdMQgDHijJp4GjhcnBCyv9QuZD\nflxL1xHPKgMXUIR9F6gvk3ajCuGCptbnHCCvljJBR9QVWk0Mhnyo4266IE++0gh+\nD8vci6q+B7sxI/n3JZ53HNnxrRfRojeH\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 349,
+          "tcId" : 452,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100dfea06865526cea11c0f9eb9512b41fa9581d0f6cb7db9680336151dce79de818cdf33c879da322740416d1e5ae532fa",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04e585a067d6dff37ae7f17f81583119b61291597345f107acffe237a08f4886d4fdf94fe63182e6143c99be25a7b7d86b572c1e06dd2c7b94b873f0578fcb2b99d60e246e51245d0804edd44b32f0f000c8f8f88f1d4a65fea51dbbb4ab1e2823",
-        "wx" : "0e585a067d6dff37ae7f17f81583119b61291597345f107acffe237a08f4886d4fdf94fe63182e6143c99be25a7b7d86b",
+        "wx" : "00e585a067d6dff37ae7f17f81583119b61291597345f107acffe237a08f4886d4fdf94fe63182e6143c99be25a7b7d86b",
         "wy" : "572c1e06dd2c7b94b873f0578fcb2b99d60e246e51245d0804edd44b32f0f000c8f8f88f1d4a65fea51dbbb4ab1e2823"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004e585a067d6dff37ae7f17f81583119b61291597345f107acffe237a08f4886d4fdf94fe63182e6143c99be25a7b7d86b572c1e06dd2c7b94b873f0578fcb2b99d60e246e51245d0804edd44b32f0f000c8f8f88f1d4a65fea51dbbb4ab1e2823",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE5YWgZ9bf83rn8X+BWDEZthKRWXNF8Qes\n/+I3oI9IhtT9+U/mMYLmFDyZviWnt9hrVyweBt0se5S4c/BXj8srmdYOJG5RJF0I\nBO3USzLw8ADI+PiPHUpl/qUdu7SrHigj\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004e585a067d6dff37ae7f17f81583119b61291597345f107acffe237a08f4886d4fdf94fe63182e6143c99be25a7b7d86b572c1e06dd2c7b94b873f0578fcb2b99d60e246e51245d0804edd44b32f0f000c8f8f88f1d4a65fea51dbbb4ab1e2823",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE5YWgZ9bf83rn8X+BWDEZthKRWXNF8Qes\n/+I3oI9IhtT9+U/mMYLmFDyZviWnt9hrVyweBt0se5S4c/BXj8srmdYOJG5RJF0I\nBO3USzLw8ADI+PiPHUpl/qUdu7SrHigj\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 350,
+          "tcId" : 453,
           "comment" : "point duplication during verification",
-          "msg" : "313233343030",
-          "sig" : "3065023100b37699e0d518a4d370dbdaaaea3788850fa03f8186d1f78fdfbae6540aa670b31c8ada0fff3e737bd69520560fe0ce60023064adb4d51a93f96bed4665de2d4e1169cc95819ec6e9333edfd5c07ca134ceef7c95957b719ae349fc439eaa49fbbe34",
-          "result" : "valid",
           "flags" : [
             "PointDuplication"
-          ]
+          ],
+          "msg" : "313233343030",
+          "sig" : "3065023100b37699e0d518a4d370dbdaaaea3788850fa03f8186d1f78fdfbae6540aa670b31c8ada0fff3e737bd69520560fe0ce60023064adb4d51a93f96bed4665de2d4e1169cc95819ec6e9333edfd5c07ca134ceef7c95957b719ae349fc439eaa49fbbe34",
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04e585a067d6dff37ae7f17f81583119b61291597345f107acffe237a08f4886d4fdf94fe63182e6143c99be25a7b7d86ba8d3e1f922d3846b478c0fa87034d46629f1db91aedba2f7fb122bb4cd0f0ffe3707076fe2b59a015ae2444c54e1d7dc",
-        "wx" : "0e585a067d6dff37ae7f17f81583119b61291597345f107acffe237a08f4886d4fdf94fe63182e6143c99be25a7b7d86b",
-        "wy" : "0a8d3e1f922d3846b478c0fa87034d46629f1db91aedba2f7fb122bb4cd0f0ffe3707076fe2b59a015ae2444c54e1d7dc"
+        "wx" : "00e585a067d6dff37ae7f17f81583119b61291597345f107acffe237a08f4886d4fdf94fe63182e6143c99be25a7b7d86b",
+        "wy" : "00a8d3e1f922d3846b478c0fa87034d46629f1db91aedba2f7fb122bb4cd0f0ffe3707076fe2b59a015ae2444c54e1d7dc"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004e585a067d6dff37ae7f17f81583119b61291597345f107acffe237a08f4886d4fdf94fe63182e6143c99be25a7b7d86ba8d3e1f922d3846b478c0fa87034d46629f1db91aedba2f7fb122bb4cd0f0ffe3707076fe2b59a015ae2444c54e1d7dc",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE5YWgZ9bf83rn8X+BWDEZthKRWXNF8Qes\n/+I3oI9IhtT9+U/mMYLmFDyZviWnt9hrqNPh+SLThGtHjA+ocDTUZinx25Gu26L3\n+xIrtM0PD/43Bwdv4rWaAVriRExU4dfc\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004e585a067d6dff37ae7f17f81583119b61291597345f107acffe237a08f4886d4fdf94fe63182e6143c99be25a7b7d86ba8d3e1f922d3846b478c0fa87034d46629f1db91aedba2f7fb122bb4cd0f0ffe3707076fe2b59a015ae2444c54e1d7dc",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE5YWgZ9bf83rn8X+BWDEZthKRWXNF8Qes\n/+I3oI9IhtT9+U/mMYLmFDyZviWnt9hrqNPh+SLThGtHjA+ocDTUZinx25Gu26L3\n+xIrtM0PD/43Bwdv4rWaAVriRExU4dfc\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 351,
+          "tcId" : 454,
           "comment" : "duplication bug",
-          "msg" : "313233343030",
-          "sig" : "3065023100b37699e0d518a4d370dbdaaaea3788850fa03f8186d1f78fdfbae6540aa670b31c8ada0fff3e737bd69520560fe0ce60023064adb4d51a93f96bed4665de2d4e1169cc95819ec6e9333edfd5c07ca134ceef7c95957b719ae349fc439eaa49fbbe34",
-          "result" : "invalid",
           "flags" : [
             "PointDuplication"
-          ]
+          ],
+          "msg" : "313233343030",
+          "sig" : "3065023100b37699e0d518a4d370dbdaaaea3788850fa03f8186d1f78fdfbae6540aa670b31c8ada0fff3e737bd69520560fe0ce60023064adb4d51a93f96bed4665de2d4e1169cc95819ec6e9333edfd5c07ca134ceef7c95957b719ae349fc439eaa49fbbe34",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04b4d78cccbced8065c0ebdc330b4670ec99309273e442b9be341196c1043e4441fc57b914085595bfc755c64fc409f0ba01fee31cbbbaed5c1323f09c87df9b0712c12e99733fa23ef91b4e6ca666b09dd7540ebf1068a15155bc069e3d595c8c",
-        "wx" : "0b4d78cccbced8065c0ebdc330b4670ec99309273e442b9be341196c1043e4441fc57b914085595bfc755c64fc409f0ba",
-        "wy" : "1fee31cbbbaed5c1323f09c87df9b0712c12e99733fa23ef91b4e6ca666b09dd7540ebf1068a15155bc069e3d595c8c"
+        "wx" : "00b4d78cccbced8065c0ebdc330b4670ec99309273e442b9be341196c1043e4441fc57b914085595bfc755c64fc409f0ba",
+        "wy" : "01fee31cbbbaed5c1323f09c87df9b0712c12e99733fa23ef91b4e6ca666b09dd7540ebf1068a15155bc069e3d595c8c"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004b4d78cccbced8065c0ebdc330b4670ec99309273e442b9be341196c1043e4441fc57b914085595bfc755c64fc409f0ba01fee31cbbbaed5c1323f09c87df9b0712c12e99733fa23ef91b4e6ca666b09dd7540ebf1068a15155bc069e3d595c8c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEtNeMzLztgGXA69wzC0Zw7JkwknPkQrm+\nNBGWwQQ+REH8V7kUCFWVv8dVxk/ECfC6Af7jHLu67VwTI/Cch9+bBxLBLplzP6I+\n+RtObKZmsJ3XVA6/EGihUVW8Bp49WVyM\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004b4d78cccbced8065c0ebdc330b4670ec99309273e442b9be341196c1043e4441fc57b914085595bfc755c64fc409f0ba01fee31cbbbaed5c1323f09c87df9b0712c12e99733fa23ef91b4e6ca666b09dd7540ebf1068a15155bc069e3d595c8c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEtNeMzLztgGXA69wzC0Zw7JkwknPkQrm+\nNBGWwQQ+REH8V7kUCFWVv8dVxk/ECfC6Af7jHLu67VwTI/Cch9+bBxLBLplzP6I+\n+RtObKZmsJ3XVA6/EGihUVW8Bp49WVyM\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 352,
+          "tcId" : 455,
           "comment" : "point with x-coordinate 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3035020101023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "046e3c68be53aade81ef89e096d841e2845a23331e7ec8a6a839d58d07fa016c0973ed75de4f99177bfdc74db566e9d15a4972ea08e577ce1f61c13a6ca1bad1deef2982ee01a2826f002b769f2c46098d3baff068a405d09ca3840d2fafe4e46e",
         "wx" : "6e3c68be53aade81ef89e096d841e2845a23331e7ec8a6a839d58d07fa016c0973ed75de4f99177bfdc74db566e9d15a",
         "wy" : "4972ea08e577ce1f61c13a6ca1bad1deef2982ee01a2826f002b769f2c46098d3baff068a405d09ca3840d2fafe4e46e"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200046e3c68be53aade81ef89e096d841e2845a23331e7ec8a6a839d58d07fa016c0973ed75de4f99177bfdc74db566e9d15a4972ea08e577ce1f61c13a6ca1bad1deef2982ee01a2826f002b769f2c46098d3baff068a405d09ca3840d2fafe4e46e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEbjxovlOq3oHvieCW2EHihFojMx5+yKao\nOdWNB/oBbAlz7XXeT5kXe/3HTbVm6dFaSXLqCOV3zh9hwTpsobrR3u8pgu4BooJv\nACt2nyxGCY07r/BopAXQnKOEDS+v5ORu\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200046e3c68be53aade81ef89e096d841e2845a23331e7ec8a6a839d58d07fa016c0973ed75de4f99177bfdc74db566e9d15a4972ea08e577ce1f61c13a6ca1bad1deef2982ee01a2826f002b769f2c46098d3baff068a405d09ca3840d2fafe4e46e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEbjxovlOq3oHvieCW2EHihFojMx5+yKao\nOdWNB/oBbAlz7XXeT5kXe/3HTbVm6dFaSXLqCOV3zh9hwTpsobrR3u8pgu4BooJv\nACt2nyxGCY07r/BopAXQnKOEDS+v5ORu\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 353,
+          "tcId" : 456,
           "comment" : "point with x-coordinate 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023101000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000023033333333333333333333333333333333333333333333333327e0a919fda4a2c644d202bd41bcee4bc8fc05155c276eb0",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04b101cdb3eba20e112adbb4bbd2cb479a69e590a44ea902631832abfab8af2c3041b3df7f1665b2c6eb533f546217100a1a61aa9951578ad4f00ae17339a8a6f1359bbd0ac355678ed4df21338f08763c1d3702ec132b634c7bcc0118efb1d0dd",
-        "wx" : "0b101cdb3eba20e112adbb4bbd2cb479a69e590a44ea902631832abfab8af2c3041b3df7f1665b2c6eb533f546217100a",
+        "wx" : "00b101cdb3eba20e112adbb4bbd2cb479a69e590a44ea902631832abfab8af2c3041b3df7f1665b2c6eb533f546217100a",
         "wy" : "1a61aa9951578ad4f00ae17339a8a6f1359bbd0ac355678ed4df21338f08763c1d3702ec132b634c7bcc0118efb1d0dd"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004b101cdb3eba20e112adbb4bbd2cb479a69e590a44ea902631832abfab8af2c3041b3df7f1665b2c6eb533f546217100a1a61aa9951578ad4f00ae17339a8a6f1359bbd0ac355678ed4df21338f08763c1d3702ec132b634c7bcc0118efb1d0dd",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEsQHNs+uiDhEq27S70stHmmnlkKROqQJj\nGDKr+rivLDBBs99/FmWyxutTP1RiFxAKGmGqmVFXitTwCuFzOaim8TWbvQrDVWeO\n1N8hM48IdjwdNwLsEytjTHvMARjvsdDd\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004b101cdb3eba20e112adbb4bbd2cb479a69e590a44ea902631832abfab8af2c3041b3df7f1665b2c6eb533f546217100a1a61aa9951578ad4f00ae17339a8a6f1359bbd0ac355678ed4df21338f08763c1d3702ec132b634c7bcc0118efb1d0dd",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEsQHNs+uiDhEq27S70stHmmnlkKROqQJj\nGDKr+rivLDBBs99/FmWyxutTP1RiFxAKGmGqmVFXitTwCuFzOaim8TWbvQrDVWeO\n1N8hM48IdjwdNwLsEytjTHvMARjvsdDd\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 354,
+          "tcId" : 457,
           "comment" : "comparison with point at infinity ",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023033333333333333333333333333333333333333333333333327e0a919fda4a2c644d202bd41bcee4bc8fc05155c276eb0",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "046761044a040a4979db269b4a377e42f11b4be0ce24611f677674dcf770f5887ca4db565303283809e6d65f7fc6bc273605c7daa403fca53549f75ff3372909642d02b7fdcac1e68242814d6e925ab01a80836cfbb35581960079e2fb44c0d186",
         "wx" : "6761044a040a4979db269b4a377e42f11b4be0ce24611f677674dcf770f5887ca4db565303283809e6d65f7fc6bc2736",
-        "wy" : "5c7daa403fca53549f75ff3372909642d02b7fdcac1e68242814d6e925ab01a80836cfbb35581960079e2fb44c0d186"
+        "wy" : "05c7daa403fca53549f75ff3372909642d02b7fdcac1e68242814d6e925ab01a80836cfbb35581960079e2fb44c0d186"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200046761044a040a4979db269b4a377e42f11b4be0ce24611f677674dcf770f5887ca4db565303283809e6d65f7fc6bc273605c7daa403fca53549f75ff3372909642d02b7fdcac1e68242814d6e925ab01a80836cfbb35581960079e2fb44c0d186",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEZ2EESgQKSXnbJptKN35C8RtL4M4kYR9n\ndnTc93D1iHyk21ZTAyg4CebWX3/GvCc2BcfapAP8pTVJ91/zNykJZC0Ct/3KweaC\nQoFNbpJasBqAg2z7s1WBlgB54vtEwNGG\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200046761044a040a4979db269b4a377e42f11b4be0ce24611f677674dcf770f5887ca4db565303283809e6d65f7fc6bc273605c7daa403fca53549f75ff3372909642d02b7fdcac1e68242814d6e925ab01a80836cfbb35581960079e2fb44c0d186",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEZ2EESgQKSXnbJptKN35C8RtL4M4kYR9n\ndnTc93D1iHyk21ZTAyg4CebWX3/GvCc2BcfapAP8pTVJ91/zNykJZC0Ct/3KweaC\nQoFNbpJasBqAg2z7s1WBlgB54vtEwNGG\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 355,
+          "tcId" : 458,
           "comment" : "extreme value for k and edgecase s",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023008d999057ba3d2d969260045c55b97f089025959a6f434d651d207d19fb96e9e4fe0e86ebe0e64f85b96a9c75295df61023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "046922c591502f01046fee5617bf16496f58398822e69afa8335308f36c09a8ed437209fefcffbbdf0a4876b35a3c7ab2655854db825b94b3f27e5f892d3bbb6c7240ec922894dd3598e91fcc6134a2b8fd154e1790466906206f0f623416e63a1",
         "wx" : "6922c591502f01046fee5617bf16496f58398822e69afa8335308f36c09a8ed437209fefcffbbdf0a4876b35a3c7ab26",
         "wy" : "55854db825b94b3f27e5f892d3bbb6c7240ec922894dd3598e91fcc6134a2b8fd154e1790466906206f0f623416e63a1"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200046922c591502f01046fee5617bf16496f58398822e69afa8335308f36c09a8ed437209fefcffbbdf0a4876b35a3c7ab2655854db825b94b3f27e5f892d3bbb6c7240ec922894dd3598e91fcc6134a2b8fd154e1790466906206f0f623416e63a1",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEaSLFkVAvAQRv7lYXvxZJb1g5iCLmmvqD\nNTCPNsCajtQ3IJ/vz/u98KSHazWjx6smVYVNuCW5Sz8n5fiS07u2xyQOySKJTdNZ\njpH8xhNKK4/RVOF5BGaQYgbw9iNBbmOh\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200046922c591502f01046fee5617bf16496f58398822e69afa8335308f36c09a8ed437209fefcffbbdf0a4876b35a3c7ab2655854db825b94b3f27e5f892d3bbb6c7240ec922894dd3598e91fcc6134a2b8fd154e1790466906206f0f623416e63a1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEaSLFkVAvAQRv7lYXvxZJb1g5iCLmmvqD\nNTCPNsCajtQ3IJ/vz/u98KSHazWjx6smVYVNuCW5Sz8n5fiS07u2xyQOySKJTdNZ\njpH8xhNKK4/RVOF5BGaQYgbw9iNBbmOh\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 356,
+          "tcId" : 459,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023008d999057ba3d2d969260045c55b97f089025959a6f434d651d207d19fb96e9e4fe0e86ebe0e64f85b96a9c75295df6102302492492492492492492492492492492492492492492492491c7be680477598d6c3716fabc13dcec86afd2833d41c2a7e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04892dac0e700fc29d1802d9a449a6f56b2172cb1b7d881013cd3b31c0edb052f2d340c8995a4477bcb9225fec15667233cc6c34ae17445444516fd8fd22ee83f79eb0771ebff6677ac5d4e089f87a1c72df957acb24492adcd7c3816b8e0c75b1",
-        "wx" : "0892dac0e700fc29d1802d9a449a6f56b2172cb1b7d881013cd3b31c0edb052f2d340c8995a4477bcb9225fec15667233",
-        "wy" : "0cc6c34ae17445444516fd8fd22ee83f79eb0771ebff6677ac5d4e089f87a1c72df957acb24492adcd7c3816b8e0c75b1"
+        "wx" : "00892dac0e700fc29d1802d9a449a6f56b2172cb1b7d881013cd3b31c0edb052f2d340c8995a4477bcb9225fec15667233",
+        "wy" : "00cc6c34ae17445444516fd8fd22ee83f79eb0771ebff6677ac5d4e089f87a1c72df957acb24492adcd7c3816b8e0c75b1"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004892dac0e700fc29d1802d9a449a6f56b2172cb1b7d881013cd3b31c0edb052f2d340c8995a4477bcb9225fec15667233cc6c34ae17445444516fd8fd22ee83f79eb0771ebff6677ac5d4e089f87a1c72df957acb24492adcd7c3816b8e0c75b1",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEiS2sDnAPwp0YAtmkSab1ayFyyxt9iBAT\nzTsxwO2wUvLTQMiZWkR3vLkiX+wVZnIzzGw0rhdEVERRb9j9Iu6D956wdx6/9md6\nxdTgifh6HHLflXrLJEkq3NfDgWuODHWx\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004892dac0e700fc29d1802d9a449a6f56b2172cb1b7d881013cd3b31c0edb052f2d340c8995a4477bcb9225fec15667233cc6c34ae17445444516fd8fd22ee83f79eb0771ebff6677ac5d4e089f87a1c72df957acb24492adcd7c3816b8e0c75b1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEiS2sDnAPwp0YAtmkSab1ayFyyxt9iBAT\nzTsxwO2wUvLTQMiZWkR3vLkiX+wVZnIzzGw0rhdEVERRb9j9Iu6D956wdx6/9md6\nxdTgifh6HHLflXrLJEkq3NfDgWuODHWx\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 357,
+          "tcId" : 460,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023008d999057ba3d2d969260045c55b97f089025959a6f434d651d207d19fb96e9e4fe0e86ebe0e64f85b96a9c75295df6102306666666666666666666666666666666666666666666666664fc15233fb49458c89a4057a8379dc9791f80a2ab84edd61",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401634117e6478ce0568b0a2469237bbac6ff096acb7e514072bf77123cb51ba0cc3e8d69284d534d8e6d1e876cecf22231e5ef04dc96762ce7d5ef3348ad1e241ac797ae3b630ea249afc5139af49b8ef68b32f812d6b514210363d498efc28c",
-        "wx" : "1634117e6478ce0568b0a2469237bbac6ff096acb7e514072bf77123cb51ba0cc3e8d69284d534d8e6d1e876cecf222",
+        "wx" : "01634117e6478ce0568b0a2469237bbac6ff096acb7e514072bf77123cb51ba0cc3e8d69284d534d8e6d1e876cecf222",
         "wy" : "31e5ef04dc96762ce7d5ef3348ad1e241ac797ae3b630ea249afc5139af49b8ef68b32f812d6b514210363d498efc28c"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000401634117e6478ce0568b0a2469237bbac6ff096acb7e514072bf77123cb51ba0cc3e8d69284d534d8e6d1e876cecf22231e5ef04dc96762ce7d5ef3348ad1e241ac797ae3b630ea249afc5139af49b8ef68b32f812d6b514210363d498efc28c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEAWNBF+ZHjOBWiwokaSN7usb/CWrLflFA\ncr93Ejy1G6DMPo1pKE1TTY5tHods7PIiMeXvBNyWdizn1e8zSK0eJBrHl647Yw6i\nSa/FE5r0m472izL4Eta1FCEDY9SY78KM\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000401634117e6478ce0568b0a2469237bbac6ff096acb7e514072bf77123cb51ba0cc3e8d69284d534d8e6d1e876cecf22231e5ef04dc96762ce7d5ef3348ad1e241ac797ae3b630ea249afc5139af49b8ef68b32f812d6b514210363d498efc28c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEAWNBF+ZHjOBWiwokaSN7usb/CWrLflFA\ncr93Ejy1G6DMPo1pKE1TTY5tHods7PIiMeXvBNyWdizn1e8zSK0eJBrHl647Yw6i\nSa/FE5r0m472izL4Eta1FCEDY9SY78KM\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 358,
+          "tcId" : 461,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023008d999057ba3d2d969260045c55b97f089025959a6f434d651d207d19fb96e9e4fe0e86ebe0e64f85b96a9c75295df6102310099999999999999999999999999999999999999999999999977a1fb4df8ede852ce760837c536cae35af40f4014764c12",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04675bdc79d8243887fe1b305d12ac10d2e9c0bde070a6e3394cd5f6adfbceda75498b0e7a794c7212f42be93f616744563e96d1bf6f95cdbefa774911ba06463d8a90a0c9d73c9699b061d779dc52496e8ee9b9ae9c5d4d90e89cd1157d811895",
         "wx" : "675bdc79d8243887fe1b305d12ac10d2e9c0bde070a6e3394cd5f6adfbceda75498b0e7a794c7212f42be93f61674456",
         "wy" : "3e96d1bf6f95cdbefa774911ba06463d8a90a0c9d73c9699b061d779dc52496e8ee9b9ae9c5d4d90e89cd1157d811895"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004675bdc79d8243887fe1b305d12ac10d2e9c0bde070a6e3394cd5f6adfbceda75498b0e7a794c7212f42be93f616744563e96d1bf6f95cdbefa774911ba06463d8a90a0c9d73c9699b061d779dc52496e8ee9b9ae9c5d4d90e89cd1157d811895",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEZ1vcedgkOIf+GzBdEqwQ0unAveBwpuM5\nTNX2rfvO2nVJiw56eUxyEvQr6T9hZ0RWPpbRv2+Vzb76d0kRugZGPYqQoMnXPJaZ\nsGHXedxSSW6O6bmunF1NkOic0RV9gRiV\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004675bdc79d8243887fe1b305d12ac10d2e9c0bde070a6e3394cd5f6adfbceda75498b0e7a794c7212f42be93f616744563e96d1bf6f95cdbefa774911ba06463d8a90a0c9d73c9699b061d779dc52496e8ee9b9ae9c5d4d90e89cd1157d811895",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEZ1vcedgkOIf+GzBdEqwQ0unAveBwpuM5\nTNX2rfvO2nVJiw56eUxyEvQr6T9hZ0RWPpbRv2+Vzb76d0kRugZGPYqQoMnXPJaZ\nsGHXedxSSW6O6bmunF1NkOic0RV9gRiV\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 359,
+          "tcId" : 462,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023008d999057ba3d2d969260045c55b97f089025959a6f434d651d207d19fb96e9e4fe0e86ebe0e64f85b96a9c75295df61023100db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6aae76701acc1950894a89e068772d8b281eef136f8a8fef5",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "040fd1aab89f47b565b8160dfcc433b6408adeb1473c036b26b7ddec714fb4d0e7dd756c88469e86e218813ead8e8e7676f1cc955c4139e0071c0079ec1d77164e0569bdf453837e8b33c98535a0e7c9c61ef24762067bb46b6116ea7909a69b23",
         "wx" : "0fd1aab89f47b565b8160dfcc433b6408adeb1473c036b26b7ddec714fb4d0e7dd756c88469e86e218813ead8e8e7676",
-        "wy" : "0f1cc955c4139e0071c0079ec1d77164e0569bdf453837e8b33c98535a0e7c9c61ef24762067bb46b6116ea7909a69b23"
+        "wy" : "00f1cc955c4139e0071c0079ec1d77164e0569bdf453837e8b33c98535a0e7c9c61ef24762067bb46b6116ea7909a69b23"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200040fd1aab89f47b565b8160dfcc433b6408adeb1473c036b26b7ddec714fb4d0e7dd756c88469e86e218813ead8e8e7676f1cc955c4139e0071c0079ec1d77164e0569bdf453837e8b33c98535a0e7c9c61ef24762067bb46b6116ea7909a69b23",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAED9GquJ9HtWW4Fg38xDO2QIresUc8A2sm\nt93scU+00OfddWyIRp6G4hiBPq2OjnZ28cyVXEE54AccAHnsHXcWTgVpvfRTg36L\nM8mFNaDnycYe8kdiBnu0a2EW6nkJppsj\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200040fd1aab89f47b565b8160dfcc433b6408adeb1473c036b26b7ddec714fb4d0e7dd756c88469e86e218813ead8e8e7676f1cc955c4139e0071c0079ec1d77164e0569bdf453837e8b33c98535a0e7c9c61ef24762067bb46b6116ea7909a69b23",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAED9GquJ9HtWW4Fg38xDO2QIresUc8A2sm\nt93scU+00OfddWyIRp6G4hiBPq2OjnZ28cyVXEE54AccAHnsHXcWTgVpvfRTg36L\nM8mFNaDnycYe8kdiBnu0a2EW6nkJppsj\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 360,
+          "tcId" : 463,
           "comment" : "extreme value for k",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023008d999057ba3d2d969260045c55b97f089025959a6f434d651d207d19fb96e9e4fe0e86ebe0e64f85b96a9c75295df6102300eb10e5ab95f2f26a40700b1300fb8c3e754d5c453d9384ecce1daa38135a48a0a96c24efc2a76d00bde1d7aeedf7f6a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0434d74ec088bab6c6323968d1f468993812f690d6edca5b97604d718e12b8cdfdd96d42e57d33afe312f0ee3c3d0a13f786f4922bb2c13bdf7752a3ecb69393e997bd65461c46867ebeef6296b23f2c56df63acfde648f3f5002dbc239ffd1582",
         "wx" : "34d74ec088bab6c6323968d1f468993812f690d6edca5b97604d718e12b8cdfdd96d42e57d33afe312f0ee3c3d0a13f7",
-        "wy" : "086f4922bb2c13bdf7752a3ecb69393e997bd65461c46867ebeef6296b23f2c56df63acfde648f3f5002dbc239ffd1582"
+        "wy" : "0086f4922bb2c13bdf7752a3ecb69393e997bd65461c46867ebeef6296b23f2c56df63acfde648f3f5002dbc239ffd1582"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000434d74ec088bab6c6323968d1f468993812f690d6edca5b97604d718e12b8cdfdd96d42e57d33afe312f0ee3c3d0a13f786f4922bb2c13bdf7752a3ecb69393e997bd65461c46867ebeef6296b23f2c56df63acfde648f3f5002dbc239ffd1582",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAENNdOwIi6tsYyOWjR9GiZOBL2kNbtyluX\nYE1xjhK4zf3ZbULlfTOv4xLw7jw9ChP3hvSSK7LBO993UqPstpOT6Ze9ZUYcRoZ+\nvu9ilrI/LFbfY6z95kjz9QAtvCOf/RWC\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000434d74ec088bab6c6323968d1f468993812f690d6edca5b97604d718e12b8cdfdd96d42e57d33afe312f0ee3c3d0a13f786f4922bb2c13bdf7752a3ecb69393e997bd65461c46867ebeef6296b23f2c56df63acfde648f3f5002dbc239ffd1582",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAENNdOwIi6tsYyOWjR9GiZOBL2kNbtyluX\nYE1xjhK4zf3ZbULlfTOv4xLw7jw9ChP3hvSSK7LBO993UqPstpOT6Ze9ZUYcRoZ+\nvu9ilrI/LFbfY6z95kjz9QAtvCOf/RWC\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 361,
+          "tcId" : 464,
           "comment" : "extreme value for k and edgecase s",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "044376c9893e9277296c766a83abbe36b34da7a631f8cbfd32a1888de0dd1455a21a153ea2d61cfa5071fc6be12a658f6b290ba1a8ee8c78b5dd58f9ffcacb22955682eea02429c3fa8cdcb649fa4d007c8693e3f8f3c0a5f3c4de7a51beaa9809",
         "wx" : "4376c9893e9277296c766a83abbe36b34da7a631f8cbfd32a1888de0dd1455a21a153ea2d61cfa5071fc6be12a658f6b",
         "wy" : "290ba1a8ee8c78b5dd58f9ffcacb22955682eea02429c3fa8cdcb649fa4d007c8693e3f8f3c0a5f3c4de7a51beaa9809"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200044376c9893e9277296c766a83abbe36b34da7a631f8cbfd32a1888de0dd1455a21a153ea2d61cfa5071fc6be12a658f6b290ba1a8ee8c78b5dd58f9ffcacb22955682eea02429c3fa8cdcb649fa4d007c8693e3f8f3c0a5f3c4de7a51beaa9809",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEQ3bJiT6SdylsdmqDq742s02npjH4y/0y\noYiN4N0UVaIaFT6i1hz6UHH8a+EqZY9rKQuhqO6MeLXdWPn/yssilVaC7qAkKcP6\njNy2SfpNAHyGk+P488Cl88TeelG+qpgJ\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200044376c9893e9277296c766a83abbe36b34da7a631f8cbfd32a1888de0dd1455a21a153ea2d61cfa5071fc6be12a658f6b290ba1a8ee8c78b5dd58f9ffcacb22955682eea02429c3fa8cdcb649fa4d007c8693e3f8f3c0a5f3c4de7a51beaa9809",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEQ3bJiT6SdylsdmqDq742s02npjH4y/0y\noYiN4N0UVaIaFT6i1hz6UHH8a+EqZY9rKQuhqO6MeLXdWPn/yssilVaC7qAkKcP6\njNy2SfpNAHyGk+P488Cl88TeelG+qpgJ\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 362,
+          "tcId" : 465,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab702302492492492492492492492492492492492492492492492491c7be680477598d6c3716fabc13dcec86afd2833d41c2a7e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0410878fc4807f6732a23c883e838e38c787f7088f94c1824b84673e8b9eab16de1544ae4bf2c6fe3fe4fb343b7487e2b43036ff439533d22f951dae966584bafb23b217dcad2f8f4e0e6999c0c4d0f076634be805f676fd2a59c27f9fe7c5d95b",
         "wx" : "10878fc4807f6732a23c883e838e38c787f7088f94c1824b84673e8b9eab16de1544ae4bf2c6fe3fe4fb343b7487e2b4",
         "wy" : "3036ff439533d22f951dae966584bafb23b217dcad2f8f4e0e6999c0c4d0f076634be805f676fd2a59c27f9fe7c5d95b"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000410878fc4807f6732a23c883e838e38c787f7088f94c1824b84673e8b9eab16de1544ae4bf2c6fe3fe4fb343b7487e2b43036ff439533d22f951dae966584bafb23b217dcad2f8f4e0e6999c0c4d0f076634be805f676fd2a59c27f9fe7c5d95b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEEIePxIB/ZzKiPIg+g444x4f3CI+UwYJL\nhGc+i56rFt4VRK5L8sb+P+T7NDt0h+K0MDb/Q5Uz0i+VHa6WZYS6+yOyF9ytL49O\nDmmZwMTQ8HZjS+gF9nb9KlnCf5/nxdlb\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000410878fc4807f6732a23c883e838e38c787f7088f94c1824b84673e8b9eab16de1544ae4bf2c6fe3fe4fb343b7487e2b43036ff439533d22f951dae966584bafb23b217dcad2f8f4e0e6999c0c4d0f076634be805f676fd2a59c27f9fe7c5d95b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEEIePxIB/ZzKiPIg+g444x4f3CI+UwYJL\nhGc+i56rFt4VRK5L8sb+P+T7NDt0h+K0MDb/Q5Uz0i+VHa6WZYS6+yOyF9ytL49O\nDmmZwMTQ8HZjS+gF9nb9KlnCf5/nxdlb\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 363,
+          "tcId" : 466,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab702306666666666666666666666666666666666666666666666664fc15233fb49458c89a4057a8379dc9791f80a2ab84edd61",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04036b253e3b4ac88bb8585a2b32b978766a931e5ad0d0e653a2e34b44d6ddcc0d386e20c4def2d8bb3f8da128c1eac69f9c8e3b5ff5dde2205af359b3974d52758d7abae812b8b275e1452c4e59cb62e9b6771d347dbd1dea761c70291cc5e0a6",
-        "wx" : "36b253e3b4ac88bb8585a2b32b978766a931e5ad0d0e653a2e34b44d6ddcc0d386e20c4def2d8bb3f8da128c1eac69f",
-        "wy" : "09c8e3b5ff5dde2205af359b3974d52758d7abae812b8b275e1452c4e59cb62e9b6771d347dbd1dea761c70291cc5e0a6"
+        "wx" : "036b253e3b4ac88bb8585a2b32b978766a931e5ad0d0e653a2e34b44d6ddcc0d386e20c4def2d8bb3f8da128c1eac69f",
+        "wy" : "009c8e3b5ff5dde2205af359b3974d52758d7abae812b8b275e1452c4e59cb62e9b6771d347dbd1dea761c70291cc5e0a6"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004036b253e3b4ac88bb8585a2b32b978766a931e5ad0d0e653a2e34b44d6ddcc0d386e20c4def2d8bb3f8da128c1eac69f9c8e3b5ff5dde2205af359b3974d52758d7abae812b8b275e1452c4e59cb62e9b6771d347dbd1dea761c70291cc5e0a6",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEA2slPjtKyIu4WForMrl4dmqTHlrQ0OZT\nouNLRNbdzA04biDE3vLYuz+NoSjB6safnI47X/Xd4iBa81mzl01SdY16uugSuLJ1\n4UUsTlnLYum2dx00fb0d6nYccCkcxeCm\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004036b253e3b4ac88bb8585a2b32b978766a931e5ad0d0e653a2e34b44d6ddcc0d386e20c4def2d8bb3f8da128c1eac69f9c8e3b5ff5dde2205af359b3974d52758d7abae812b8b275e1452c4e59cb62e9b6771d347dbd1dea761c70291cc5e0a6",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEA2slPjtKyIu4WForMrl4dmqTHlrQ0OZT\nouNLRNbdzA04biDE3vLYuz+NoSjB6safnI47X/Xd4iBa81mzl01SdY16uugSuLJ1\n4UUsTlnLYum2dx00fb0d6nYccCkcxeCm\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 364,
+          "tcId" : 467,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3066023100aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab702310099999999999999999999999999999999999999999999999977a1fb4df8ede852ce760837c536cae35af40f4014764c12",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "042783c1be922fce155864ecb41d0a316e193a55843e80192f1fe556772f3debd04b9fc93c27bc6f353938886a404419941a352cec336946424fa3c208ea7105f5549edde8688abd305344bf4f66dda7eabcda6f8557c9af88109804d702e9670b",
         "wx" : "2783c1be922fce155864ecb41d0a316e193a55843e80192f1fe556772f3debd04b9fc93c27bc6f353938886a40441994",
         "wy" : "1a352cec336946424fa3c208ea7105f5549edde8688abd305344bf4f66dda7eabcda6f8557c9af88109804d702e9670b"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200042783c1be922fce155864ecb41d0a316e193a55843e80192f1fe556772f3debd04b9fc93c27bc6f353938886a404419941a352cec336946424fa3c208ea7105f5549edde8688abd305344bf4f66dda7eabcda6f8557c9af88109804d702e9670b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ4PBvpIvzhVYZOy0HQoxbhk6VYQ+gBkv\nH+VWdy8969BLn8k8J7xvNTk4iGpARBmUGjUs7DNpRkJPo8II6nEF9VSe3ehoir0w\nU0S/T2bdp+q82m+FV8mviBCYBNcC6WcL\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200042783c1be922fce155864ecb41d0a316e193a55843e80192f1fe556772f3debd04b9fc93c27bc6f353938886a404419941a352cec336946424fa3c208ea7105f5549edde8688abd305344bf4f66dda7eabcda6f8557c9af88109804d702e9670b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJ4PBvpIvzhVYZOy0HQoxbhk6VYQ+gBkv\nH+VWdy8969BLn8k8J7xvNTk4iGpARBmUGjUs7DNpRkJPo8II6nEF9VSe3ehoir0w\nU0S/T2bdp+q82m+FV8mviBCYBNcC6WcL\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 365,
+          "tcId" : 468,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3066023100aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7023100db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6aae76701acc1950894a89e068772d8b281eef136f8a8fef5",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04fa92538cdc740368caf16480ff1304cebbbe59a46a7a84603726b9592d105be069df1c61b5974f27e7552f797de97cdb620e03a46da862e4b089bafbb80df8f055c8f47991b3a3ddb2b089aedb2f15841a6a5b5e14c1dc36b3c155c4f74d3409",
-        "wx" : "0fa92538cdc740368caf16480ff1304cebbbe59a46a7a84603726b9592d105be069df1c61b5974f27e7552f797de97cdb",
+        "wx" : "00fa92538cdc740368caf16480ff1304cebbbe59a46a7a84603726b9592d105be069df1c61b5974f27e7552f797de97cdb",
         "wy" : "620e03a46da862e4b089bafbb80df8f055c8f47991b3a3ddb2b089aedb2f15841a6a5b5e14c1dc36b3c155c4f74d3409"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004fa92538cdc740368caf16480ff1304cebbbe59a46a7a84603726b9592d105be069df1c61b5974f27e7552f797de97cdb620e03a46da862e4b089bafbb80df8f055c8f47991b3a3ddb2b089aedb2f15841a6a5b5e14c1dc36b3c155c4f74d3409",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+pJTjNx0A2jK8WSA/xMEzru+WaRqeoRg\nNya5WS0QW+Bp3xxhtZdPJ+dVL3l96XzbYg4DpG2oYuSwibr7uA348FXI9HmRs6Pd\nsrCJrtsvFYQaalteFMHcNrPBVcT3TTQJ\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004fa92538cdc740368caf16480ff1304cebbbe59a46a7a84603726b9592d105be069df1c61b5974f27e7552f797de97cdb620e03a46da862e4b089bafbb80df8f055c8f47991b3a3ddb2b089aedb2f15841a6a5b5e14c1dc36b3c155c4f74d3409",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+pJTjNx0A2jK8WSA/xMEzru+WaRqeoRg\nNya5WS0QW+Bp3xxhtZdPJ+dVL3l96XzbYg4DpG2oYuSwibr7uA348FXI9HmRs6Pd\nsrCJrtsvFYQaalteFMHcNrPBVcT3TTQJ\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 366,
+          "tcId" : 469,
           "comment" : "extreme value for k",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab702300eb10e5ab95f2f26a40700b1300fb8c3e754d5c453d9384ecce1daa38135a48a0a96c24efc2a76d00bde1d7aeedf7f6a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab73617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f",
-        "wx" : "0aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
+        "wx" : "00aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
         "wy" : "3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab73617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqofKIr6LBTeOscce8yCtdG4dO2KLp5uY\nWfdB4IJUKjhVAvJdv1UpbDpUXjhydgq3NhfeSpYmLG9dnpi/kpLcKfj0Hb0omhR8\n6doxE7XwuMAKYLHOHX6BnXpDHXyQ6g5f\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab73617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqofKIr6LBTeOscce8yCtdG4dO2KLp5uY\nWfdB4IJUKjhVAvJdv1UpbDpUXjhydgq3NhfeSpYmLG9dnpi/kpLcKfj0Hb0omhR8\n6doxE7XwuMAKYLHOHX6BnXpDHXyQ6g5f\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 367,
-          "comment" : "testing point duplication",
+          "tcId" : 470,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100f9b127f0d81ebcd17b7ba0ea131c660d340b05ce557c82160e0f793de07d38179023942871acb7002dfafdfffc8deace02302492492492492492492492492492492492492492492492491c7be680477598d6c3716fabc13dcec86afd2833d41c2a7e",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 368,
-          "comment" : "testing point duplication",
+          "tcId" : 471,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "30640230064ed80f27e1432e84845f15ece399f2cbf4fa31aa837de9b953d44413b9f5c7c7f67989d703f07abef11b6ad0373ea502302492492492492492492492492492492492492492492492491c7be680477598d6c3716fabc13dcec86afd2833d41c2a7e",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7c9e821b569d9d390a26167406d6d23d6070be242d765eb831625ceec4a0f473ef59f4e30e2817e6285bce2846f15f1a0",
-        "wx" : "0aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
-        "wy" : "0c9e821b569d9d390a26167406d6d23d6070be242d765eb831625ceec4a0f473ef59f4e30e2817e6285bce2846f15f1a0"
+        "wx" : "00aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
+        "wy" : "00c9e821b569d9d390a26167406d6d23d6070be242d765eb831625ceec4a0f473ef59f4e30e2817e6285bce2846f15f1a0"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7c9e821b569d9d390a26167406d6d23d6070be242d765eb831625ceec4a0f473ef59f4e30e2817e6285bce2846f15f1a0",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqofKIr6LBTeOscce8yCtdG4dO2KLp5uY\nWfdB4IJUKjhVAvJdv1UpbDpUXjhydgq3yeghtWnZ05CiYWdAbW0j1gcL4kLXZeuD\nFiXO7EoPRz71n04w4oF+YoW84oRvFfGg\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7c9e821b569d9d390a26167406d6d23d6070be242d765eb831625ceec4a0f473ef59f4e30e2817e6285bce2846f15f1a0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqofKIr6LBTeOscce8yCtdG4dO2KLp5uY\nWfdB4IJUKjhVAvJdv1UpbDpUXjhydgq3yeghtWnZ05CiYWdAbW0j1gcL4kLXZeuD\nFiXO7EoPRz71n04w4oF+YoW84oRvFfGg\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 369,
-          "comment" : "testing point duplication",
+          "tcId" : 472,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100f9b127f0d81ebcd17b7ba0ea131c660d340b05ce557c82160e0f793de07d38179023942871acb7002dfafdfffc8deace02302492492492492492492492492492492492492492492492491c7be680477598d6c3716fabc13dcec86afd2833d41c2a7e",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 370,
-          "comment" : "testing point duplication",
+          "tcId" : 473,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "30640230064ed80f27e1432e84845f15ece399f2cbf4fa31aa837de9b953d44413b9f5c7c7f67989d703f07abef11b6ad0373ea502302492492492492492492492492492492492492492492492491c7be680477598d6c3716fabc13dcec86afd2833d41c2a7e",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
-        "uncompressed" : "0429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
-        "wx" : "29bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc",
-        "wy" : "09a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3"
-      },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEKb23bV+nQb/XAjPLOmbMfUS+s7BmPZKo\nE2ZQR4vO+2HvGC4VWlQ0Wl6OXojwZOW8mlJat/dk2tPa4UaMK0GfO2K5upF9XoxP\nsexHQEo/x2R0snEwgb6dtMAOBDran8Sj\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-384",
-      "type" : "ECDSAVer",
-      "tests" : [
-        {
-          "tcId" : 371,
-          "comment" : "pseudorandom signature",
-          "msg" : "",
-          "sig" : "3064023032401249714e9091f05a5e109d5c1216fdc05e98614261aa0dbd9e9cd4415dee29238afbd3b103c1e40ee5c9144aee0f02304326756fb2c4fd726360dd6479b5849478c7a9d054a833a58c1631c33b63c3441336ddf2c7fe0ed129aae6d4ddfeb753",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 372,
-          "comment" : "pseudorandom signature",
-          "msg" : "4d7367",
-          "sig" : "3066023100d7143a836608b25599a7f28dec6635494c2992ad1e2bbeecb7ef601a9c01746e710ce0d9c48accb38a79ede5b9638f3402310080f9e165e8c61035bf8aa7b5533960e46dd0e211c904a064edb6de41f797c0eae4e327612ee3f816f4157272bb4fabc9",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 373,
-          "comment" : "pseudorandom signature",
-          "msg" : "313233343030",
-          "sig" : "30650230234503fcca578121986d96be07fbc8da5d894ed8588c6dbcdbe974b4b813b21c52d20a8928f2e2fdac14705b0705498c023100cd7b9b766b97b53d1a80fc0b760af16a11bf4a59c7c367c6c7275dfb6e18a88091eed3734bf5cf41b3dc6fecd6d3baaf",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 374,
-          "comment" : "pseudorandom signature",
-          "msg" : "0000000000000000000000000000000000000000",
-          "sig" : "306502305cad9ae1565f2588f86d821c2cc1b4d0fdf874331326568f5b0e130e4e0c0ec497f8f5f564212bd2a26ecb782cf0a18d023100bf2e9d0980fbb00696673e7fbb03e1f854b9d7596b759a17bf6e6e67a95ea6c1664f82dc449ae5ea779abd99c78e6840",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp384r1",
-        "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04ffffffffaa63f1a239ac70197c6ebfcea5756dc012123f82c51fa874d66028be00e976a1080606737cc75c40bdfe4aacacbd85389088a62a6398384c22b52d492f23f46e4a27a4724ad55551da5c483438095a247cb0c3378f1f52c3425ff9f1",
-        "wx" : "0ffffffffaa63f1a239ac70197c6ebfcea5756dc012123f82c51fa874d66028be00e976a1080606737cc75c40bdfe4aac",
-        "wy" : "0acbd85389088a62a6398384c22b52d492f23f46e4a27a4724ad55551da5c483438095a247cb0c3378f1f52c3425ff9f1"
+        "wx" : "00ffffffffaa63f1a239ac70197c6ebfcea5756dc012123f82c51fa874d66028be00e976a1080606737cc75c40bdfe4aac",
+        "wy" : "00acbd85389088a62a6398384c22b52d492f23f46e4a27a4724ad55551da5c483438095a247cb0c3378f1f52c3425ff9f1"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004ffffffffaa63f1a239ac70197c6ebfcea5756dc012123f82c51fa874d66028be00e976a1080606737cc75c40bdfe4aacacbd85389088a62a6398384c22b52d492f23f46e4a27a4724ad55551da5c483438095a247cb0c3378f1f52c3425ff9f1",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE/////6pj8aI5rHAZfG6/zqV1bcASEj+C\nxR+odNZgKL4A6XahCAYGc3zHXEC9/kqsrL2FOJCIpipjmDhMIrUtSS8j9G5KJ6Ry\nStVVUdpcSDQ4CVokfLDDN48fUsNCX/nx\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004ffffffffaa63f1a239ac70197c6ebfcea5756dc012123f82c51fa874d66028be00e976a1080606737cc75c40bdfe4aacacbd85389088a62a6398384c22b52d492f23f46e4a27a4724ad55551da5c483438095a247cb0c3378f1f52c3425ff9f1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE/////6pj8aI5rHAZfG6/zqV1bcASEj+C\nxR+odNZgKL4A6XahCAYGc3zHXEC9/kqsrL2FOJCIpipjmDhMIrUtSS8j9G5KJ6Ry\nStVVUdpcSDQ4CVokfLDDN48fUsNCX/nx\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 375,
+          "tcId" : 474,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3065023007648b6660d01ba2520a09d298adf3b1a02c32744bd2877208f5a4162f6c984373139d800a4cdc1ffea15bce4871a0ed02310099fd367012cb9e02cde2749455e0d495c52818f3c14f6e6aad105b0925e2a7290ac4a06d9fadf4b15b578556fe332a5f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 376,
+          "tcId" : 475,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3065023100a049dcd96c72e4f36144a51bba30417b451a305dd01c9e30a5e04df94342617dc383f17727708e3277cd7246ca44074102303970e264d85b228bf9e9b9c4947c5dd041ea8b5bde30b93aa59fedf2c428d3e2540a54e0530688acccb83ac7b29b79a2",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 377,
+          "tcId" : 476,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30650230441800ea9377c27865be000ad008eb3d7502bdd105824b26d15cf3d06452969a9d0607a915a8fe989215fc4d61af6e05023100dce29faa5137f75ad77e03918c8ee6747cc7a39b0a69f8b915654cac4cf4bfd9c87cc46ae1631b5c6baebd4fc08ff8fd",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04d1827fc6f6f12f21992c5a409a0653b121d2ef02b2b0ab01a9161ce956280740b1e356b255701b0a6ddc9ec2ca8a9422c6ed5d2ced8d8ab7560fa5bb88c738e74541883d8a2b1c0e2ba7e36d030fc4d9bfb8b22f24db897ebac49dd400000000",
-        "wx" : "0d1827fc6f6f12f21992c5a409a0653b121d2ef02b2b0ab01a9161ce956280740b1e356b255701b0a6ddc9ec2ca8a9422",
-        "wy" : "0c6ed5d2ced8d8ab7560fa5bb88c738e74541883d8a2b1c0e2ba7e36d030fc4d9bfb8b22f24db897ebac49dd400000000"
+        "wx" : "00d1827fc6f6f12f21992c5a409a0653b121d2ef02b2b0ab01a9161ce956280740b1e356b255701b0a6ddc9ec2ca8a9422",
+        "wy" : "00c6ed5d2ced8d8ab7560fa5bb88c738e74541883d8a2b1c0e2ba7e36d030fc4d9bfb8b22f24db897ebac49dd400000000"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004d1827fc6f6f12f21992c5a409a0653b121d2ef02b2b0ab01a9161ce956280740b1e356b255701b0a6ddc9ec2ca8a9422c6ed5d2ced8d8ab7560fa5bb88c738e74541883d8a2b1c0e2ba7e36d030fc4d9bfb8b22f24db897ebac49dd400000000",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE0YJ/xvbxLyGZLFpAmgZTsSHS7wKysKsB\nqRYc6VYoB0Cx41ayVXAbCm3cnsLKipQixu1dLO2NirdWD6W7iMc450VBiD2KKxwO\nK6fjbQMPxNm/uLIvJNuJfrrEndQAAAAA\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004d1827fc6f6f12f21992c5a409a0653b121d2ef02b2b0ab01a9161ce956280740b1e356b255701b0a6ddc9ec2ca8a9422c6ed5d2ced8d8ab7560fa5bb88c738e74541883d8a2b1c0e2ba7e36d030fc4d9bfb8b22f24db897ebac49dd400000000",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE0YJ/xvbxLyGZLFpAmgZTsSHS7wKysKsB\nqRYc6VYoB0Cx41ayVXAbCm3cnsLKipQixu1dLO2NirdWD6W7iMc450VBiD2KKxwO\nK6fjbQMPxNm/uLIvJNuJfrrEndQAAAAA\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 378,
+          "tcId" : 477,
           "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "306402303244768016457c463b74f2097f216d9670b191f76281c74bc6a1a1971d19f209bf4696468f5eb75d6326a0a43c0a65290230501e0ad985ed9f95697bd17fdbe3f9ca92e0f76426d3664e6896648d9c750bf588d0ce7d011c1a1e8d6c2e082422dc93",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 379,
+          "tcId" : 478,
           "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "306402305e1af40f2480e3d97c4ae4bfd34a9f45269241356f3a46becd86a4a7c9716d73ca5aebdb3db1a7765650666683bc856b02307e7c4b473a2baaa4953785be8aa2a10006f6d36b400ab981864d69cecec046718d0404b9647454b159aa5a92d76d7955",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 380,
+          "tcId" : 479,
           "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "306502306688e36a26f15bdc1c3f91367f8a7667f7bb3e30a335d6f0900e9534eb88b260cb29344c723fedfbe7ac9c5a33f4bf0d023100aa35fddf0fdc9017860b378f801cd806f3e2d754cd2fd94eb7bb36a46ce828cef87e9ebbf447068e630b87fee385ad8f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "041099bb45100f55f5a85cca3de2b3bd5e250f4f6fad6631a3156c2e52a33d7d615dd279f79f8b4baff7c713ac00000000e6c9b736a8929f2ed7be0c753a54cbb48b8469e0411eaf93a4a82459ba0b681bba8f5fb383b4906d4901a3303e2f1557",
         "wx" : "1099bb45100f55f5a85cca3de2b3bd5e250f4f6fad6631a3156c2e52a33d7d615dd279f79f8b4baff7c713ac00000000",
-        "wy" : "0e6c9b736a8929f2ed7be0c753a54cbb48b8469e0411eaf93a4a82459ba0b681bba8f5fb383b4906d4901a3303e2f1557"
+        "wy" : "00e6c9b736a8929f2ed7be0c753a54cbb48b8469e0411eaf93a4a82459ba0b681bba8f5fb383b4906d4901a3303e2f1557"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200041099bb45100f55f5a85cca3de2b3bd5e250f4f6fad6631a3156c2e52a33d7d615dd279f79f8b4baff7c713ac00000000e6c9b736a8929f2ed7be0c753a54cbb48b8469e0411eaf93a4a82459ba0b681bba8f5fb383b4906d4901a3303e2f1557",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEEJm7RRAPVfWoXMo94rO9XiUPT2+tZjGj\nFWwuUqM9fWFd0nn3n4tLr/fHE6wAAAAA5sm3NqiSny7Xvgx1OlTLtIuEaeBBHq+T\npKgkWboLaBu6j1+zg7SQbUkBozA+LxVX\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200041099bb45100f55f5a85cca3de2b3bd5e250f4f6fad6631a3156c2e52a33d7d615dd279f79f8b4baff7c713ac00000000e6c9b736a8929f2ed7be0c753a54cbb48b8469e0411eaf93a4a82459ba0b681bba8f5fb383b4906d4901a3303e2f1557",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEEJm7RRAPVfWoXMo94rO9XiUPT2+tZjGj\nFWwuUqM9fWFd0nn3n4tLr/fHE6wAAAAA5sm3NqiSny7Xvgx1OlTLtIuEaeBBHq+T\npKgkWboLaBu6j1+zg7SQbUkBozA+LxVX\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 381,
+          "tcId" : 480,
           "comment" : "x-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3065023100d4a8f3b0b4d3a5769e3a0bbc644b35f1d509355ed1fe401e170f667b661f693b32598e8c143a817a958982845042bb48023004cc07578bbd1981dbf6e8a97a354c98d41b8b6f6e8a2c2b1763c7c2a29d79e24f8476075c9aed9aec6c64dff50461ae",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 382,
+          "tcId" : 481,
           "comment" : "x-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3065023100c286d1928e9c79fdd3bebdf22a1dbd37c8105e8ecf41e9e3777fe341b6b8d5a89b9d986827d6d1dbb381cd8239484a220230201119ae305b9360aa9b5e5d1567e0674c09e4f025556ebf81b987466b0f421b8d31f72bbe95f3ce2aa9874a84edfd40",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 383,
+          "tcId" : 482,
           "comment" : "x-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3065023100d9c678550167f10c511e62acb4bd0a3f7f336bc090c94e6c6b02622439c348a2159c5f41f9b5aa4b470590d40dcd7cc202301fd5eaee295abb4081cb626745f4ad279ceb44604062830b58e6c0465c562d41f02ba588fc0db1ebbe339cdc008d7a1b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04000000002b089edd754169010145f263f334fc167cc19dae8225970ae19cc8cb7ec73593d6a465c370f5478b0e539d69d1951d597b56a67345acb25809581f07cd0eb78d9538a3f8a65f300e68a1eb78507df76de650e8f8ee63a5f0c5687c98",
         "wx" : "2b089edd754169010145f263f334fc167cc19dae8225970ae19cc8cb7ec73593d6a465c370f5478b0e539d69",
-        "wy" : "0d1951d597b56a67345acb25809581f07cd0eb78d9538a3f8a65f300e68a1eb78507df76de650e8f8ee63a5f0c5687c98"
+        "wy" : "00d1951d597b56a67345acb25809581f07cd0eb78d9538a3f8a65f300e68a1eb78507df76de650e8f8ee63a5f0c5687c98"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004000000002b089edd754169010145f263f334fc167cc19dae8225970ae19cc8cb7ec73593d6a465c370f5478b0e539d69d1951d597b56a67345acb25809581f07cd0eb78d9538a3f8a65f300e68a1eb78507df76de650e8f8ee63a5f0c5687c98",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEAAAAACsInt11QWkBAUXyY/M0/BZ8wZ2u\ngiWXCuGcyMt+xzWT1qRlw3D1R4sOU51p0ZUdWXtWpnNFrLJYCVgfB80Ot42VOKP4\npl8wDmih63hQffdt5lDo+O5jpfDFaHyY\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004000000002b089edd754169010145f263f334fc167cc19dae8225970ae19cc8cb7ec73593d6a465c370f5478b0e539d69d1951d597b56a67345acb25809581f07cd0eb78d9538a3f8a65f300e68a1eb78507df76de650e8f8ee63a5f0c5687c98",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEAAAAACsInt11QWkBAUXyY/M0/BZ8wZ2u\ngiWXCuGcyMt+xzWT1qRlw3D1R4sOU51p0ZUdWXtWpnNFrLJYCVgfB80Ot42VOKP4\npl8wDmih63hQffdt5lDo+O5jpfDFaHyY\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 384,
+          "tcId" : 483,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3065023020fee7c71b6cb0d1da3641ec6622c055a3b16a1f596c64b34da1b2d0b868b66a8f0a0d0db983b3dc7e53bb7295da81970231008141a931d3579aec1cac9887d2fff9c6f12d47a27e4aab8cf262a9d14a715bca0b2057cbc3f18b6fd3d1df76f7410f16",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 385,
+          "tcId" : 484,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3065023100913eecc559b3cf7108a65d6cc3076bfdf36c6f94dcc6693d06690470f34a2e81564241e1de5f5f51421de30af467f10f0230649bd3717244e8ef3c6b0eda983f84dca5ea86d1bec15386b9c473ec43a8cd0ba558eee819f791d9ff9272b9afd59551",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 386,
+          "tcId" : 485,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3064023023855c46403a97b76cbb316ec3fe7e2c422b818387604bda8c3d91121b4f20179d9107c5f92dedc8b620d7db87fccccd023050f57343ab148e50662320c4161e44543c35bc992011ea5b1680b94382cf224ea0ec5da511e102f566cb67201f30a2ee",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b33600000000208b3f5ad3b3937acc9d606cc5ececab4a701f75ed42957ea4d7858d33f5c26c6ae20a9cccda56996700d6b4",
-        "wx" : "0fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b336",
+        "wx" : "00fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b336",
         "wy" : "208b3f5ad3b3937acc9d606cc5ececab4a701f75ed42957ea4d7858d33f5c26c6ae20a9cccda56996700d6b4"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b33600000000208b3f5ad3b3937acc9d606cc5ececab4a701f75ed42957ea4d7858d33f5c26c6ae20a9cccda56996700d6b4",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+wG6rV8Lj3m5zRBNEqq5MQFGrdfWtMAi\n2HrmcRF4uU1hjKezrxOFSxxYiHnod7M2AAAAACCLP1rTs5N6zJ1gbMXs7KtKcB91\n7UKVfqTXhY0z9cJsauIKnMzaVplnANa0\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b33600000000208b3f5ad3b3937acc9d606cc5ececab4a701f75ed42957ea4d7858d33f5c26c6ae20a9cccda56996700d6b4",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+wG6rV8Lj3m5zRBNEqq5MQFGrdfWtMAi\n2HrmcRF4uU1hjKezrxOFSxxYiHnod7M2AAAAACCLP1rTs5N6zJ1gbMXs7KtKcB91\n7UKVfqTXhY0z9cJsauIKnMzaVplnANa0\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 387,
+          "tcId" : 486,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3066023100d200958d491fcebde667cd736c9dba0961c70db2ecaf573c31dd7fa41ecca32b40b5896f9a0ddf272110e3d21e84593a023100c2ecf73943b9adce596bac14fce62495ae93825c5ff6f61c247d1d8afcba52082fc96f63a26e55bccfc3779f88cfd799",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 388,
+          "tcId" : 487,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "306402306ac17d71260c79f81a7566124738cb3ee5d0aa690e73a98ae9e766f1336691e500cad51ba1302366c09cc06b8f7049e0023032ca965d6d7012ec187c7cab9544334d66c2a7658ddefa67e4ad40429815518ecc87b1492ddd57333bd2300b4660a835",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 389,
+          "tcId" : 488,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3065023100e19a4646f0ed8a271fe86ba533f8be4fd81bbf4674716f668efa89a40cac51eec2a6cfbd92327d25efe91ca4ff712bc502304a86b2e8e12378e633dec2691e3b1eed4e932cc48b28e45fa3d464cc0e948c02cc9decf2bb43b25937fcf37e9ad86ef0",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b336ffffffffdf74c0a52c4c6c8533629f933a131354b58fe08a12bd6a815b287a71cc0a3d92951df5633325a96798ff294b",
-        "wx" : "0fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b336",
-        "wy" : "0ffffffffdf74c0a52c4c6c8533629f933a131354b58fe08a12bd6a815b287a71cc0a3d92951df5633325a96798ff294b"
+        "wx" : "00fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b336",
+        "wy" : "00ffffffffdf74c0a52c4c6c8533629f933a131354b58fe08a12bd6a815b287a71cc0a3d92951df5633325a96798ff294b"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b336ffffffffdf74c0a52c4c6c8533629f933a131354b58fe08a12bd6a815b287a71cc0a3d92951df5633325a96798ff294b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+wG6rV8Lj3m5zRBNEqq5MQFGrdfWtMAi\n2HrmcRF4uU1hjKezrxOFSxxYiHnod7M2/////990wKUsTGyFM2KfkzoTE1S1j+CK\nEr1qgVsoenHMCj2SlR31YzMlqWeY/ylL\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b336ffffffffdf74c0a52c4c6c8533629f933a131354b58fe08a12bd6a815b287a71cc0a3d92951df5633325a96798ff294b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+wG6rV8Lj3m5zRBNEqq5MQFGrdfWtMAi\n2HrmcRF4uU1hjKezrxOFSxxYiHnod7M2/////990wKUsTGyFM2KfkzoTE1S1j+CK\nEr1qgVsoenHMCj2SlR31YzMlqWeY/ylL\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-384",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 390,
+          "tcId" : 489,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3064023015aac6c0f435cb662d110db5cf686caee53c64fe2d6d600a83ebe505a0e6fc62dc5705160477c47528c8c903fa865b5d02307f94ddc01a603f9bec5d10c9f2c89fb23b3ffab6b2b68d0f04336d499085e32d22bf3ab67a49a74c743f72473172b59f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 391,
+          "tcId" : 490,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "306602310090b95a7d194b73498fba5afc95c1aea9be073162a9edc57c4d12f459f0a1730baf2f87d7d6624aea7b931ec53370fe47023100cbc1ef470e666010604c609384b872db7fa7b8a5a9f20fdefd656be2fcc75db53948102f7ab203ea1860a6a32af246a1",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 392,
+          "tcId" : 491,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3066023100dd4391ce7557cbd005e3d5d727cd264399dcc3c6501e4547505b6d57b40bbf0a7fac794dcc8d4233159dd0aa40d4e0b9023100a77fa1374fd60aa91600912200fc83c6aa447f8171ecea72ae322df32dccd68951dc5caf6c50380e400e45bf5c0e626b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     }

--- a/Tests/Test Vectors/ecdsa_secp384r1_sha512_test.json
+++ b/Tests/Test Vectors/ecdsa_secp384r1_sha512_test.json
@@ -1,4758 +1,6954 @@
 {
   "algorithm" : "ECDSA",
-  "generatorVersion" : "0.4.12",
+  "schema" : "ecdsa_verify_schema.json",
+  "generatorVersion" : "0.9rc5",
+  "numberOfTests" : 529,
+  "header" : [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of ASN encoded ECDSA signatures."
+  ],
   "notes" : {
-    "BER" : "This is a signature with correct values for (r, s) but using some alternative BER encoding instead of DER encoding. Implementations should not accept such signatures to limit signature malleability.",
-    "EdgeCase" : "Edge case values such as r=1 and s=0 can lead to forgeries if the ECDSA implementation does not check boundaries and computes s^(-1)==0.",
-    "MissingZero" : "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
-    "PointDuplication" : "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission."
+    "ArithmeticError" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "cves" : [
+        "CVE-2017-18146"
+      ]
+    },
+    "BerEncodedSignature" : {
+      "bugType" : "BER_ENCODING",
+      "description" : "ECDSA signatures are usually DER encoded. This signature contains valid values for r and s, but it uses alternative BER encoding.",
+      "effect" : "Accepting alternative BER encodings may be benign in some cases, or be an issue if protocol requires signature malleability.",
+      "cves" : [
+        "CVE-2020-14966",
+        "CVE-2020-13822",
+        "CVE-2019-14859",
+        "CVE-2016-1000342"
+      ]
+    },
+    "EdgeCasePublicKey" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidEncoding" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "ECDSA signatures are encoded using ASN.1. This test vector contains an incorrectly encoded signature. The test vector itself was generated from a valid signature by modifying its encoding.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature" : {
+      "bugType" : "AUTH_BYPASS",
+      "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "cves" : [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "InvalidTypesInSignature" : {
+      "bugType" : "AUTH_BYPASS",
+      "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "cves" : [
+        "CVE-2022-21449"
+      ]
+    },
+    "MissingZero" : {
+      "bugType" : "LEGACY",
+      "description" : "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
+      "effect" : "While signatures are more malleable if such signatures are accepted, this typically leads to no vulnerability, since a badly encoded signature can be reencoded correctly."
+    },
+    "ModifiedInteger" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModifiedSignature" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an invalid signature that was generated from a valid signature by modifying it.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect" : "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves" : [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves" : [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SmallRandS" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect" : "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves" : [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "Untruncatedhash" : {
+      "bugType" : "MISSING_STEP",
+      "description" : "If the size of the digest is longer than the size of the underlying order of the multiplicative subgroup then the hash digest must be truncated during signature generation and verification. This test vector contains a signature where this step has been omitted."
+    },
+    "ValidSignature" : {
+      "bugType" : "BASIC",
+      "description" : "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
   },
-  "numberOfTests" : 430,
-  "header" : [],
   "testGroups" : [
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
+        "uncompressed" : "0429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+        "wx" : "29bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc",
+        "wy" : "009a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEKb23bV+nQb/XAjPLOmbMfUS+s7BmPZKo\nE2ZQR4vO+2HvGC4VWlQ0Wl6OXojwZOW8mlJat/dk2tPa4UaMK0GfO2K5upF9XoxP\nsexHQEo/x2R0snEwgb6dtMAOBDran8Sj\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 1,
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
+          "msg" : "",
+          "sig" : "306402302290c886bbad8f53089583d543a269a727665626d6b94a3796324c62d08988f66f6011e845811a03589e92abe1f17faf023066e2cb4380997f4e7f85022541adb22d24d1196be68a3db888b03eb3d2d40b0d9a3a6a00a1a4782ee0a00e8410ba2d86",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 2,
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
+          "msg" : "4d7367",
+          "sig" : "30650231008071d8cf9df9efef696ebafc59f74db90c1f1ecf5ccde18858de22fe4d7df2a25cb3001695d706dfd7984b39df65a0f4023027291e6339c2a7fed7a174bb97ffe41d8cfdc20c1260c6ec85d7259f0cc7781bf2ae7a6e6fb4c08e0d75b7381bb7d9b8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 3,
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30650230470014ccd7a1a5e5333d301c8ea528ac3b07b01944af30cec60f4bad94db108509e45ba381818b5bdfaf9daf0d372301023100e3d49d6a05a755aa871d7cb96fffb79fed7625f83f69498ba07c0d65166a67107c9a17ae6e1028e244377a44096217b2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 4,
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
+          "msg" : "0000000000000000000000000000000000000000",
+          "sig" : "30640230377044d343f900175ac6833071be74964cd636417039e10e837da94b6919bffc3f5a517b945a450852af3259f5cbf108023032ea25006375c153581e80c09f53ad585c736f823c70147aba4fb47bb0a224fae4d8819adad80d4c144ecc2380954a9e",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
         "uncompressed" : "042da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f",
         "wx" : "2da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa",
         "wy" : "4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200042da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAELaV92hCJJ2pUP5/9rAv/DZdsrXHrcoDn\n2b/Z/uS9svIPR/+IgnQ4l3LZjMV1ITiqS20FTWnc8+JexJ34cHFeNIg7GDYZfXb4\nrZYuePZXG7x0B7DWCR+eTYjwFCdEBhdP\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200042da57dda1089276a543f9ffdac0bff0d976cad71eb7280e7d9bfd9fee4bdb2f20f47ff888274389772d98cc5752138aa4b6d054d69dcf3e25ec49df870715e34883b1836197d76f8ad962e78f6571bbc7407b0d6091f9e4d88f014274406174f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAELaV92hCJJ2pUP5/9rAv/DZdsrXHrcoDn\n2b/Z/uS9svIPR/+IgnQ4l3LZjMV1ITiqS20FTWnc8+JexJ34cHFeNIg7GDYZfXb4\nrZYuePZXG7x0B7DWCR+eTYjwFCdEBhdP\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 1,
+          "tcId" : 5,
           "comment" : "signature malleability",
+          "flags" : [
+            "ValidSignature"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202307b0a10ee2dd0dd2fab75095af240d095e446faba7a50a19fbb197e4c4250926e30c5303a2c2d34250f17fcf5ab3181a6",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 2,
-          "comment" : "Legacy:ASN encoding of r misses leading 0",
-          "msg" : "313233343030",
-          "sig" : "30650230814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "acceptable",
-          "flags" : [
-            "MissingZero"
-          ]
-        },
-        {
-          "tcId" : 3,
-          "comment" : "Legacy:ASN encoding of s misses leading 0",
-          "msg" : "313233343030",
-          "sig" : "3065023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2023084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "acceptable",
-          "flags" : [
-            "MissingZero"
-          ]
-        },
-        {
-          "tcId" : 4,
-          "comment" : "valid",
-          "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 5,
-          "comment" : "long form encoding of length",
-          "msg" : "313233343030",
-          "sig" : "308166023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : [
-            "BER"
-          ]
+          "result" : "valid"
         },
         {
           "tcId" : 6,
-          "comment" : "long form encoding of length",
-          "msg" : "313233343030",
-          "sig" : "306702813100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
+          "comment" : "Legacy: ASN encoding of r misses leading 0",
           "flags" : [
-            "BER"
-          ]
+            "MissingZero"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30650230814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 7,
-          "comment" : "long form encoding of length",
-          "msg" : "313233343030",
-          "sig" : "3067023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20281310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
+          "comment" : "Legacy: ASN encoding of s misses leading 0",
           "flags" : [
-            "BER"
-          ]
+            "MissingZero"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3065023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2023084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 8,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "30820066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
+          "comment" : "valid",
           "flags" : [
-            "BER"
-          ]
+            "ValidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "valid"
         },
         {
           "tcId" : 9,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "30680282003100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
+          "comment" : "length of sequence [r, s] uses long form encoding",
           "flags" : [
-            "BER"
-          ]
+            "BerEncodedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308166023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 10,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2028200310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
+          "comment" : "length of sequence [r, s] contains a leading 0",
           "flags" : [
-            "BER"
-          ]
+            "BerEncodedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30820066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 11,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] uses 103 instead of 102",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
           "sig" : "3067023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
           "tcId" : 12,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] uses 101 instead of 102",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
           "tcId" : 13,
-          "comment" : "wrong length",
+          "comment" : "uint32 overflow in length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023200814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30850100000066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 14,
-          "comment" : "wrong length",
+          "comment" : "uint64 overflow in length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023000814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3089010000000000000066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 15,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202320084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30847fffffff023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 16,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202300084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308480000000023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 17,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30850100000066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3084ffffffff023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 18,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**40 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306b0285010000003100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3085ffffffffff023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 19,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306b023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2028501000000310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3088ffffffffffffffff023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 20,
-          "comment" : "uint64 overflow in length",
+          "comment" : "incorrect length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3089010000000000000066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30ff023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 21,
-          "comment" : "uint64 overflow in length",
+          "comment" : "replaced sequence [r, s] by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306f028901000000000000003100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 22,
-          "comment" : "uint64 overflow in length",
+          "comment" : "removing sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306f023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202890100000000000000310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "",
+          "result" : "invalid"
         },
         {
           "tcId" : 23,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "lonely sequence tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30847fffffff023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30",
+          "result" : "invalid"
         },
         {
           "tcId" : 24,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "appending 0's to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a02847fffffff00814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 25,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "prepending 0's to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202847fffffff0084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30680000023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 26,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "appending unused 0's to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3084ffffffff023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 27,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "appending null value to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a0284ffffffff00814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 28,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "prepending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20284ffffffff0084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306b4981773066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 29,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "prepending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3085ffffffffff023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a25003066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 30,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "appending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306b0285ffffffffff00814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30683066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0004deadbeef",
+          "result" : "invalid"
         },
         {
           "tcId" : 31,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306b023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20285ffffffffff0084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306eaa00bb00cd003066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 32,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3088ffffffffffffffff023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306e2239aa00bb00cd00023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 33,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306e0288ffffffffffffffff00814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306e023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e22239aa00bb00cd0002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 34,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "truncated length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306e023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20288ffffffffffffffff0084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3081",
+          "result" : "invalid"
         },
         {
           "tcId" : 35,
-          "comment" : "incorrect length",
+          "comment" : "including undefined tags to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30ff023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306caa02aabb3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 36,
-          "comment" : "incorrect length",
+          "comment" : "using composition with indefinite length for sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306602ff00814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30803066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 37,
-          "comment" : "incorrect length",
+          "comment" : "using composition with wrong tag for sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202ff0084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30803166023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 38,
-          "comment" : "indefinite length without termination",
+          "comment" : "Replacing sequence [r, s] with NULL",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 39,
-          "comment" : "indefinite length without termination",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066028000814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "2e66023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 40,
-          "comment" : "indefinite length without termination",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202800084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "2f66023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 41,
-          "comment" : "removing sequence",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3166023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 42,
-          "comment" : "lonely sequence tag",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3266023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 43,
-          "comment" : "appending 0's to sequence",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "ff66023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 44,
-          "comment" : "prepending 0's to sequence",
+          "comment" : "dropping value of sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30680000023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 45,
-          "comment" : "appending unused 0's to sequence",
+          "comment" : "using composition for sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a30010230653100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 46,
-          "comment" : "appending null value to sequence",
+          "comment" : "truncated sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7",
+          "result" : "invalid"
         },
         {
           "tcId" : 47,
-          "comment" : "including garbage",
+          "comment" : "truncated sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306b4981773066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30653100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 48,
-          "comment" : "including garbage",
+          "comment" : "sequence [r, s] of size 4199 to check for overflows",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a25003066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30821067023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 49,
-          "comment" : "including garbage",
+          "comment" : "indefinite length",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30683066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0004deadbeef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 50,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with truncated delimiter",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306b2236498177023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd00",
+          "result" : "invalid"
         },
         {
           "tcId" : 51,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with additional element",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a22352500023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd05000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 52,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with truncated element",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306e2233023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20004deadbeef02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd060811220000",
+          "result" : "invalid"
         },
         {
           "tcId" : 53,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with garbage",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306b023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2223649817702310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000fe02beef",
+          "result" : "invalid"
         },
         {
           "tcId" : 54,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with nonempty EOC",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e22235250002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3080023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0002beef",
+          "result" : "invalid"
         },
         {
           "tcId" : 55,
-          "comment" : "including garbage",
+          "comment" : "prepend empty sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306e023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2223302310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0004deadbeef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30683000023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 56,
-          "comment" : "including undefined tags",
+          "comment" : "append empty sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306eaa00bb00cd003066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 57,
-          "comment" : "including undefined tags",
+          "comment" : "append zero",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306caa02aabb3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3069023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 58,
-          "comment" : "including undefined tags",
+          "comment" : "append garbage with high tag number",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306e2239aa00bb00cd00023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3069023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cdbf7f00",
+          "result" : "invalid"
         },
         {
           "tcId" : 59,
-          "comment" : "including undefined tags",
+          "comment" : "append null with explicit tag",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306c2237aa02aabb023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cda0020500",
+          "result" : "invalid"
         },
         {
           "tcId" : 60,
-          "comment" : "including undefined tags",
+          "comment" : "append null with implicit tag",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306e023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e22239aa00bb00cd0002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cda000",
+          "result" : "invalid"
         },
         {
           "tcId" : 61,
-          "comment" : "including undefined tags",
+          "comment" : "sequence of sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306c023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e22237aa02aabb02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30683066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 62,
-          "comment" : "truncated length of sequence",
+          "comment" : "truncated sequence: removed last 1 elements",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3081",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3033023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2",
+          "result" : "invalid"
         },
         {
           "tcId" : 63,
-          "comment" : "using composition with indefinite length",
+          "comment" : "repeating element in sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30803066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308199023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 64,
-          "comment" : "using composition with indefinite length",
+          "comment" : "flipped bit 0 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a2280023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2000002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306400814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e302310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 65,
-          "comment" : "using composition with indefinite length",
+          "comment" : "flipped bit 32 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2228002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306400814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297eb944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 66,
-          "comment" : "using composition with wrong tag",
+          "comment" : "flipped bit 48 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30803166023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306400814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d397ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 67,
-          "comment" : "using composition with wrong tag",
+          "comment" : "flipped bit 64 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a2280033100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2000002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306400814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854672d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 68,
-          "comment" : "using composition with wrong tag",
+          "comment" : "length of r uses long form encoding",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2228003310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306702813100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 69,
-          "comment" : "Replacing sequence with NULL",
+          "comment" : "length of r contains a leading 0",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "0500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30680282003100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 70,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r uses 50 instead of 49",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "2e66023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023200814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 71,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r uses 48 instead of 49",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "2f66023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023000814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 72,
-          "comment" : "changing tag value of sequence",
+          "comment" : "uint32 overflow in length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3166023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306b0285010000003100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 73,
-          "comment" : "changing tag value of sequence",
+          "comment" : "uint64 overflow in length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3266023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306f028901000000000000003100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 74,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "ff66023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a02847fffffff00814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 75,
-          "comment" : "dropping value of sequence",
+          "comment" : "length of r = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a02848000000000814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 76,
-          "comment" : "using composition for sequence",
+          "comment" : "length of r = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a30010230653100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a0284ffffffff00814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 77,
-          "comment" : "truncate sequence",
+          "comment" : "length of r = 2**40 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306b0285ffffffffff00814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 78,
-          "comment" : "truncate sequence",
+          "comment" : "length of r = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30653100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306e0288ffffffffffffffff00814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 79,
-          "comment" : "indefinite length",
-          "msg" : "313233343030",
-          "sig" : "3080023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
-          "result" : "invalid",
+          "comment" : "incorrect length of r",
           "flags" : [
-            "BER"
-          ]
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306602ff00814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 80,
-          "comment" : "indefinite length with truncated delimiter",
+          "comment" : "replaced r by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd00",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066028000814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 81,
-          "comment" : "indefinite length with additional element",
+          "comment" : "removing r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd05000000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "303302310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 82,
-          "comment" : "indefinite length with truncated element",
+          "comment" : "lonely integer tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd060811220000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30340202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 83,
-          "comment" : "indefinite length with garbage",
+          "comment" : "lonely integer tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000fe02beef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3034023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202",
+          "result" : "invalid"
         },
         {
           "tcId" : 84,
-          "comment" : "indefinite length with nonempty EOC",
+          "comment" : "appending 0's to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3080023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0002beef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3068023300814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2000002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 85,
-          "comment" : "prepend empty sequence",
+          "comment" : "prepending 0's to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30683000023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30680233000000814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 86,
-          "comment" : "append empty sequence",
+          "comment" : "appending unused 0's to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd3000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2000002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 87,
-          "comment" : "sequence of sequence",
+          "comment" : "appending null value to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30683066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3068023300814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2050002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 88,
-          "comment" : "truncated sequence",
+          "comment" : "prepending garbage to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3033023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306b2236498177023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 89,
-          "comment" : "repeat element in sequence",
+          "comment" : "prepending garbage to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308199023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a22352500023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 90,
-          "comment" : "removing integer",
+          "comment" : "appending garbage to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "303302310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306e2233023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20004deadbeef02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 91,
-          "comment" : "lonely integer tag",
+          "comment" : "truncated length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30340202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3035028102310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 92,
-          "comment" : "lonely integer tag",
+          "comment" : "including undefined tags to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3034023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306c2237aa02aabb023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 93,
-          "comment" : "appending 0's to integer",
+          "comment" : "using composition with indefinite length for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3068023300814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2000002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a2280023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2000002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 94,
-          "comment" : "appending 0's to integer",
+          "comment" : "using composition with wrong tag for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202330084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a2280033100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2000002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 95,
-          "comment" : "prepending 0's to integer",
-          "msg" : "313233343030",
-          "sig" : "30680233000000814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
+          "comment" : "Replacing r with NULL",
           "flags" : [
-            "BER"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035050002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 96,
-          "comment" : "prepending 0's to integer",
-          "msg" : "313233343030",
-          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2023300000084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
+          "comment" : "changing tag value of r",
           "flags" : [
-            "BER"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066003100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 97,
-          "comment" : "appending unused 0's to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2000002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066013100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 98,
-          "comment" : "appending null value to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3068023300814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2050002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066033100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 99,
-          "comment" : "appending null value to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202330084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066043100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 100,
-          "comment" : "truncated length of integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3035028102310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066ff3100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 101,
-          "comment" : "truncated length of integer",
+          "comment" : "dropping value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3035023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20281",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3035020002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 102,
-          "comment" : "Replacing integer with NULL",
+          "comment" : "using composition for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3035050002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a22350201000230814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 103,
-          "comment" : "Replacing integer with NULL",
+          "comment" : "modifying first byte of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3035023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023102814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 104,
-          "comment" : "changing tag value of integer",
+          "comment" : "modifying last byte of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066003100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a156202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 105,
-          "comment" : "changing tag value of integer",
+          "comment" : "truncated r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066013100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3065023000814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a1502310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 106,
-          "comment" : "changing tag value of integer",
+          "comment" : "r of size 4146 to check for overflows",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066033100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308210690282103200814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 107,
-          "comment" : "changing tag value of integer",
+          "comment" : "leading ff in r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066043100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30670232ff00814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 108,
-          "comment" : "changing tag value of integer",
+          "comment" : "replaced r by infinity",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066ff3100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "303609018002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 109,
-          "comment" : "changing tag value of integer",
+          "comment" : "replacing r with zero",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e200310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "303602010002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 110,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 0 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e201310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3064023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cc",
+          "result" : "invalid"
         },
         {
           "tcId" : 111,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 32 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e203310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3064023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c742193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 112,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 48 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e204310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3064023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd51c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 113,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 64 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2ff310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3064023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837354ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 114,
-          "comment" : "dropping value of integer",
+          "comment" : "length of s uses long form encoding",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3035020002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3067023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20281310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 115,
-          "comment" : "dropping value of integer",
+          "comment" : "length of s contains a leading 0",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3035023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20200",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2028200310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 116,
-          "comment" : "using composition for integer",
+          "comment" : "length of s uses 50 instead of 49",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a22350201000230814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202320084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 117,
-          "comment" : "using composition for integer",
+          "comment" : "length of s uses 48 instead of 49",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306a023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e22235020100023084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202300084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 118,
-          "comment" : "modify first byte of integer",
+          "comment" : "uint32 overflow in length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023102814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306b023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2028501000000310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 119,
-          "comment" : "modify first byte of integer",
+          "comment" : "uint64 overflow in length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310284f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306f023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202890100000000000000310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 120,
-          "comment" : "modify last byte of integer",
+          "comment" : "length of s = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a156202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202847fffffff0084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 121,
-          "comment" : "modify last byte of integer",
+          "comment" : "length of s = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a74d",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20284800000000084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 122,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023000814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a1502310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20284ffffffff0084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 123,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**40 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30650230814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306b023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20285ffffffffff0084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 124,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202300084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306e023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20288ffffffffffffffff0084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 125,
-          "comment" : "truncate integer",
+          "comment" : "incorrect length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2023084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202ff0084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 126,
-          "comment" : "leading ff in integer",
+          "comment" : "replaced s by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30670232ff00814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202800084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 127,
-          "comment" : "leading ff in integer",
+          "comment" : "appending 0's to s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3067023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20232ff0084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202330084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 128,
-          "comment" : "infinity",
+          "comment" : "prepending 0's to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "303609018002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2023300000084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 129,
-          "comment" : "infinity",
+          "comment" : "appending null value to s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3036023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2090180",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3068023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202330084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 130,
-          "comment" : "replacing integer with zero",
+          "comment" : "prepending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "303602010002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306b023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2223649817702310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 131,
-          "comment" : "replacing integer with zero",
+          "comment" : "prepending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3036023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2020100",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e22235250002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 132,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "appending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023101814cc9a70febda342d4ada87fc39426f403d5e8980842845d38217e2bcceedb5caa7aef8bc35edeec4beb155610f3f5502310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306e023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2223302310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0004deadbeef",
+          "result" : "invalid"
         },
         {
           "tcId" : 133,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "truncated length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30650230814cc9a70febda342d4ada87fc39426f403d5e898084284644bb7cded46091f71a7393942ad49ef8eae67e7fc784ec6f02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3035023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20281",
+          "result" : "invalid"
         },
         {
           "tcId" : 134,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "including undefined tags to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30660231ff7eb33658f01425cbd2b5257803c6bd90bfc2a1767f7bd7b9f3e1359f376840298d725eb98c7ab98c282d68156bb5ea1e02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306c023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e22237aa02aabb02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 135,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "using composition with indefinite length for s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "306502307eb33658f01425cbd2b5257803c6bd90bfc2a1767f7bd7b9bb4483212b9f6e08e58c6c6bd52b610715198180387b139102310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2228002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 136,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "using composition with wrong tag for s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30660231fe7eb33658f01425cbd2b5257803c6bd90bfc2a1767f7bd7ba2c7de81d4331124a3558510743ca12113b414eaa9ef0c0ab02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2228003310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000",
+          "result" : "invalid"
         },
         {
           "tcId" : 137,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "Replacing s with NULL",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023101814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3035023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20500",
+          "result" : "invalid"
         },
         {
           "tcId" : 138,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "306502307eb33658f01425cbd2b5257803c6bd90bfc2a1767f7bd7b9f3e1359f376840298d725eb98c7ab98c282d68156bb5ea1e02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e200310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 139,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310184f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e5fd3ad1cb7a61dc9507f6eeb2a65341ad0cac035dfee58d140",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e201310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 140,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2023084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e6044e681b3bdaf6d91cf3acfc5d3d2cbdaf0e8030a54ce7e5a",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e203310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 141,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20231ff7b0a10ee2dd0dd2fab75095af240d095e446faba7a50a19ff3b630ca4e19648ed8ab2287e37c8caa222be38ade6c5833",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e204310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 142,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20231fe7b0a10ee2dd0dd2fab75095af240d095e446faba7a50a1a02c52e34859e236af809114d59acbe52f353fca2011a72ec0",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2ff310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 143,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "dropping value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310184f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3035023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20200",
+          "result" : "invalid"
         },
         {
           "tcId" : 144,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "using composition for s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3065023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202307b0a10ee2dd0dd2fab75095af240d095e446faba7a50a19ff3b630ca4e19648ed8ab2287e37c8caa222be38ade6c5833",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306a023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e22235020100023084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 145,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020100020100",
-          "result" : "invalid",
+          "comment" : "modifying first byte of s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310284f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 146,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020100020101",
-          "result" : "invalid",
+          "comment" : "modifying last byte of s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a74d",
+          "result" : "invalid"
         },
         {
           "tcId" : 147,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201000201ff",
-          "result" : "invalid",
+          "comment" : "truncated s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3065023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202300084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7",
+          "result" : "invalid"
         },
         {
           "tcId" : 148,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020100023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "s of size 4146 to check for overflows",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30821069023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2028210320084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 149,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020100023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "leading ff in s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3067023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e20232ff0084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 150,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020100023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "replaced s by infinity",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2090180",
+          "result" : "invalid"
         },
         {
           "tcId" : 151,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020100023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "replacing s with zero",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e2020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 152,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020100023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "replaced r by r + n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023101814cc9a70febda342d4ada87fc39426f403d5e8980842845d38217e2bcceedb5caa7aef8bc35edeec4beb155610f3f5502310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 153,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3008020100090380fe01",
-          "result" : "invalid",
+          "comment" : "replaced r by r - n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30650230814cc9a70febda342d4ada87fc39426f403d5e898084284644bb7cded46091f71a7393942ad49ef8eae67e7fc784ec6f02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 154,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020101020100",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 256 * n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306702320100814cc9a70febda342d4ada87fc39426f403d5e898084280d6f6c4c54ffc59f2e8c9b538f242cc160c3ec02b7597388e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 155,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020101020101",
-          "result" : "invalid",
+          "comment" : "replaced r by -r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30660231ff7eb33658f01425cbd2b5257803c6bd90bfc2a1767f7bd7b9f3e1359f376840298d725eb98c7ab98c282d68156bb5ea1e02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 156,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201010201ff",
-          "result" : "invalid",
+          "comment" : "replaced r by n - r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306502307eb33658f01425cbd2b5257803c6bd90bfc2a1767f7bd7b9bb4483212b9f6e08e58c6c6bd52b610715198180387b139102310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 157,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020101023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "replaced r by -n - r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30660231fe7eb33658f01425cbd2b5257803c6bd90bfc2a1767f7bd7ba2c7de81d4331124a3558510743ca12113b414eaa9ef0c0ab02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 158,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020101023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 2**384",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023101814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 159,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020101023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 2**448",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306e0239010000000000000000814cc9a70febda342d4ada87fc39426f403d5e89808428460c1eca60c897bfd6728da14673854673d7d297ea944a15e202310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 160,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020101023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "replaced s by s + n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306602310184f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e5fd3ad1cb7a61dc9507f6eeb2a65341ad0cac035dfee58d14002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 161,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036020101023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "replaced s by s - n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3065023084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e6044e681b3bdaf6d91cf3acfc5d3d2cbdaf0e8030a54ce7e5a02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 162,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3008020101090380fe01",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 256 * n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30670232010084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e276f975129e9147ac941628fc0cd2aee42c9ed8741e6bd1acd02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 163,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff020100",
-          "result" : "invalid",
+          "comment" : "replaced s by -s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30660231ff7b0a10ee2dd0dd2fab75095af240d095e446faba7a50a19ff3b630ca4e19648ed8ab2287e37c8caa222be38ade6c583302310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 164,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff020101",
-          "result" : "invalid",
+          "comment" : "replaced s by -n - s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30660231fe7b0a10ee2dd0dd2fab75095af240d095e446faba7a50a1a02c52e34859e236af809114d59acbe52f353fca2011a72ec002310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 165,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff0201ff",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 2**384",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306602310184f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 166,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30360201ff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "replaced s by s - 2**384",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3065023084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 167,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30360201ff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 2**448",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306e023901000000000000000084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd02310084f5ef11d22f22d0548af6a50dbf2f6a1bb9054585af5e600c49cf35b1e69b712754dd781c837355ddd41c752193a7cd",
+          "result" : "invalid"
         },
         {
           "tcId" : 168,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30360201ff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 169,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30360201ff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 170,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30360201ff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201000201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 171,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30080201ff090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020100023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 172,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020100023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 173,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020100023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 174,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529730201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020100023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 175,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020100023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 176,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 177,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 178,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201010201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 179,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020101023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 180,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3038023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020101023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 181,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020101023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 182,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020101023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 183,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529720201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036020101023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 184,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 185,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 186,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff0201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 187,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30360201ff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 188,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30360201ff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 189,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3038023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30360201ff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 190,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30360201ff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 191,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30360201ff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 192,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529740201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 193,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 194,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529730201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 195,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 196,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 197,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 198,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3038023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 199,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 200,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 201,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff0201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 202,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529720201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 203,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 204,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 205,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 206,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 207,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3038023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 208,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 209,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 210,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000001000000000201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529740201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 211,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 212,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 213,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 214,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 215,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 216,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3038023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=p and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 217,
-          "comment" : "Edge case for Shamir multiplication",
-          "msg" : "3637323636",
-          "sig" : "3066023100ac042e13ab83394692019170707bc21dd3d7b8d233d11b651757085bdd5767eabbb85322984f14437335de0cdf5656840231008f8a277dde5282671af958e3315e795a20e2885157b77663a67a77ef2379020c5d12be6c732fd725402cb9ee8c345284",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 218,
-          "comment" : "special case hash",
-          "msg" : "33393439313934313732",
-          "sig" : "3065023100d51c53fa3e201c440a4e33ea0bbc1d3f3fe18b0cc2a4d6812dd217a9b426e54eb4024113b354441272174549c979857c02300992c5442dc6d5d6095a45720f5c5344acb78bc18817ef32c1334e6eba7726246577d4257942bdefe994c1575ed15a6e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=-1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff0201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 219,
-          "comment" : "special case hash",
-          "msg" : "35333637363431383737",
-          "sig" : "3065023100c8d44c8b70abed9e6ae6bbb9f4b72ed6e8b50a52a8e6e1bd3447c0828dad26fc6f395ba09069b307f040d1e86a42c022023001e0af500505bb88b3a2b0f132acb4da64adddc0598318cb7612b5812d29c2d0dde1413d0ce40044b44590e91b97bacd",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 220,
-          "comment" : "special case hash",
-          "msg" : "35363731343831303935",
-          "sig" : "3065023100d3513bd06496d8576e01e8c4b284587acafd239acfd739a19a5899f0a00d269f990659a671b2e0e25f935b3a28a1f5fd0230366b35315ce114bffbb75a969543646ee253f046a8630fbbb121ecc5d62df4a7eb09d2878805d5dab9c9b3880b747b68",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n - 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 221,
-          "comment" : "special case hash",
-          "msg" : "3131323037313732393039",
-          "sig" : "3065023100b08c4018556ca8833b524504e30c58346e1c0345b678fdf91891c464a33180ed85a99bc8911acf4f22aceb40440afc9402304a595f7eed2db9f6bd3e90355d5c0e96486dc64242319e41fc07be00a732354b62ec9c34319720b9ffb24c994b1cf875",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 222,
-          "comment" : "special case hash",
-          "msg" : "3131323938303334323336",
-          "sig" : "306502302b08f784617fd0707a83d3c2615efa0c45f28d7d928fc45cd8a886e116b45f4686aee97474d091012e27057b6ba8f7e6023100c440aa6ecb63e0d43c639b37e5810a96def7eec8e90a4c55e5b57971c48dfb4e850232fbb37bd32bb3b0523b815ff985",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=p",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 223,
-          "comment" : "special case hash",
-          "msg" : "39383736303239363833",
-          "sig" : "306402300609f4ec120c8838bda916f668e9600af7652e1d3f7182734f97f54da5d106bbfd216c32f227b76d583de1c53949b2ee023046926dffc766ff90c3b921b3e51a2982a1072314c1fdfb4175de7adea5a6f97bdff587a473504a9c402aac7c05bd4785",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=p + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 224,
-          "comment" : "special case hash",
-          "msg" : "3230323034323936353139",
-          "sig" : "306502305ae2220e4716e1ef0382afcc39db339e5bd5f05e8a188d4a5daaab71c6c35263ee8820a34558092877449ebb15898c5c023100c4d38e2e85451c43ee35b0c56196cbf3059acf2b8b529f06dc1de9b281d9b0f3f3983df8936e944ab0b18330a342ee88",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=0",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 225,
-          "comment" : "special case hash",
-          "msg" : "31343531363639313830",
-          "sig" : "3065023051fb84ed71d436c737ab24e2a45c68f8f623748be2caebd89e02bfc89309b8350042ab1b97849b9f680f044a58765175023100d4a8f60791657a8c12985fd896ac77e7d95cb050582f2466471dc2c6dcf90db05ce34beadbfcfe690dc56c0cc9944007",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 226,
-          "comment" : "special case hash",
-          "msg" : "31303933363835393531",
-          "sig" : "3065023040159290d161df6b3f81a92cefb6df56149d588e7b886bf24939f5c8b6bb515d325b3764f0ed284a77fa9081ccfa5237023100bd55dfb47709287ce7b88dfd96ac7543eeba9bd31b8c91f203d2b90418122406399c80a53539b81f1cb60fa3b23a2563",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=-1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000001000000000201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 227,
-          "comment" : "special case hash",
-          "msg" : "36323139353630323031",
-          "sig" : "3066023100d7fb9f53865cdf9d4cad6f66981aea35a1454858ceb678d7b851c12a4c6644fe1915a4b219b51389a5ae2c98a433cc3a02310094ad75c3dea88740205cab41032dfe149341cf4ee94dcd2f0c8bbe5af5860b30b5e1f764b2c767b09fd10761050c989c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973",
+          "result" : "invalid"
         },
         {
           "tcId" : 228,
-          "comment" : "special case hash",
-          "msg" : "35363832343734333033",
-          "sig" : "30650230157ef8f85cdb9257983d06a7f29674752659097364b401e701705b3bd9ead884fd32141320ae76ae05f6fc7ec155d6c2023100ccadc3851020e41dd91bc28a6c073409136a47f20b8dbf2553fd456a8ed5fa7e73e4ec59dca499e0d082efbb9ad34dc7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n - 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972",
+          "result" : "invalid"
         },
         {
           "tcId" : 229,
-          "comment" : "special case hash",
-          "msg" : "33373336353331373836",
-          "sig" : "3066023100e763001769c76f6a6d06fad37b584d7f25832501491bec283b3b6836f947dc4e2cef021c6c6e525b0a6a3890d1da122a023100acbd88729cce3992d14ec99e69ff0712b82a33a1c1e8b90e1399c66fe196f7c99bdb3ff81db77dc25ae6f0c1a025117d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52974",
+          "result" : "invalid"
         },
         {
           "tcId" : 230,
-          "comment" : "special case hash",
-          "msg" : "34373935393033373932",
-          "sig" : "3066023100c6425b6b046ec91ebc32b9e6de750e5d3d36d4ddc6dffd25ba47817385a9466f6fc52259c7d02c66af5bf12045b5659d02310084cdc06e35fecc85a3e00b16488eac3584942f663d8b59df111c0650139d7cda20d68dccae569d433170d832147bc94c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=p",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 231,
-          "comment" : "special case hash",
-          "msg" : "39333939363131303037",
-          "sig" : "306502303061f090e4932133a0e08ac984d1c8d8d4f565e21cf15427671503880341265cd44f35a437ee3c3a8857579dd7af0c3502310093ae374a0f63dcbe41a1b7b07a50faf2b33f35e0b6600bb36aa5cda05238640fa35c635c0fa78e1410f3a879bbb8a541",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=p + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff000000000000000100000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 232,
-          "comment" : "special case hash",
-          "msg" : "31303837343931313835",
-          "sig" : "306502300ccc627f35454cc84e08a828f5bd5f5e41eeeaa40475bcc2e71ff372e8c718a5e179d3b7f2d7051db9060c4c978eb638023100b12d0240afbdfc64c60861548c33663b8960316a55f860cc33d1908e89aa6fc9519f23a900e0488fa6a37cfb37856565",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008020100090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 233,
-          "comment" : "special case hash",
-          "msg" : "33323336363738353030",
-          "sig" : "3065023100e72419fb67ebbcc0de9c46ce5475c608f9de7e83fc5e582920b8e9848000d820d393fdac6c96ea35ce941cb14951640002306aa19934ef60f4a247bc261ba256283a94857a268f42a0939c95a536fbd4f8e1f1c285a7b164c12213abb9e3393cbe9f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 234,
-          "comment" : "special case hash",
-          "msg" : "31343438393937373033",
-          "sig" : "30660231008b740931f9afa8a04c08cde896b7fdd9aca3177d5e4a3e5a51e54bfa824b66ab11df4e90f49798d644babfede7830224023100afd91e7ce15059a5b5499e5aef4afa91fd090e4e5029b3f4348f0d4349df11745869f9255117eea405a78af5dd6a646d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 235,
-          "comment" : "special case hash",
-          "msg" : "35373134363332383037",
-          "sig" : "3066023100989024bce204a7539fbd2b185ecf375590d873177c1ff26bbf755838ae5bcde180054663702ac3a4e68fe8b58fd88c70023100bdbedf64e424dbd7f979f83adef3fc85077fa76f8b1724815b5b8c24fde7fbd72f4b369a415d9bbf565cdc459bdce54c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 236,
-          "comment" : "special case hash",
-          "msg" : "323236343837343932",
-          "sig" : "3064023022624fc23403955c0c9f5b89871177fa53879c8424de3b4ab1bcbcddc6e57b870b0491b848e19f728722b3163f4aa32802305bb82642cdaa84d6977fb95b3ede4ec7f2d54881cf435636d3509816f13ebb7be24fd7d4e1e81fddf07bde685e8d630d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201000500",
+          "result" : "invalid"
         },
         {
           "tcId" : 237,
-          "comment" : "special case hash",
-          "msg" : "35333533343439343739",
-          "sig" : "3065023100da5a2daa7437df4566ebba6ac5ed424655633e354ef4d943dc95ddefb0dae69f3616e506cc8cb5bc433a82ba71f6feb402305107b24041bba45073ce54488a5aef861e7805bbb8f970aedc1c59149cfe72c7025e2d117337e8677c88ef43374e6907",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201000c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 238,
-          "comment" : "special case hash",
-          "msg" : "34373837333033383830",
-          "sig" : "306402302b0659fb7fa5fc1fce767418c20978de9a6a59941fc54f8380619b2ab2a7d6039de5373fbb503c24f2ce38e9c57995de02300d94dba98dd874bfffeac96a9295b6ab667708b8e33252edc029574c484a132135b13e52db6f877987c1be4f51fca193",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201000c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 239,
-          "comment" : "special case hash",
-          "msg" : "32323332313935383233",
-          "sig" : "306402304a5a14f1ecf053bf3ec14843db8c7dd153e9545d20d76345a9e1d1a8fcb49558ca1ee5a9402311c2eaa102e646e57c2c02301573b8b4b633496da320e99a85c6f57b7ee543548180a77f7fced2d0665911cb4cde9de21bc1a981b97742c9040a6369",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201003000",
+          "result" : "invalid"
         },
         {
           "tcId" : 240,
-          "comment" : "special case hash",
-          "msg" : "3130373339333931393137",
-          "sig" : "30650230104e66e6e26c36633c0af001f0d9a216236816923ec93b70bea0a8ff053a15aaaef5fe3483e5cc73564e60fe8364ce0e023100ec2df9100e34875a5dc436da824916487b38e7aeb02944860e257fd982b01782b3bd6b13b376e8a6dbd783dfa0d77169",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201003003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 241,
-          "comment" : "special case hash",
-          "msg" : "31383831303237333135",
-          "sig" : "306402304b06795da82bda354e8d9422a76c7bc064027fcdd68f95b7bc6177a85b2d822c84dc31cb91fc016afa48816a3a019267023018e31018e312d3dd3dd49ec355fdb0def3bb3e44393c26cf1bc110b23a3aacf6c442bfcec5535ce37527d0e068f75c03",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008020101090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 242,
-          "comment" : "special case hash",
-          "msg" : "36303631363933393037",
-          "sig" : "3066023100ad75ca5a3df34e5a6d3ea4c9df534e8910cfb1d8c605fc398fbee4c05f2b715bd2146221920de8bac86c2b210221bcff023100a322d3df3bb2cf9e4215adf1ff459e70f2f86bec6dd6af5d04ae307d21ed5955136c8e258fdc0f9cbd6cf89c31aa691f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 243,
-          "comment" : "special case hash",
-          "msg" : "38383935323237303934",
-          "sig" : "3065023100b0fa6289cc61bab335932ea1ac6540462653cc747ef67827825f77689a4398602297835d08aa16e23a76dea9f75404ef0230278d654a0b50c57d13f9c9c8c7c694001167f8e3b71491772a7427f1410fb6de518740c22e455e58de48846479b300cc",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 244,
-          "comment" : "special case hash",
-          "msg" : "31353830323334303934",
-          "sig" : "3065023100c216cb4fe97facb7cd66f02cd751155b94fa2f35f8a62ba565aca575728af533540ff5d769b7c15c1345ab6414e150680230278a8a372b75d6eb17a4f7c7f62d5555c7357a1a047026bead52185cbcc01d73b80a1577e86220b2278da2b1ee8c983a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 245,
-          "comment" : "special case hash",
-          "msg" : "33393635393931353132",
-          "sig" : "30660231009591c80453cffbcd0b8d6d20fce0cbb2a458e54aed7ba1c767e6c017af4c4aa07a76859c0b249f6692a3c9ace893f14e023100893b567cd2959cd60557d3d6013d6e1741421a6edc5bc18244b3e8d7744e57928ce006a3fbd6e6324cb8ea3e5177e7e3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201010500",
+          "result" : "invalid"
         },
         {
           "tcId" : 246,
-          "comment" : "special case hash",
-          "msg" : "32323838373332313938",
-          "sig" : "30650230350b5515ba9785f149e2a566c14f4178757bb325179888f526f7db11161aedcd752551381316c2713f5de21d3d517af002310097d48a90c3bb3444736bec69db0649f82428b39238ada6048a0bead84f2f3b73816b48fed4d57b5f87a194ce4004ed7b",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201010c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 247,
-          "comment" : "special case hash",
-          "msg" : "32323330383837333139",
-          "sig" : "3066023100833210c45d2448d9a4d69622d6f2193e64c65c79d45d62e28f517ca5c68eef05a2e98b1faed4cc87cbdbec6fe6bb8987023100b777b44cd30e6a049dc56af19a251d955c1bbab0c307fe12e9e5382fd48c173db0292f0b1047da28ee18518e11688eea",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201010c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 248,
-          "comment" : "special case hash",
-          "msg" : "313239303536393337",
-          "sig" : "306402307728ef10d9d5f3f32132716e6b403926929b05201700658d4b7f25a0692f153b8d666fd0da39888ab6234212659268d0023055df9466ee2c98225a2b0c4ff77622f9d11b4e48aa7f9279cdc2e245fdd9b9f4282106e25a458ff618bc3ca9422bea25",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201013000",
+          "result" : "invalid"
         },
         {
           "tcId" : 249,
-          "comment" : "special case hash",
-          "msg" : "32373438363536343338",
-          "sig" : "30640230552040701dba17be3b4d5d6e136ce412b6a4c50ce1ee53415d8100c69a8ee4726652648f50e695f8bb552d0df3e8d1c402301374972b2f35b2fd86d45ed0c9358b394e271575e429ac8aa60eb94b9df7e755d9317fb259269e9d3b1db8d48d91dc7e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201013003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 250,
-          "comment" : "special case hash",
-          "msg" : "37353833353032363034",
-          "sig" : "3065023100fe6ef07056ce647128584bec156b68b8005f42d8c85dfb122134c488cc0e72cf8f06700417d7ff694b45e894ec23cbbd02307f5e33c5bfa697c144d440b32d06221f630a9ccaa8e9a0489490c04b86e8daae0e41d2466429b4b3cc1d37348e36cc0b",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201ff090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 251,
-          "comment" : "special case hash",
-          "msg" : "32333237373534323739",
-          "sig" : "3065023100e009fc1a13d282bd37f10693350a5b421a0039713d29cb9e816e013c173bd1ec2bd6eb6bd88429023ee3d75d9a5ec06f02300b8bd481982a6e52355bcde5fe0092abac41f0543c31d1928b9a585e63e9520e24a65f46db2696e1b85a65c4e5240879",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 252,
-          "comment" : "special case hash",
-          "msg" : "373735353038353834",
-          "sig" : "3065023100acee00dfdfcee7343aeffa8514b11020c5435027887529d255bdbd45a90f160c68f05bd4b567daa8fa14e5807f5167a402301c9fdf546190970aa33121a3043280669be694e5f700b52a805aa6101b4c58f0467e7b699641d1d03f6229b2faf4253f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 253,
-          "comment" : "special case hash",
-          "msg" : "3137393832363438333832",
-          "sig" : "30650231008a4ee1e3bb251982475877d18763fafcf49ccc8b0fec1da63b0edccbb8d3e38608a2e02d0d951031179e12ac899d30c3023073cb62ad7632cd42dff829abfbfcb6165207e3708ed10043c0cdee951c7f8012432696e9cf732dcbadb504630648419f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 254,
-          "comment" : "special case hash",
-          "msg" : "32333936373737333635",
-          "sig" : "306402303903b59f837ff5f41f42cbe3e2fc8e17d859cbb35386c4327d3947fb012b3629fea911c83cefdbd503aebbcc1114afd102300e5be9094b5a22ade00c24644f476baad0f7741dfb2ce9644a1c45769404f8dccc522017c2b8cc630f1a0ef5fee99fe8",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 255,
-          "comment" : "special case hash",
-          "msg" : "35393938313035383031",
-          "sig" : "306502307717ffc8d0811f357299423c56ec181c58f1981f5c1dd4f346f6a2ad71d3582e203a11e8609c1146ff3247a1820f832c02310096c89ec707da3cd8b09084b065e3265327a536a974c4285155388011e348f2e7f005ae7e3e502732fc2971ac13fd72c0",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff0c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 256,
-          "comment" : "special case hash",
-          "msg" : "3136363737383237303537",
-          "sig" : "3065023100a21519ce3533c80826f1e47fa9afde7096151144291134421990285a8d89a8c2d4afdadd547a923dcc17bfcdd0e9ffb9023040577245dd2e022c8ed8b5de7b8c26f31307429a7a64e5729311cc4128e3b486867e61b4a8a1cd0731792eb1466d08f3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff0c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 257,
-          "comment" : "special case hash",
-          "msg" : "323036323134333632",
-          "sig" : "3065023100a727addad0b2acd2942cb1e3f7b2917ca65453275198b06436a993bfc982d3f54620c395e253d57b8fe026efcf7252f902307a19811aa4c12c45c3c041e7c614d0d98051ca7a0c57a9a107d552793ba1d0debb373525aafcc13ae1acd50a42a89adf",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 258,
-          "comment" : "special case hash",
-          "msg" : "36383432343936303435",
-          "sig" : "3065023022287277872d175d8a3ff5be9818658f845eb9c1b2edc093ae82a75aa31cc26fe1771b4bfbd4c320251388d7279b5245023100b47d1833867e889fcfd7ac171855293a50aa6db24c6522e374fe87be12bf49b13c8b5e1455a2f25aa7912f799eebe552",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201ff3003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 259,
-          "comment" : "special case hash",
-          "msg" : "33323639383937333231",
-          "sig" : "3065023100a0f41362009b8e7e7545d0f7c4127e22d82ac1921eb61bf51e9ea711e41557a84f7bb6ace499a3bc9ebca8e83728787b02301f6e0c15a3e402370885e2aceb712280ebc45b63986357765b7e54b06cd00db8308e4715c39d48d246030bf960e6a2ff",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3038023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 260,
-          "comment" : "special case hash",
-          "msg" : "31333837333234363932",
-          "sig" : "306502304144e1c6ad29ad88aa5472d6d1a8d1f15de315f5b281f87cc392d66d7042547e6af7c733b31828f89c8a5dafce5bb9af023100f5d0d81f92428df2977757c88ba67f9e03abd4c15b1e87fa1dd49e601a9dd479e7c3dc03a8bfea60fcfc1c543931a7de",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 261,
-          "comment" : "special case hash",
-          "msg" : "34313138383837353336",
-          "sig" : "306402305f177fc05542be6e09027b7eac5eb34f34fc10ad1429e4daaea75834de48dd22626f2bf653dfcc46234921d19b97406b02307def6c993a87560425f2c911046357c4b1c4c376bfa22bb45d533654fea6f565ba722147b2269ea7652f9c4af62ed118",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 262,
-          "comment" : "special case hash",
-          "msg" : "393838363036353435",
-          "sig" : "3066023100bd77a8ff0cd798d8f6e75dfbbb16c3ee5bf3f626dcb5abdfd453b301cb4fd4caee8e84dd650a8b4cf6655dea163788c7023100ef8f42394469eb8cd7b2ac6942cdb5e70dd54980ad8c0c483099573d75b936880459c9d14f9e73645865a4f24ee2c4ce",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52973010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 263,
-          "comment" : "special case hash",
-          "msg" : "32343739313135383435",
-          "sig" : "3066023100a02e2196258436da6a35a2f73cf6b08880f27757566ce80c7fc45f5dcbaec62d3fcebb784b4a650e24c1a997e4b971f7023100f1195d2ba3321b6938e04169d7baf605001b6311f08a5e82157a7675d54993f2fd1e41f8c84fc437a1a139d2e73e8d46",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529730500",
+          "result" : "invalid"
         },
         {
           "tcId" : 264,
-          "comment" : "special case hash",
-          "msg" : "35303736383837333637",
-          "sig" : "30640230686c5dfe858629125fdee522b77a9b9be5e03a347d79cb4c407f17fd25c97293cd99711f33e77814bd30d2453d3a86c10230509ac9b18c1b2b5a2b1b889d994b950743a988c2fcfb683e89211a43da6ee362c2e414d84fe82db1904b81701c257822",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529730c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 265,
-          "comment" : "special case hash",
-          "msg" : "393838353036393637",
-          "sig" : "306502310083ce818ecd276432a8ddfe75406d01329e76d7586cd6f611c1fe1a0913ad80014c2156381942d58dd6356e44ccdc52a8023036a35983b97a9ae2a19cf05ba947dd880c973d5c78f9676ebbcb0b40d639124030c137236232f1fad15afd71c52ad8ec",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529730c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 266,
-          "comment" : "special case hash",
-          "msg" : "32373231333036313331",
-          "sig" : "306502307cb78ebb712b5a2e0b0573d28440a5da36bd2338805d90ef3b0c1178ae613be8ae8bf548af4e7403e5a5410462afc2e30231008631a82cbdb8c2c7df70f012405f06ad0ab20d6c4fbceb3e736f40fdff1a8e5f6e667a0e77259f277494de84ec0de50d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529733000",
+          "result" : "invalid"
         },
         {
           "tcId" : 267,
-          "comment" : "special case hash",
-          "msg" : "33323034313031363535",
-          "sig" : "306602310085110fe21156b7764b91bcb6cf44da3eb21d162395071c216a13b5920d67a31aaa20dfc4669cf32c04964d0831bcdc29023100e19187033d8b4e1edf7ab8eaaae1e13c80c0c4db51d921ccf62f424524cbd530d07de2cf902a0ecda5e01206ae61e240",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3038023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc529733003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 268,
-          "comment" : "special case hash",
-          "msg" : "33313530363830393530",
-          "sig" : "306402300fd621a892ee5a3eb0bcb80f3184714a6635f568d92f41ad8d523887d5b82d2b930eb5ff2922fda1a3d299f5a045837f02301278725a607fa6f2fc7549b0de816fe2f88e3a1ec1ccaf9fb58e70a0f6646c2d7aad6e4f73d116e73096bdef231d0c89",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3038023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 269,
-          "comment" : "special case hash",
-          "msg" : "31373237343630313033",
-          "sig" : "3066023100802cbe405d3ce9663b0b13c639aa27730b3377ce42521098ae09096b7fc5e7ac998b6994344e89abfb50c05476f9cae80231009aa7258c0dc4eff4b2d583575368301e2a7865cfaa3753055a79c8b8e91e94496a5d539181c2fd77941df50fe87453cd",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 270,
-          "comment" : "special case hash",
-          "msg" : "3134353731343631323235",
-          "sig" : "3066023100859b0446949d7f78a0301ac4cc02b599a758fd1be006bf1a12570015869e59b9a429ce1c77a750969f49e291f6ab899402310099a812a1acc2c646814315cf9b6290d2232236cdf131f9590088e75a55786cdfc9d9027ec70056408ab55445fd79fe60",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 271,
-          "comment" : "special case hash",
-          "msg" : "34313739353136303930",
-          "sig" : "3065023100dbcc7ee9fa620e943193deae3f46b3142779caa2bce2df79a20639c8d01bce414a61f72764c1ec949c945320f5ee2a1d02301d9879787b880bd05db39bac07bfe3e7d0792932144e211e81f21da9621b83bff11bc52bcc7cb40cf5093f9bad8650fb",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 272,
-          "comment" : "special case hash",
-          "msg" : "35383932373133303534",
-          "sig" : "306402307a1f9fbd0f6e776c3e3a3c798f5c0d9e20f0e2f3f4d22e5893dd09e5af69a46abc2f888d3c76834462008069275dfeb9023045e6d62a74d3eb81f0a3a62902b8949132821b45d8e6cad9bb3d8660451727cdf7b332a9ac7bb04604991312143f8a6a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 273,
-          "comment" : "special case hash",
-          "msg" : "33383936313832323937",
-          "sig" : "30640230047962e09e1b61823d23726bf72b4dde380e032b534e3273db157fa60908159ab7ee4cadce14fd06ebe8e08e8d8d5a0702301892f65ee09e34ce45dd44b5a172b200ce66b678b0e200c17e424e319f414f8dfbb2769a0259c9cc105191aa924e48d5",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff0c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 274,
-          "comment" : "special case hash",
-          "msg" : "38323833333436373332",
-          "sig" : "30660231008f02799390ab861452cd4949942cbbcc25cad7c4334c4bc6146fbef8ad96c86f923fbf376d9ab79073e5fcb663f1ea91023100ce15d9862d100ff95ad7368922eec3f6d7060ce412c01ff13870aa61626ee49edf39bb27005ecbe406bb6825f74c0438",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3036023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff0c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 275,
-          "comment" : "special case hash",
-          "msg" : "33333636393734383931",
-          "sig" : "306502301879c4d6cf7c5425515547575049be2a40c624a928cf281250f8bdcbf47e9f95310d0992c9887dc6318b3197114f358e023100e1116bf68320bade7d07a1a9651512d60b551af8625b98b5eb8ca222d4073ae5c140a80e5dbe59f073647daa00837aee",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3035023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 276,
-          "comment" : "special case hash",
-          "msg" : "32313939313533323239",
-          "sig" : "3064023031dced9a6767f39045472749baec1644ae7d93a810a4b60eb213c02c42de65152ffc669af96089554570801a704e2a2d02303022ecfbc88a72b9c50ef65344765b615738f2b3d420ade68cbf3ec40bef0e10c5cc43bcfe003bb6f17ec23802c40569",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3038023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000ffffffff3003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 277,
-          "comment" : "special case hash",
-          "msg" : "35363030333136383232",
-          "sig" : "3066023100f4bdf786c61c5f1ce7568638ba9dbc9a134e27fc142003bf9870353980a8f4c2fbd03c8d0171e4048ef30db6fe15388a023100d0e96768bc6adc91f93ae5704e86888853f479f32a45bfd436dc8a030603d233c56880124b7971362aa11b71315ae304",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0.25, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300a090380fe01090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 278,
-          "comment" : "special case hash",
-          "msg" : "383639363531363935",
-          "sig" : "3065023100ec0f635b7ce31988a07f41b3df35ca03c70e376bfb3b6ab24831a83be2121b9f9e93928b10a8f5fc0322bdb9edd406fe023066618ccb473c6dac3b14cfab6dfb24d219b37aec63425067c2c1c631d64a80b9cab6445f5a5439adb28bb99daa9234a5",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=nan, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006090142090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 279,
-          "comment" : "special case hash",
-          "msg" : "36353833393236333732",
-          "sig" : "306402304f2bea24f7de57901e365d4c332ddb62d294d0c5fd58342a43bdd3ba5cbaf25adaddb5944bfef9dcc88f94d93650bbbb02300851b97ddc433e4521c600904970e2bf55aa901e1aaaaf06818377f84a28e033a49eebc21ffe9cff3cbefd0963fbed00",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=True, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010101010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 280,
-          "comment" : "special case hash",
-          "msg" : "3133323035303135373235",
-          "sig" : "3064023072a9bab30f8da1437f17115cc37b6ef8cf6591ed934d596675ad7b000c6a74cca5f37210a68228a58023790e3726c357023012d697c4e20b18f63a3e0164dca8ca4a5fa0058ad7cd1c571cef356e85fd8f56ab7963d8aba824e8d31efb3e690c27b9",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=False, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010100010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 281,
-          "comment" : "special case hash",
-          "msg" : "35303835333330373931",
-          "sig" : "3064023033b7105f4cc98a1ea2abad45dbbe3761b4613ddd350e62da91560da694be3e84b1684f9a8ee4b3f556c61d02af54446202302c86e3a216dc7dd784cdcbf5084bdf6cdc1c7e67dbd61f9f6ed161fda4d4c26167e5b12731cf2b0cf5d9a5f0b6124939",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=Null, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300405000500",
+          "result" : "invalid"
         },
         {
           "tcId" : 282,
-          "comment" : "special case hash",
-          "msg" : "37383636383133313139",
-          "sig" : "30640230252e3b5b60b8f80748b83623e30013723115cabcc48770c0ab6e7ee29c429ef1d9da78db3a9a8504133b9bd6feceb82502301ba740f87907cf6d450080f7807a50f21c31cd245dd30f95849a168d63b37628e8043c292ab7f130a4468eaf8b47e56d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30040c000c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 283,
-          "comment" : "special case hash",
-          "msg" : "32303832353339343239",
-          "sig" : "3066023100b8694dbf8310ccd78398a1cffa51493f95e3317f238291771cb331f8e3a9753774ae3be78df16d22b3fbe9ad45bed793023100daaead431bbdbf8d82368fbbd2473695683206ee67092c146b266ed32f56b31cb0f033eebf6c75118730eef7b7f96ba7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=\"0\", s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060c01300c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 284,
-          "comment" : "special case hash",
-          "msg" : "3130303635393536363937",
-          "sig" : "3066023100d37ba39cd1b5289e7aa3f33afefa4df6821a07d3e8ee1c11e7df036c37e36214bb90264633d4c395644cd2cc2523833f0231008b0d58ed75af59e2abbcec9226836f176b27da2d9f3094f2d4a09898136436235025208cf5444265af66fed05b3dc27c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empty list, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300430003000",
+          "result" : "invalid"
         },
         {
           "tcId" : 285,
-          "comment" : "special case hash",
-          "msg" : "33303234313831363034",
-          "sig" : "3066023100b4ef419020c0dcbdeeeed76c255560f1ed783c0f9e7fcea4c08a0714b9d1f491fda9ae7bb1eb96d294b02799f82861290231008d987611063d2f28cb309a56eaf1ea65f27d95c97b77a5f037f2f914fed728267aaf62a37f3c7b44fc4b15125b349863",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=list containing 0, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300a30030201003003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 286,
-          "comment" : "special case hash",
-          "msg" : "37373637383532383734",
-          "sig" : "3066023100b2df7b11cf60ac93c078d19f37f889717aa5d9af1d00d0964f9e9f5257c3b51b3d3e47ca5b5aa72058ed63b52464e582023100b524968ea8c58d379e38f4cfa9da1527a2acb26d605d22f173fcf1e834db0d7f031cb9245cb62b8458ff499b8d3decbe",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0.25, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008090380fe01020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 287,
-          "comment" : "special case hash",
-          "msg" : "353434313939393734",
-          "sig" : "3066023100e0edc08b4122b75ebbd1635d07f0bb55771bda15573a5081da971955f9a63f6decdd4919911dbfea503ea8ed1faad93d023100ca7850c74ce878587056206c590a1097d197a2090cfe3e057becfa2700c7a531623ae7331e163def693e26a97feb540d",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=nan, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006090142020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 288,
-          "comment" : "special case hash",
-          "msg" : "35383433343830333931",
-          "sig" : "3065023068f555eef5a323a929719bfd8cf81d6d8a977ecb35defd86fa54d8e5749c7b5f3e80087fbd39f8aa0cd29d8310bd6578023100e2c2314a50fc0ad78c1ec02ea77ee2e13dcef1460957c6b573f721d72c209ac5fb529ab20397234c59ed44f60400971a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=True, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010101020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 289,
-          "comment" : "special case hash",
-          "msg" : "373138383932363239",
-          "sig" : "30660231009e330e29f18123813e83b9c6abd68de96a57f97a4005b88d5b470a67a541b6d3af12124cf8658b751671c6698fb8b021023100d210fba9bde6ef077ca06b75e1cf7ce8dd70b08e9dd42d81a215ef9272f1779ae3e9f0dec510571d87237cc6bf3203e8",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=False, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010100020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 290,
-          "comment" : "special case hash",
-          "msg" : "31373433323233343433",
-          "sig" : "30650230483192056f753f64ddf0f21072b73d68893e6fa5432c981c7a1955b6592a6045a5c1c58c383e70023c34e09b7964ec8d02310094b005d5f98c4fd2ad40ff8e03a8599f45e206082112f834df1d48502d2ac690cd3204f0078913794c9c39077ad6c58b",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=Null, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050500020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 291,
-          "comment" : "special case hash",
-          "msg" : "32343036303035393336",
-          "sig" : "306402302b7ec14fd77c4b33230dd0a4e2710fbd307e469baec54b6f25daac7e196b7b4b5df251cdddba7bdc9836ca1319bb900b0230590036192586ff66ae9a288199db9d02bbd5b703f8c329a9a1f986001b190f20ae96fe8b63681eda17bac2a57fd40f2e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050c00020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 292,
-          "comment" : "special case hash",
-          "msg" : "31363134303336393838",
-          "sig" : "306402302611484e7ff47dfaece4aa883dd73f891869e2786f20c87b980055ddd792070c0d0d9a370878126bab89a402b9ea173c02304e0006b8aabe9d6a3c3018d9c87eae7f46461187d3c20b33e975c850599ec1cb52c76e1f507e439afc43f9f682e7a8d2",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=\"0\", s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060c0130020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 293,
-          "comment" : "special case hash",
-          "msg" : "32303935343235363835",
-          "sig" : "306502302d504e38cdb1bb80bf29e07afbc66aea732accc85a722011069988f21eef685084f55efa30bfe32427eb8636db9171b4023100883e3d80d766ccb29e73a9e929111930da8353ec69769785633fe1b4505f9051e78d50c79a6b7c885c10b160bbb57fb6",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empty list, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30053000020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 294,
-          "comment" : "special case hash",
-          "msg" : "31303038303938393833",
-          "sig" : "3064023028dc1b63dc61ecde754ff4913780e486339103178e27d761987dac0b03c9bdf4a4a96b8680fa07fc47ae175b780e896e02305a9898eedf8781b9afeb506e0272a12c0c79bb893b8a5893c5a0a1bf4324d46dde71a245be2fd8aa2975fdeb40adf8f3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=list containing 0, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30083003020100020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 295,
-          "comment" : "special case hash",
-          "msg" : "31353734313437393237",
-          "sig" : "306402304c978a47b9e9449337178aa6413a794c4c9bf182a42062646a469b1d2c2c95621e818e661352b07e63254b6954e1459802306997345f05cfc05c0fd4d1dd133e555e5e5002e0929a59f60bbffc354234783ebf4fe5db10a870952cabd453635c1082",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Edge case for Shamir multiplication",
+          "flags" : [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg" : "3637323636",
+          "sig" : "3066023100ac042e13ab83394692019170707bc21dd3d7b8d233d11b651757085bdd5767eabbb85322984f14437335de0cdf5656840231008f8a277dde5282671af958e3315e795a20e2885157b77663a67a77ef2379020c5d12be6c732fd725402cb9ee8c345284",
+          "result" : "valid"
         },
         {
           "tcId" : 296,
           "comment" : "special case hash",
-          "msg" : "32383636373731353232",
-          "sig" : "3065023036d8e2cfc80d0436e1fad3702ec05aa138618cdb745652cb85b0b121ee107bdf1ade0464dc0c6bd16875bcc364044d8c023100898b8775c9b39aa9fd130b5ab77e6c462ced6114898045b7f606142277d9eb2aa897f24c9ba4c8d112111de04dc57c10",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33393439313934313732",
+          "sig" : "3065023100d51c53fa3e201c440a4e33ea0bbc1d3f3fe18b0cc2a4d6812dd217a9b426e54eb4024113b354441272174549c979857c02300992c5442dc6d5d6095a45720f5c5344acb78bc18817ef32c1334e6eba7726246577d4257942bdefe994c1575ed15a6e",
+          "result" : "valid"
         },
         {
           "tcId" : 297,
           "comment" : "special case hash",
-          "msg" : "31363934323830373837",
-          "sig" : "3065023100ce2bdcf924caaa81e79bd7dd983dfeeee91652e4ea6edd077f8b56ada4953733a22dd3a6336446a648aec4ffc367cb3e023008eb09faeef4b0e5c1262eda2127464f7e2981ea1736e80afc7c622461c3d26fe08694fb4914ce9dbba83704e3077b3c",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35333637363431383737",
+          "sig" : "3065023100c8d44c8b70abed9e6ae6bbb9f4b72ed6e8b50a52a8e6e1bd3447c0828dad26fc6f395ba09069b307f040d1e86a42c022023001e0af500505bb88b3a2b0f132acb4da64adddc0598318cb7612b5812d29c2d0dde1413d0ce40044b44590e91b97bacd",
+          "result" : "valid"
         },
         {
           "tcId" : 298,
           "comment" : "special case hash",
-          "msg" : "39393231363932353638",
-          "sig" : "3066023100e3a1b4b0567d6c664dec02f3ee9cd8581129046944b0e6650f6e6a41b5d9d4bf79d7a6fd54ea5a218492cfa1bb03ca07023100986206925cbfa186c7d88f7100d87dd3b2d03b8789309a722d582f119eef48cd0ea5460917cf27246c31f90e28540424",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35363731343831303935",
+          "sig" : "3065023100d3513bd06496d8576e01e8c4b284587acafd239acfd739a19a5899f0a00d269f990659a671b2e0e25f935b3a28a1f5fd0230366b35315ce114bffbb75a969543646ee253f046a8630fbbb121ecc5d62df4a7eb09d2878805d5dab9c9b3880b747b68",
+          "result" : "valid"
         },
         {
           "tcId" : 299,
           "comment" : "special case hash",
-          "msg" : "3131363039343339373938",
-          "sig" : "306502310095a5e29940e42099c4637f4ae51e7d1ec02be0dcfb0b627030984c35e477e80cc57e7eef970e384dee16a9b9fc8f2bf202300ca166c390339653cde84e79a87e5ceb4f52c1a515a5878542fd82705b9983976fd31a4123b5d0bde95a0818114cf462",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131323037313732393039",
+          "sig" : "3065023100b08c4018556ca8833b524504e30c58346e1c0345b678fdf91891c464a33180ed85a99bc8911acf4f22aceb40440afc9402304a595f7eed2db9f6bd3e90355d5c0e96486dc64242319e41fc07be00a732354b62ec9c34319720b9ffb24c994b1cf875",
+          "result" : "valid"
         },
         {
           "tcId" : 300,
           "comment" : "special case hash",
-          "msg" : "37313836313632313030",
-          "sig" : "3066023100c30c49d0ba131944e2075daacb1259d5580a712a08f73d889c4d3d484d73dd9719a439a986f48b072c4595c507a01083023100a5595c0691bc2d215f981fab513e3a88a452f2a1433367b99b02b6efe507519afedbe1ad0337899944e29c9ccccb2476",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131323938303334323336",
+          "sig" : "306502302b08f784617fd0707a83d3c2615efa0c45f28d7d928fc45cd8a886e116b45f4686aee97474d091012e27057b6ba8f7e6023100c440aa6ecb63e0d43c639b37e5810a96def7eec8e90a4c55e5b57971c48dfb4e850232fbb37bd32bb3b0523b815ff985",
+          "result" : "valid"
         },
         {
           "tcId" : 301,
           "comment" : "special case hash",
-          "msg" : "33323934333437313737",
-          "sig" : "30650231009fd0585f8740669885c162842bba25323ea12b1d05e524bb945cad4e31538742eda5128f467b3c562c5f0a99019d3406023043acfadd03915c2350e1d8e514c47eb36f3c3456169c9a562a6262c1c2d7d33378bf9fec7f220239d5c61e06414414a4",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "39383736303239363833",
+          "sig" : "306402300609f4ec120c8838bda916f668e9600af7652e1d3f7182734f97f54da5d106bbfd216c32f227b76d583de1c53949b2ee023046926dffc766ff90c3b921b3e51a2982a1072314c1fdfb4175de7adea5a6f97bdff587a473504a9c402aac7c05bd4785",
+          "result" : "valid"
         },
         {
           "tcId" : 302,
           "comment" : "special case hash",
-          "msg" : "3138353134343535313230",
-          "sig" : "306402304ecac0cdbf665c584f8a40614cd55d042706c54895b1de02984fe309122566c959a4dd3315e7d3f089879f8f45821336023009187da6587a3de90eba41f4e6510e711f4467f3122971566ecc39a4bd53e95b8a19380e20ec2a7c752d29de54fd2e8f",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3230323034323936353139",
+          "sig" : "306502305ae2220e4716e1ef0382afcc39db339e5bd5f05e8a188d4a5daaab71c6c35263ee8820a34558092877449ebb15898c5c023100c4d38e2e85451c43ee35b0c56196cbf3059acf2b8b529f06dc1de9b281d9b0f3f3983df8936e944ab0b18330a342ee88",
+          "result" : "valid"
         },
         {
           "tcId" : 303,
           "comment" : "special case hash",
-          "msg" : "343736303433393330",
-          "sig" : "3065023037a1ba49f11e97ad0ec47e687c6c6e94f794f874720c0dd2da501437b50e5b00fb6ed33adf7cf1f9c870fd3d37165bf7023100b3ad08c9886b4ca1593a68938b67142c65ed4da1714c22204cba71300c094ccdbdf84c38a3f6d896db72ed5051a19266",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31343531363639313830",
+          "sig" : "3065023051fb84ed71d436c737ab24e2a45c68f8f623748be2caebd89e02bfc89309b8350042ab1b97849b9f680f044a58765175023100d4a8f60791657a8c12985fd896ac77e7d95cb050582f2466471dc2c6dcf90db05ce34beadbfcfe690dc56c0cc9944007",
+          "result" : "valid"
         },
         {
           "tcId" : 304,
           "comment" : "special case hash",
-          "msg" : "32353637333738373431",
-          "sig" : "3066023100a0abe896d2f30207bc9b21e75400eedb88d3498d49806f41aa8e7f9bd815a33382f278db39710c2cb097937790d0236c0231009a29aded30e8ce4790756208d12044e18c34168608026000a883044dd0d91109d866b422a054c232810ddfbb2ae440bb",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31303933363835393531",
+          "sig" : "3065023040159290d161df6b3f81a92cefb6df56149d588e7b886bf24939f5c8b6bb515d325b3764f0ed284a77fa9081ccfa5237023100bd55dfb47709287ce7b88dfd96ac7543eeba9bd31b8c91f203d2b90418122406399c80a53539b81f1cb60fa3b23a2563",
+          "result" : "valid"
         },
         {
           "tcId" : 305,
           "comment" : "special case hash",
-          "msg" : "35373339393334393935",
-          "sig" : "3065023100b024fc3479d0ddde1c9e06b63c9bfb76a00d0f2f555220cb9a1311c2deec32eb3d6d2b648f5e8c104d5f88931754c0c20230767950cc149697edbae836f977bd38d89d141ff9774147b13ddd525b7a3f3a14a80d9979856f65b99a6faff173b5d6eb",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36323139353630323031",
+          "sig" : "3066023100d7fb9f53865cdf9d4cad6f66981aea35a1454858ceb678d7b851c12a4c6644fe1915a4b219b51389a5ae2c98a433cc3a02310094ad75c3dea88740205cab41032dfe149341cf4ee94dcd2f0c8bbe5af5860b30b5e1f764b2c767b09fd10761050c989c",
+          "result" : "valid"
         },
         {
           "tcId" : 306,
           "comment" : "special case hash",
-          "msg" : "33343738333636313339",
-          "sig" : "306402302a0ae7b5d42645051212cafb7339b9c5283d1fd9881d77ad5c18d25ee10907b7809740a510e65aecd61b53ba3a0f660a02304c0457dd19ef6e4d6ae65f45417ddf1a58c07663a86737d271becfa3ea5724b6018f1fa9e64fd08601a7dbd3957761d9",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35363832343734333033",
+          "sig" : "30650230157ef8f85cdb9257983d06a7f29674752659097364b401e701705b3bd9ead884fd32141320ae76ae05f6fc7ec155d6c2023100ccadc3851020e41dd91bc28a6c073409136a47f20b8dbf2553fd456a8ed5fa7e73e4ec59dca499e0d082efbb9ad34dc7",
+          "result" : "valid"
         },
         {
           "tcId" : 307,
           "comment" : "special case hash",
-          "msg" : "363439303532363032",
-          "sig" : "306502300c1657320faca6668c6e9f06f657a310b01939a7d9640fa0429872fe28bd1667688bc162221285ecfb14e8d80627450a023100f5272aa08c321aa4f7e520825cc720f6511d635598c648d4d514669b3ad803ad259c799e195a095982f66c176435be21",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33373336353331373836",
+          "sig" : "3066023100e763001769c76f6a6d06fad37b584d7f25832501491bec283b3b6836f947dc4e2cef021c6c6e525b0a6a3890d1da122a023100acbd88729cce3992d14ec99e69ff0712b82a33a1c1e8b90e1399c66fe196f7c99bdb3ff81db77dc25ae6f0c1a025117d",
+          "result" : "valid"
         },
         {
           "tcId" : 308,
           "comment" : "special case hash",
-          "msg" : "34373633383837343936",
-          "sig" : "3066023100d821798a7a72bfb483e6e9840e8d921200ef1976b7e514036bf9133a01740ce397c73fa046054438c5806c294a02c6800231008c5d12887fcd945ba123fc5a5605d13a5a3e7e781ad69c6103577ee9dc47adc3e39a21080dd50304b59e5f5cf3f5a385",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34373935393033373932",
+          "sig" : "3066023100c6425b6b046ec91ebc32b9e6de750e5d3d36d4ddc6dffd25ba47817385a9466f6fc52259c7d02c66af5bf12045b5659d02310084cdc06e35fecc85a3e00b16488eac3584942f663d8b59df111c0650139d7cda20d68dccae569d433170d832147bc94c",
+          "result" : "valid"
         },
         {
           "tcId" : 309,
           "comment" : "special case hash",
-          "msg" : "353739303230303830",
-          "sig" : "3065023100c996bd6fa63c9586779f27523d5583135a594808514f98cc44cac1fa5cfa03c78c7f12f746c6bd20608ecbe3060eb068023027d40a11d52373df3054a28b0ab98a91ad689d1211d69919fc04cadc22ff0367d3ef9433012a760c1d1df3715c8d5cf3",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "39333939363131303037",
+          "sig" : "306502303061f090e4932133a0e08ac984d1c8d8d4f565e21cf15427671503880341265cd44f35a437ee3c3a8857579dd7af0c3502310093ae374a0f63dcbe41a1b7b07a50faf2b33f35e0b6600bb36aa5cda05238640fa35c635c0fa78e1410f3a879bbb8a541",
+          "result" : "valid"
         },
         {
           "tcId" : 310,
           "comment" : "special case hash",
-          "msg" : "35333434373837383438",
-          "sig" : "3065023042dd6c8d995938701a538909ed6aeae0ba50c995138de84e195bbb9c56180e108d4a6274548c7be6e121c4d218d2d4a0023100fae8668bb2003f0da1dc90bec67d354ccbb899432599c3198b96c5ca4bd2324c46998f4fb76a123467cf24570b1b6916",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31303837343931313835",
+          "sig" : "306502300ccc627f35454cc84e08a828f5bd5f5e41eeeaa40475bcc2e71ff372e8c718a5e179d3b7f2d7051db9060c4c978eb638023100b12d0240afbdfc64c60861548c33663b8960316a55f860cc33d1908e89aa6fc9519f23a900e0488fa6a37cfb37856565",
+          "result" : "valid"
         },
         {
           "tcId" : 311,
           "comment" : "special case hash",
-          "msg" : "3139323636343130393230",
-          "sig" : "30650230061f185633291b9a768e15ec03a2b7c356c757b023b61e313fdf0c5349d128a78668d20b2561709b3bd8451b920f12ab0231008fc5edc66410dbf20a7cbc3498e405761756ed39866856e74256ac1f255f62b0edff519762ecdbbc8395d14715c4388e",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323336363738353030",
+          "sig" : "3065023100e72419fb67ebbcc0de9c46ce5475c608f9de7e83fc5e582920b8e9848000d820d393fdac6c96ea35ce941cb14951640002306aa19934ef60f4a247bc261ba256283a94857a268f42a0939c95a536fbd4f8e1f1c285a7b164c12213abb9e3393cbe9f",
+          "result" : "valid"
         },
         {
           "tcId" : 312,
           "comment" : "special case hash",
-          "msg" : "33373033393135373035",
-          "sig" : "3065023069326e047c62e8bac5c090b76bf73ae652fa9a6aecfa1ccb8702f419094c9727511264fb1aeec00e425c7a0d746793d30231009dbddd22db4a77dbe16114bc6fbb981aecba7e82a9cbc1ed385e28a51793561770fb3f9696090efca24f268d8788f2c9",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31343438393937373033",
+          "sig" : "30660231008b740931f9afa8a04c08cde896b7fdd9aca3177d5e4a3e5a51e54bfa824b66ab11df4e90f49798d644babfede7830224023100afd91e7ce15059a5b5499e5aef4afa91fd090e4e5029b3f4348f0d4349df11745869f9255117eea405a78af5dd6a646d",
+          "result" : "valid"
         },
         {
           "tcId" : 313,
           "comment" : "special case hash",
-          "msg" : "3831353435373730",
-          "sig" : "306402304ca1df89b23ed5efcdf601d295c45e402d786a14d62f7261104e4cb05b8cae17abb095799e71173841749615c829411b02301bb777e0a6fee8a2337a436a6fa26a487de4640ff97d57b44b55305989803863d748c7302f2dfde8b8cedd69bb602e2d",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35373134363332383037",
+          "sig" : "3066023100989024bce204a7539fbd2b185ecf375590d873177c1ff26bbf755838ae5bcde180054663702ac3a4e68fe8b58fd88c70023100bdbedf64e424dbd7f979f83adef3fc85077fa76f8b1724815b5b8c24fde7fbd72f4b369a415d9bbf565cdc459bdce54c",
+          "result" : "valid"
         },
         {
           "tcId" : 314,
           "comment" : "special case hash",
-          "msg" : "313935353330333737",
-          "sig" : "3065023067be1b06f67172c503a5ac50582235d30bc9079eaa4cdec69a39c096310f8d99186cc9af7c8b4369a291d3e921d60705023100ab645fc91f06b1ff7cc58fccf6f7cfac74db30d839748a78cb5f3b8fefc7a06f3b5ff0310a8580c6050bebb75eda972c",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "323236343837343932",
+          "sig" : "3064023022624fc23403955c0c9f5b89871177fa53879c8424de3b4ab1bcbcddc6e57b870b0491b848e19f728722b3163f4aa32802305bb82642cdaa84d6977fb95b3ede4ec7f2d54881cf435636d3509816f13ebb7be24fd7d4e1e81fddf07bde685e8d630d",
+          "result" : "valid"
         },
         {
           "tcId" : 315,
           "comment" : "special case hash",
-          "msg" : "31323637383130393033",
-          "sig" : "3066023100d966442d6c29e5a4cc60e2374eccd373db3ebe405ee7c9664c4273100cd1899a1c58110487528616d8c5321dbf5227640231009bb0e4a2c041a3b7b672029fe480d155f57671ecd6eb598660d025acce1f613d03cd6cff4a214131c8c7a8ad22df1397",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35333533343439343739",
+          "sig" : "3065023100da5a2daa7437df4566ebba6ac5ed424655633e354ef4d943dc95ddefb0dae69f3616e506cc8cb5bc433a82ba71f6feb402305107b24041bba45073ce54488a5aef861e7805bbb8f970aedc1c59149cfe72c7025e2d117337e8677c88ef43374e6907",
+          "result" : "valid"
         },
         {
           "tcId" : 316,
           "comment" : "special case hash",
-          "msg" : "3131313830373230383135",
-          "sig" : "3064023008a84a2bc39b082ab82e6e45f088a36f1cb255f97ec8124eca929d4506d7dab63957c647994be2c2c7344f902de5b38f02300c9645e84a304ba0970ca5ce00b8c8a971fa0d0bcbec6a70134894c44d3075030ff04333ea3889f847a1ed769ee618ee",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34373837333033383830",
+          "sig" : "306402302b0659fb7fa5fc1fce767418c20978de9a6a59941fc54f8380619b2ab2a7d6039de5373fbb503c24f2ce38e9c57995de02300d94dba98dd874bfffeac96a9295b6ab667708b8e33252edc029574c484a132135b13e52db6f877987c1be4f51fca193",
+          "result" : "valid"
         },
         {
           "tcId" : 317,
           "comment" : "special case hash",
-          "msg" : "38333831383639323930",
-          "sig" : "306502310083004b034202bbf51a327d32ed3ddf67b46eda9bac695a4422744a4bd99aaac3b3e8ed80ddac6538939c9385d6c8f61602307b4e61926cb9afa8cdaaf44909df6dc6449887d59fe2acac05f7684a235fa77179bdbcc69fd8f359e8eda19e5a5d4807",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32323332313935383233",
+          "sig" : "306402304a5a14f1ecf053bf3ec14843db8c7dd153e9545d20d76345a9e1d1a8fcb49558ca1ee5a9402311c2eaa102e646e57c2c02301573b8b4b633496da320e99a85c6f57b7ee543548180a77f7fced2d0665911cb4cde9de21bc1a981b97742c9040a6369",
+          "result" : "valid"
         },
         {
           "tcId" : 318,
           "comment" : "special case hash",
-          "msg" : "33313331323837323737",
-          "sig" : "3065023100ad93375a1d374c41e5de268a8c08c205ff5652445bfe3ddf4ca77a70f5819f9f06db861d82fc9637946f0fe38457f2bd02304bc043acbc6a68d4824ed768af9476ad5b93e4cb3bbac284fb5fbd548ae3b96c265c6d1ef4588a3e2da21b124c0d6b12",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130373339333931393137",
+          "sig" : "30650230104e66e6e26c36633c0af001f0d9a216236816923ec93b70bea0a8ff053a15aaaef5fe3483e5cc73564e60fe8364ce0e023100ec2df9100e34875a5dc436da824916487b38e7aeb02944860e257fd982b01782b3bd6b13b376e8a6dbd783dfa0d77169",
+          "result" : "valid"
         },
         {
           "tcId" : 319,
           "comment" : "special case hash",
-          "msg" : "3134333331393236353338",
-          "sig" : "30660231009e0d45d2dc93fd363dc919405818e39922f3f9dd0827bcad86d4ba80a44b45a6f60b8e593b580c91262b32859dbb1e53023100eb9b8dfe5ba4a055a974f19b488f3a6fa07161006ac94eb1fe1c12dd0e20f3a7be38a37ce96d671183c5871249b2a3c5",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31383831303237333135",
+          "sig" : "306402304b06795da82bda354e8d9422a76c7bc064027fcdd68f95b7bc6177a85b2d822c84dc31cb91fc016afa48816a3a019267023018e31018e312d3dd3dd49ec355fdb0def3bb3e44393c26cf1bc110b23a3aacf6c442bfcec5535ce37527d0e068f75c03",
+          "result" : "valid"
         },
         {
           "tcId" : 320,
           "comment" : "special case hash",
-          "msg" : "333434393038323336",
-          "sig" : "306502307a5d04cd2fda59d8565c79ea2a7f1289ab79cae9fde060094c805c591a2534e4393e28c3fd858529bf17643846aceb830231008de0d8c0092fd02d554afe25f814744beaaa17c6946a6387ec7046b602db8a6c900246c2fb63fcef2ac8d9394444a0fc",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36303631363933393037",
+          "sig" : "3066023100ad75ca5a3df34e5a6d3ea4c9df534e8910cfb1d8c605fc398fbee4c05f2b715bd2146221920de8bac86c2b210221bcff023100a322d3df3bb2cf9e4215adf1ff459e70f2f86bec6dd6af5d04ae307d21ed5955136c8e258fdc0f9cbd6cf89c31aa691f",
+          "result" : "valid"
         },
         {
           "tcId" : 321,
           "comment" : "special case hash",
-          "msg" : "36383239383335393239",
-          "sig" : "3065023100a564eea0cdac051a769f8ff1e0c834a288ce514f67d138113727b53a1a6fc95ce237367b91f1b91b2f65d589adc8288e0230182e5b47b6fbd8e741a04e809487ba5fcb8a5f2f1b9af6ce214128623a4768e38e6ddc958ff39078c36c04a314708427",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "38383935323237303934",
+          "sig" : "3065023100b0fa6289cc61bab335932ea1ac6540462653cc747ef67827825f77689a4398602297835d08aa16e23a76dea9f75404ef0230278d654a0b50c57d13f9c9c8c7c694001167f8e3b71491772a7427f1410fb6de518740c22e455e58de48846479b300cc",
+          "result" : "valid"
         },
         {
           "tcId" : 322,
           "comment" : "special case hash",
-          "msg" : "33343435313538303233",
-          "sig" : "306402306758867cd1ca1446cc41043d1625c967a0ae04d9db17bbb42fa9c076b3593125d63cd3e7471ee6cdba5235a21cec2f220230563db387adb537e1d89231d935ac790316925aeb29132b9f87bee91116c33bf50943fe39b671ce9535dca0a5d22bbfa4",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31353830323334303934",
+          "sig" : "3065023100c216cb4fe97facb7cd66f02cd751155b94fa2f35f8a62ba565aca575728af533540ff5d769b7c15c1345ab6414e150680230278a8a372b75d6eb17a4f7c7f62d5555c7357a1a047026bead52185cbcc01d73b80a1577e86220b2278da2b1ee8c983a",
+          "result" : "valid"
         },
         {
           "tcId" : 323,
           "comment" : "special case hash",
-          "msg" : "3132363937393837363434",
-          "sig" : "3066023100cde033e38d3f791db87d8a6907516bd8021acd47e897df683fda529d48050f8b5688f6361daf1b14bc3f45fc7f76150f023100e14f4811a667c85335a4709a589ea46bac72055b794eaea92d28e834d5bc459c605fe4f27c1ab18d186d59e7d205cb67",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33393635393931353132",
+          "sig" : "30660231009591c80453cffbcd0b8d6d20fce0cbb2a458e54aed7ba1c767e6c017af4c4aa07a76859c0b249f6692a3c9ace893f14e023100893b567cd2959cd60557d3d6013d6e1741421a6edc5bc18244b3e8d7744e57928ce006a3fbd6e6324cb8ea3e5177e7e3",
+          "result" : "valid"
         },
         {
           "tcId" : 324,
           "comment" : "special case hash",
-          "msg" : "333939323432353533",
-          "sig" : "3065023100f2384468b55553c68f9764d8248cfd7358d604fa377ebb13828c43a8ebdf308fbbbebfa49a9458bfda957d2068d24e3f02301fdf4891d56e3e90c02b05c14c27c17f56f8e6aa144f02328c90109e1f70c9e3f582f0d299c44da505c543cc89c6a990",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32323838373332313938",
+          "sig" : "30650230350b5515ba9785f149e2a566c14f4178757bb325179888f526f7db11161aedcd752551381316c2713f5de21d3d517af002310097d48a90c3bb3444736bec69db0649f82428b39238ada6048a0bead84f2f3b73816b48fed4d57b5f87a194ce4004ed7b",
+          "result" : "valid"
         },
         {
           "tcId" : 325,
           "comment" : "special case hash",
-          "msg" : "31363031393737393737",
-          "sig" : "3065023100b1ccafedcc21ba90b342fa23c0149f3d12a939ab6c3342b36ae61fddbdc753927a7c3e978bd780cf25cd78c8c5efe28002304c32a73f3157bbe2384095eb67726b9cd3c2623b98a182a3b4f00e8db933e1113b7ada2695a7d79b471026462b20e289",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32323330383837333139",
+          "sig" : "3066023100833210c45d2448d9a4d69622d6f2193e64c65c79d45d62e28f517ca5c68eef05a2e98b1faed4cc87cbdbec6fe6bb8987023100b777b44cd30e6a049dc56af19a251d955c1bbab0c307fe12e9e5382fd48c173db0292f0b1047da28ee18518e11688eea",
+          "result" : "valid"
         },
         {
           "tcId" : 326,
           "comment" : "special case hash",
-          "msg" : "3130383738373535313435",
-          "sig" : "3066023100f3ed170e449758299ae55eb85244745e1876621c1f708e07e55c0d2d9ab5f9af9e0a8b3c7bdf8936ab3c9ebd1908e9dc023100da62ccdb658868147286d7269bcbd4addb4dec9ea3d5d79fdbe0ccffa40d055170bddeb4ef4c5e0bc99fae5db62b4477",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "313239303536393337",
+          "sig" : "306402307728ef10d9d5f3f32132716e6b403926929b05201700658d4b7f25a0692f153b8d666fd0da39888ab6234212659268d0023055df9466ee2c98225a2b0c4ff77622f9d11b4e48aa7f9279cdc2e245fdd9b9f4282106e25a458ff618bc3ca9422bea25",
+          "result" : "valid"
         },
         {
           "tcId" : 327,
           "comment" : "special case hash",
-          "msg" : "37303034323532393939",
-          "sig" : "306502310083455fc4629e7693c8e495fec2d29bb23bb6db79180fcfa83a4f9310d9db27e29297dee27ee80a71ab2f7a2d59f48b8802307736c056c8f2bb57e9fb6b8de0ab6d09879f6611e737634e7b6337aa5c5a01f515d5e3702dec9a702177c816e32bac67",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32373438363536343338",
+          "sig" : "30640230552040701dba17be3b4d5d6e136ce412b6a4c50ce1ee53415d8100c69a8ee4726652648f50e695f8bb552d0df3e8d1c402301374972b2f35b2fd86d45ed0c9358b394e271575e429ac8aa60eb94b9df7e755d9317fb259269e9d3b1db8d48d91dc7e",
+          "result" : "valid"
         },
         {
           "tcId" : 328,
           "comment" : "special case hash",
-          "msg" : "31353635333235323833",
-          "sig" : "3065023074961587cbe49bbf0a73fea82b8b2242f67b0ea09224774639f437c60378a36b2d511a9145d576b440dffd1f02286a8b0231008fb95d46c22889085cc1d3e20bcfbcbc52f4532445f76f08efae2de8b56fe8525204643330dfd23cce946687a0aef046",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37353833353032363034",
+          "sig" : "3065023100fe6ef07056ce647128584bec156b68b8005f42d8c85dfb122134c488cc0e72cf8f06700417d7ff694b45e894ec23cbbd02307f5e33c5bfa697c144d440b32d06221f630a9ccaa8e9a0489490c04b86e8daae0e41d2466429b4b3cc1d37348e36cc0b",
+          "result" : "valid"
         },
         {
           "tcId" : 329,
           "comment" : "special case hash",
-          "msg" : "3233383236333432333530",
-          "sig" : "3065023100a3fd322330d0f0efccc54bd7d73c3159eb1bcca08cec369a4a08fd00f9ec6d482ced58eb08a0d7c2113bd5575de4917d0230164e3232a628c40fbba1de82bfb9627cec78a8040cf325a5a8bb8f864c2ac19e3524ac93f4db5713ce62ba256176e05e",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32333237373534323739",
+          "sig" : "3065023100e009fc1a13d282bd37f10693350a5b421a0039713d29cb9e816e013c173bd1ec2bd6eb6bd88429023ee3d75d9a5ec06f02300b8bd481982a6e52355bcde5fe0092abac41f0543c31d1928b9a585e63e9520e24a65f46db2696e1b85a65c4e5240879",
+          "result" : "valid"
         },
         {
           "tcId" : 330,
           "comment" : "special case hash",
-          "msg" : "31343437383437303635",
-          "sig" : "306502304c862ff9e4ff88f9a58e9fceaaf9bbb30740d3f6c8c6a69b5627fe234b144f8cdf09520735cfd708f5e341a78cc4873d023100a861972514a0e975cf2da214125ec93288524cc77492ed63c516424278e5ec8d41724467cb7c3111fa34c69193abb435",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "373735353038353834",
+          "sig" : "3065023100acee00dfdfcee7343aeffa8514b11020c5435027887529d255bdbd45a90f160c68f05bd4b567daa8fa14e5807f5167a402301c9fdf546190970aa33121a3043280669be694e5f700b52a805aa6101b4c58f0467e7b699641d1d03f6229b2faf4253f",
+          "result" : "valid"
         },
         {
           "tcId" : 331,
           "comment" : "special case hash",
-          "msg" : "3134323630323035353434",
-          "sig" : "3065023062225e4e492a9773397870336168960a66b9e50391ef7289cb2d3878f32252dc1b904f6682545e14564e415bd93e01170231009f4d0327f79e043505c691e361fa2e00f87f41324777eca6966f4bea2fa0858876aa01980b2cad7f66037524de49bf65",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3137393832363438333832",
+          "sig" : "30650231008a4ee1e3bb251982475877d18763fafcf49ccc8b0fec1da63b0edccbb8d3e38608a2e02d0d951031179e12ac899d30c3023073cb62ad7632cd42dff829abfbfcb6165207e3708ed10043c0cdee951c7f8012432696e9cf732dcbadb504630648419f",
+          "result" : "valid"
         },
         {
           "tcId" : 332,
           "comment" : "special case hash",
-          "msg" : "31393933383335323835",
-          "sig" : "30640230450c65d2d88ba464eee3a5ce9310b519d5dcf608799fb2275eee987a67c2c4d7ac53716987cc5139c18c67ef07b1e20702301ee0439311a7bce1c4fed0a3152d1b354d96536c6ca0c9188ac1f1afcc5cd7305b5611ef0d19d8bd57c5059976dc5e68",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32333936373737333635",
+          "sig" : "306402303903b59f837ff5f41f42cbe3e2fc8e17d859cbb35386c4327d3947fb012b3629fea911c83cefdbd503aebbcc1114afd102300e5be9094b5a22ade00c24644f476baad0f7741dfb2ce9644a1c45769404f8dccc522017c2b8cc630f1a0ef5fee99fe8",
+          "result" : "valid"
         },
         {
           "tcId" : 333,
           "comment" : "special case hash",
-          "msg" : "34323932313533353233",
-          "sig" : "3066023100aa2575fb5bea0effb5247d20c3d0165d575831840b5c18b0245a99a61b7ad5d7bf8a8cfcc375e095a84e781025bee3ee0231009c8b7797ad330abc206060b28b6ca1c639d89f59582528bda1527e3ab081697a2ab576f9d09c2ee329dd73231667308d",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35393938313035383031",
+          "sig" : "306502307717ffc8d0811f357299423c56ec181c58f1981f5c1dd4f346f6a2ad71d3582e203a11e8609c1146ff3247a1820f832c02310096c89ec707da3cd8b09084b065e3265327a536a974c4285155388011e348f2e7f005ae7e3e502732fc2971ac13fd72c0",
+          "result" : "valid"
         },
         {
           "tcId" : 334,
           "comment" : "special case hash",
-          "msg" : "34343539393031343936",
-          "sig" : "3064023001fc45285aa2c2e50458199ade2ded0dd36b1de03e8969175be4a6f09f9719b195ded8d9eb4ea132d95d19a3528fd6c9023059609a358c5919fef4781061804d4d64a067edecdcfd14620161aae3ef2735095a558e4f8ae345040123f093e5f70af2",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3136363737383237303537",
+          "sig" : "3065023100a21519ce3533c80826f1e47fa9afde7096151144291134421990285a8d89a8c2d4afdadd547a923dcc17bfcdd0e9ffb9023040577245dd2e022c8ed8b5de7b8c26f31307429a7a64e5729311cc4128e3b486867e61b4a8a1cd0731792eb1466d08f3",
+          "result" : "valid"
         },
         {
           "tcId" : 335,
           "comment" : "special case hash",
-          "msg" : "31333933393731313731",
-          "sig" : "3065023100d8e1f6b19e5b92e36060e59e53eeb788a4758c2c8ee9519f3949d5f3315abafbe937b8ed44d47e886a07c107aa8ac9f4023012550574318371e5168d0a339f20fcacaec87db211bba4d4e7c7e055b63b75fd31790ad285f4cc061378692b0a248e34",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "323036323134333632",
+          "sig" : "3065023100a727addad0b2acd2942cb1e3f7b2917ca65453275198b06436a993bfc982d3f54620c395e253d57b8fe026efcf7252f902307a19811aa4c12c45c3c041e7c614d0d98051ca7a0c57a9a107d552793ba1d0debb373525aafcc13ae1acd50a42a89adf",
+          "result" : "valid"
         },
         {
           "tcId" : 336,
           "comment" : "special case hash",
-          "msg" : "32333930363936343935",
-          "sig" : "306402304815aec44a7a6b86ae87fc2556accd77832fa33a4710e02ec5ef6f41f68a910e6af4d173ae462a759bd98079b371bf5d02306e78d562f9e8be65e8d7a74a7305e5d6cf2f3c4c980f2b18dfb8e9c8b0134ec86548053b3d125e56d5872294d2d14ebc",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36383432343936303435",
+          "sig" : "3065023022287277872d175d8a3ff5be9818658f845eb9c1b2edc093ae82a75aa31cc26fe1771b4bfbd4c320251388d7279b5245023100b47d1833867e889fcfd7ac171855293a50aa6db24c6522e374fe87be12bf49b13c8b5e1455a2f25aa7912f799eebe552",
+          "result" : "valid"
         },
         {
           "tcId" : 337,
           "comment" : "special case hash",
-          "msg" : "3131343436303536323634",
-          "sig" : "3065023100d302f9db6b2d94e194412f0d40a135a554aee014bd939b3d7e45c1221ef7ce45c2aed875f9a2bc43dbc8264d92e444a5023004e7247b258c6e7739979c0a07282f62958ac45e52dd76a41d5e1aca31a5cda73d7b026d67b4d609803001cb661d74c6",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323639383937333231",
+          "sig" : "3065023100a0f41362009b8e7e7545d0f7c4127e22d82ac1921eb61bf51e9ea711e41557a84f7bb6ace499a3bc9ebca8e83728787b02301f6e0c15a3e402370885e2aceb712280ebc45b63986357765b7e54b06cd00db8308e4715c39d48d246030bf960e6a2ff",
+          "result" : "valid"
         },
         {
           "tcId" : 338,
           "comment" : "special case hash",
-          "msg" : "363835303034373530",
-          "sig" : "3065023100889f0e2a6ae2ddcad1cde3f65b61d4dd40985917ba841b47a1f802491f5af5067722b7683df0fca7ee19d2b73724c8fd02301f989bac23b51c49e5d7dcc319eed2fc767e9b432bf75af92814d9e67a5d4b3398eb15e98b70527abbc029abc1bea524",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31333837333234363932",
+          "sig" : "306502304144e1c6ad29ad88aa5472d6d1a8d1f15de315f5b281f87cc392d66d7042547e6af7c733b31828f89c8a5dafce5bb9af023100f5d0d81f92428df2977757c88ba67f9e03abd4c15b1e87fa1dd49e601a9dd479e7c3dc03a8bfea60fcfc1c543931a7de",
+          "result" : "valid"
         },
         {
           "tcId" : 339,
           "comment" : "special case hash",
-          "msg" : "3232323035333630363139",
-          "sig" : "3066023100e69c70c679795ca7d2b66e2632529651c120055fa3cf25435fe8bb28987c02412ce73e6ca5ca7e0b42e9670c0a588175023100edd8513bff40cdca9e22659238fbcea2de2caeef53c5287a515db9168b3008ec446c9b94f28a6e021c69bc6637fc4634",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34313138383837353336",
+          "sig" : "306402305f177fc05542be6e09027b7eac5eb34f34fc10ad1429e4daaea75834de48dd22626f2bf653dfcc46234921d19b97406b02307def6c993a87560425f2c911046357c4b1c4c376bfa22bb45d533654fea6f565ba722147b2269ea7652f9c4af62ed118",
+          "result" : "valid"
         },
         {
           "tcId" : 340,
           "comment" : "special case hash",
-          "msg" : "36323135363635313234",
-          "sig" : "30640230068cbecfd47bfd688f495df05e45fd5fced6d8e240605c5b2be5e69368740b694b9b1ea034af3180e571dd38a86369ef02301a1d2976f748d1621128013c61abda5398a3e24f0073d1a6e07a1e96c12be4f1e2e7b144f9b5a350500acfc5cb0698d9",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp384r1",
-        "keySize" : 384,
-        "type" : "ECPublicKey",
-        "uncompressed" : "04ca5ee479ad6624ab5870539a56a23b3816eef7bbc67156836dfb58c425fdb7213e31770f12b43152e887d88a3afb4b182aceec92b3139aca8396402a8f81bb5014e748eab2e2059f8656a883e62d78b9dc988b98332627f95232d37df26585d3",
-        "wx" : "0ca5ee479ad6624ab5870539a56a23b3816eef7bbc67156836dfb58c425fdb7213e31770f12b43152e887d88a3afb4b18",
-        "wy" : "2aceec92b3139aca8396402a8f81bb5014e748eab2e2059f8656a883e62d78b9dc988b98332627f95232d37df26585d3"
-      },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004ca5ee479ad6624ab5870539a56a23b3816eef7bbc67156836dfb58c425fdb7213e31770f12b43152e887d88a3afb4b182aceec92b3139aca8396402a8f81bb5014e748eab2e2059f8656a883e62d78b9dc988b98332627f95232d37df26585d3",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEyl7kea1mJKtYcFOaVqI7OBbu97vGcVaD\nbftYxCX9tyE+MXcPErQxUuiH2Io6+0sYKs7skrMTmsqDlkAqj4G7UBTnSOqy4gWf\nhlaog+YteLncmIuYMyYn+VIy033yZYXT\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-512",
-      "type" : "ECDSAVer",
-      "tests" : [
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "393838363036353435",
+          "sig" : "3066023100bd77a8ff0cd798d8f6e75dfbbb16c3ee5bf3f626dcb5abdfd453b301cb4fd4caee8e84dd650a8b4cf6655dea163788c7023100ef8f42394469eb8cd7b2ac6942cdb5e70dd54980ad8c0c483099573d75b936880459c9d14f9e73645865a4f24ee2c4ce",
+          "result" : "valid"
+        },
         {
           "tcId" : 341,
-          "comment" : "k*G has a large x-coordinate",
-          "msg" : "313233343030",
-          "sig" : "304d0218389cb27e0bc8d21fa7e5f24cb74f58851313e696333ad68b023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32343739313135383435",
+          "sig" : "3066023100a02e2196258436da6a35a2f73cf6b08880f27757566ce80c7fc45f5dcbaec62d3fcebb784b4a650e24c1a997e4b971f7023100f1195d2ba3321b6938e04169d7baf605001b6311f08a5e82157a7675d54993f2fd1e41f8c84fc437a1a139d2e73e8d46",
+          "result" : "valid"
         },
         {
           "tcId" : 342,
-          "comment" : "r too large",
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35303736383837333637",
+          "sig" : "30640230686c5dfe858629125fdee522b77a9b9be5e03a347d79cb4c407f17fd25c97293cd99711f33e77814bd30d2453d3a86c10230509ac9b18c1b2b5a2b1b889d994b950743a988c2fcfb683e89211a43da6ee362c2e414d84fe82db1904b81701c257822",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 343,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "393838353036393637",
+          "sig" : "306502310083ce818ecd276432a8ddfe75406d01329e76d7586cd6f611c1fe1a0913ad80014c2156381942d58dd6356e44ccdc52a8023036a35983b97a9ae2a19cf05ba947dd880c973d5c78f9676ebbcb0b40d639124030c137236232f1fad15afd71c52ad8ec",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 344,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32373231333036313331",
+          "sig" : "306502307cb78ebb712b5a2e0b0573d28440a5da36bd2338805d90ef3b0c1178ae613be8ae8bf548af4e7403e5a5410462afc2e30231008631a82cbdb8c2c7df70f012405f06ad0ab20d6c4fbceb3e736f40fdff1a8e5f6e667a0e77259f277494de84ec0de50d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 345,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323034313031363535",
+          "sig" : "306602310085110fe21156b7764b91bcb6cf44da3eb21d162395071c216a13b5920d67a31aaa20dfc4669cf32c04964d0831bcdc29023100e19187033d8b4e1edf7ab8eaaae1e13c80c0c4db51d921ccf62f424524cbd530d07de2cf902a0ecda5e01206ae61e240",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 346,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33313530363830393530",
+          "sig" : "306402300fd621a892ee5a3eb0bcb80f3184714a6635f568d92f41ad8d523887d5b82d2b930eb5ff2922fda1a3d299f5a045837f02301278725a607fa6f2fc7549b0de816fe2f88e3a1ec1ccaf9fb58e70a0f6646c2d7aad6e4f73d116e73096bdef231d0c89",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 347,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31373237343630313033",
+          "sig" : "3066023100802cbe405d3ce9663b0b13c639aa27730b3377ce42521098ae09096b7fc5e7ac998b6994344e89abfb50c05476f9cae80231009aa7258c0dc4eff4b2d583575368301e2a7865cfaa3753055a79c8b8e91e94496a5d539181c2fd77941df50fe87453cd",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 348,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3134353731343631323235",
+          "sig" : "3066023100859b0446949d7f78a0301ac4cc02b599a758fd1be006bf1a12570015869e59b9a429ce1c77a750969f49e291f6ab899402310099a812a1acc2c646814315cf9b6290d2232236cdf131f9590088e75a55786cdfc9d9027ec70056408ab55445fd79fe60",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 349,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34313739353136303930",
+          "sig" : "3065023100dbcc7ee9fa620e943193deae3f46b3142779caa2bce2df79a20639c8d01bce414a61f72764c1ec949c945320f5ee2a1d02301d9879787b880bd05db39bac07bfe3e7d0792932144e211e81f21da9621b83bff11bc52bcc7cb40cf5093f9bad8650fb",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 350,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35383932373133303534",
+          "sig" : "306402307a1f9fbd0f6e776c3e3a3c798f5c0d9e20f0e2f3f4d22e5893dd09e5af69a46abc2f888d3c76834462008069275dfeb9023045e6d62a74d3eb81f0a3a62902b8949132821b45d8e6cad9bb3d8660451727cdf7b332a9ac7bb04604991312143f8a6a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 351,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33383936313832323937",
+          "sig" : "30640230047962e09e1b61823d23726bf72b4dde380e032b534e3273db157fa60908159ab7ee4cadce14fd06ebe8e08e8d8d5a0702301892f65ee09e34ce45dd44b5a172b200ce66b678b0e200c17e424e319f414f8dfbb2769a0259c9cc105191aa924e48d5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 352,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "38323833333436373332",
+          "sig" : "30660231008f02799390ab861452cd4949942cbbcc25cad7c4334c4bc6146fbef8ad96c86f923fbf376d9ab79073e5fcb663f1ea91023100ce15d9862d100ff95ad7368922eec3f6d7060ce412c01ff13870aa61626ee49edf39bb27005ecbe406bb6825f74c0438",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 353,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33333636393734383931",
+          "sig" : "306502301879c4d6cf7c5425515547575049be2a40c624a928cf281250f8bdcbf47e9f95310d0992c9887dc6318b3197114f358e023100e1116bf68320bade7d07a1a9651512d60b551af8625b98b5eb8ca222d4073ae5c140a80e5dbe59f073647daa00837aee",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 354,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32313939313533323239",
+          "sig" : "3064023031dced9a6767f39045472749baec1644ae7d93a810a4b60eb213c02c42de65152ffc669af96089554570801a704e2a2d02303022ecfbc88a72b9c50ef65344765b615738f2b3d420ade68cbf3ec40bef0e10c5cc43bcfe003bb6f17ec23802c40569",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 355,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35363030333136383232",
+          "sig" : "3066023100f4bdf786c61c5f1ce7568638ba9dbc9a134e27fc142003bf9870353980a8f4c2fbd03c8d0171e4048ef30db6fe15388a023100d0e96768bc6adc91f93ae5704e86888853f479f32a45bfd436dc8a030603d233c56880124b7971362aa11b71315ae304",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 356,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "383639363531363935",
+          "sig" : "3065023100ec0f635b7ce31988a07f41b3df35ca03c70e376bfb3b6ab24831a83be2121b9f9e93928b10a8f5fc0322bdb9edd406fe023066618ccb473c6dac3b14cfab6dfb24d219b37aec63425067c2c1c631d64a80b9cab6445f5a5439adb28bb99daa9234a5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 357,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36353833393236333732",
+          "sig" : "306402304f2bea24f7de57901e365d4c332ddb62d294d0c5fd58342a43bdd3ba5cbaf25adaddb5944bfef9dcc88f94d93650bbbb02300851b97ddc433e4521c600904970e2bf55aa901e1aaaaf06818377f84a28e033a49eebc21ffe9cff3cbefd0963fbed00",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 358,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3133323035303135373235",
+          "sig" : "3064023072a9bab30f8da1437f17115cc37b6ef8cf6591ed934d596675ad7b000c6a74cca5f37210a68228a58023790e3726c357023012d697c4e20b18f63a3e0164dca8ca4a5fa0058ad7cd1c571cef356e85fd8f56ab7963d8aba824e8d31efb3e690c27b9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 359,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35303835333330373931",
+          "sig" : "3064023033b7105f4cc98a1ea2abad45dbbe3761b4613ddd350e62da91560da694be3e84b1684f9a8ee4b3f556c61d02af54446202302c86e3a216dc7dd784cdcbf5084bdf6cdc1c7e67dbd61f9f6ed161fda4d4c26167e5b12731cf2b0cf5d9a5f0b6124939",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 360,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37383636383133313139",
+          "sig" : "30640230252e3b5b60b8f80748b83623e30013723115cabcc48770c0ab6e7ee29c429ef1d9da78db3a9a8504133b9bd6feceb82502301ba740f87907cf6d450080f7807a50f21c31cd245dd30f95849a168d63b37628e8043c292ab7f130a4468eaf8b47e56d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 361,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32303832353339343239",
+          "sig" : "3066023100b8694dbf8310ccd78398a1cffa51493f95e3317f238291771cb331f8e3a9753774ae3be78df16d22b3fbe9ad45bed793023100daaead431bbdbf8d82368fbbd2473695683206ee67092c146b266ed32f56b31cb0f033eebf6c75118730eef7b7f96ba7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 362,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130303635393536363937",
+          "sig" : "3066023100d37ba39cd1b5289e7aa3f33afefa4df6821a07d3e8ee1c11e7df036c37e36214bb90264633d4c395644cd2cc2523833f0231008b0d58ed75af59e2abbcec9226836f176b27da2d9f3094f2d4a09898136436235025208cf5444265af66fed05b3dc27c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 363,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33303234313831363034",
+          "sig" : "3066023100b4ef419020c0dcbdeeeed76c255560f1ed783c0f9e7fcea4c08a0714b9d1f491fda9ae7bb1eb96d294b02799f82861290231008d987611063d2f28cb309a56eaf1ea65f27d95c97b77a5f037f2f914fed728267aaf62a37f3c7b44fc4b15125b349863",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 364,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37373637383532383734",
+          "sig" : "3066023100b2df7b11cf60ac93c078d19f37f889717aa5d9af1d00d0964f9e9f5257c3b51b3d3e47ca5b5aa72058ed63b52464e582023100b524968ea8c58d379e38f4cfa9da1527a2acb26d605d22f173fcf1e834db0d7f031cb9245cb62b8458ff499b8d3decbe",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 365,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "353434313939393734",
+          "sig" : "3066023100e0edc08b4122b75ebbd1635d07f0bb55771bda15573a5081da971955f9a63f6decdd4919911dbfea503ea8ed1faad93d023100ca7850c74ce878587056206c590a1097d197a2090cfe3e057becfa2700c7a531623ae7331e163def693e26a97feb540d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 366,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35383433343830333931",
+          "sig" : "3065023068f555eef5a323a929719bfd8cf81d6d8a977ecb35defd86fa54d8e5749c7b5f3e80087fbd39f8aa0cd29d8310bd6578023100e2c2314a50fc0ad78c1ec02ea77ee2e13dcef1460957c6b573f721d72c209ac5fb529ab20397234c59ed44f60400971a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 367,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "373138383932363239",
+          "sig" : "30660231009e330e29f18123813e83b9c6abd68de96a57f97a4005b88d5b470a67a541b6d3af12124cf8658b751671c6698fb8b021023100d210fba9bde6ef077ca06b75e1cf7ce8dd70b08e9dd42d81a215ef9272f1779ae3e9f0dec510571d87237cc6bf3203e8",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 368,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31373433323233343433",
+          "sig" : "30650230483192056f753f64ddf0f21072b73d68893e6fa5432c981c7a1955b6592a6045a5c1c58c383e70023c34e09b7964ec8d02310094b005d5f98c4fd2ad40ff8e03a8599f45e206082112f834df1d48502d2ac690cd3204f0078913794c9c39077ad6c58b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 369,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32343036303035393336",
+          "sig" : "306402302b7ec14fd77c4b33230dd0a4e2710fbd307e469baec54b6f25daac7e196b7b4b5df251cdddba7bdc9836ca1319bb900b0230590036192586ff66ae9a288199db9d02bbd5b703f8c329a9a1f986001b190f20ae96fe8b63681eda17bac2a57fd40f2e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 370,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31363134303336393838",
+          "sig" : "306402302611484e7ff47dfaece4aa883dd73f891869e2786f20c87b980055ddd792070c0d0d9a370878126bab89a402b9ea173c02304e0006b8aabe9d6a3c3018d9c87eae7f46461187d3c20b33e975c850599ec1cb52c76e1f507e439afc43f9f682e7a8d2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 371,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32303935343235363835",
+          "sig" : "306502302d504e38cdb1bb80bf29e07afbc66aea732accc85a722011069988f21eef685084f55efa30bfe32427eb8636db9171b4023100883e3d80d766ccb29e73a9e929111930da8353ec69769785633fe1b4505f9051e78d50c79a6b7c885c10b160bbb57fb6",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 372,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31303038303938393833",
+          "sig" : "3064023028dc1b63dc61ecde754ff4913780e486339103178e27d761987dac0b03c9bdf4a4a96b8680fa07fc47ae175b780e896e02305a9898eedf8781b9afeb506e0272a12c0c79bb893b8a5893c5a0a1bf4324d46dde71a245be2fd8aa2975fdeb40adf8f3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 373,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31353734313437393237",
+          "sig" : "306402304c978a47b9e9449337178aa6413a794c4c9bf182a42062646a469b1d2c2c95621e818e661352b07e63254b6954e1459802306997345f05cfc05c0fd4d1dd133e555e5e5002e0929a59f60bbffc354234783ebf4fe5db10a870952cabd453635c1082",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 374,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32383636373731353232",
+          "sig" : "3065023036d8e2cfc80d0436e1fad3702ec05aa138618cdb745652cb85b0b121ee107bdf1ade0464dc0c6bd16875bcc364044d8c023100898b8775c9b39aa9fd130b5ab77e6c462ced6114898045b7f606142277d9eb2aa897f24c9ba4c8d112111de04dc57c10",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 375,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31363934323830373837",
+          "sig" : "3065023100ce2bdcf924caaa81e79bd7dd983dfeeee91652e4ea6edd077f8b56ada4953733a22dd3a6336446a648aec4ffc367cb3e023008eb09faeef4b0e5c1262eda2127464f7e2981ea1736e80afc7c622461c3d26fe08694fb4914ce9dbba83704e3077b3c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 376,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "39393231363932353638",
+          "sig" : "3066023100e3a1b4b0567d6c664dec02f3ee9cd8581129046944b0e6650f6e6a41b5d9d4bf79d7a6fd54ea5a218492cfa1bb03ca07023100986206925cbfa186c7d88f7100d87dd3b2d03b8789309a722d582f119eef48cd0ea5460917cf27246c31f90e28540424",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 377,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131363039343339373938",
+          "sig" : "306502310095a5e29940e42099c4637f4ae51e7d1ec02be0dcfb0b627030984c35e477e80cc57e7eef970e384dee16a9b9fc8f2bf202300ca166c390339653cde84e79a87e5ceb4f52c1a515a5878542fd82705b9983976fd31a4123b5d0bde95a0818114cf462",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 378,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37313836313632313030",
+          "sig" : "3066023100c30c49d0ba131944e2075daacb1259d5580a712a08f73d889c4d3d484d73dd9719a439a986f48b072c4595c507a01083023100a5595c0691bc2d215f981fab513e3a88a452f2a1433367b99b02b6efe507519afedbe1ad0337899944e29c9ccccb2476",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 379,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323934333437313737",
+          "sig" : "30650231009fd0585f8740669885c162842bba25323ea12b1d05e524bb945cad4e31538742eda5128f467b3c562c5f0a99019d3406023043acfadd03915c2350e1d8e514c47eb36f3c3456169c9a562a6262c1c2d7d33378bf9fec7f220239d5c61e06414414a4",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 380,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3138353134343535313230",
+          "sig" : "306402304ecac0cdbf665c584f8a40614cd55d042706c54895b1de02984fe309122566c959a4dd3315e7d3f089879f8f45821336023009187da6587a3de90eba41f4e6510e711f4467f3122971566ecc39a4bd53e95b8a19380e20ec2a7c752d29de54fd2e8f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 381,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "343736303433393330",
+          "sig" : "3065023037a1ba49f11e97ad0ec47e687c6c6e94f794f874720c0dd2da501437b50e5b00fb6ed33adf7cf1f9c870fd3d37165bf7023100b3ad08c9886b4ca1593a68938b67142c65ed4da1714c22204cba71300c094ccdbdf84c38a3f6d896db72ed5051a19266",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 382,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32353637333738373431",
+          "sig" : "3066023100a0abe896d2f30207bc9b21e75400eedb88d3498d49806f41aa8e7f9bd815a33382f278db39710c2cb097937790d0236c0231009a29aded30e8ce4790756208d12044e18c34168608026000a883044dd0d91109d866b422a054c232810ddfbb2ae440bb",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 383,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35373339393334393935",
+          "sig" : "3065023100b024fc3479d0ddde1c9e06b63c9bfb76a00d0f2f555220cb9a1311c2deec32eb3d6d2b648f5e8c104d5f88931754c0c20230767950cc149697edbae836f977bd38d89d141ff9774147b13ddd525b7a3f3a14a80d9979856f65b99a6faff173b5d6eb",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 384,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33343738333636313339",
+          "sig" : "306402302a0ae7b5d42645051212cafb7339b9c5283d1fd9881d77ad5c18d25ee10907b7809740a510e65aecd61b53ba3a0f660a02304c0457dd19ef6e4d6ae65f45417ddf1a58c07663a86737d271becfa3ea5724b6018f1fa9e64fd08601a7dbd3957761d9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 385,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "363439303532363032",
+          "sig" : "306502300c1657320faca6668c6e9f06f657a310b01939a7d9640fa0429872fe28bd1667688bc162221285ecfb14e8d80627450a023100f5272aa08c321aa4f7e520825cc720f6511d635598c648d4d514669b3ad803ad259c799e195a095982f66c176435be21",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 386,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34373633383837343936",
+          "sig" : "3066023100d821798a7a72bfb483e6e9840e8d921200ef1976b7e514036bf9133a01740ce397c73fa046054438c5806c294a02c6800231008c5d12887fcd945ba123fc5a5605d13a5a3e7e781ad69c6103577ee9dc47adc3e39a21080dd50304b59e5f5cf3f5a385",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 387,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "353739303230303830",
+          "sig" : "3065023100c996bd6fa63c9586779f27523d5583135a594808514f98cc44cac1fa5cfa03c78c7f12f746c6bd20608ecbe3060eb068023027d40a11d52373df3054a28b0ab98a91ad689d1211d69919fc04cadc22ff0367d3ef9433012a760c1d1df3715c8d5cf3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 388,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35333434373837383438",
+          "sig" : "3065023042dd6c8d995938701a538909ed6aeae0ba50c995138de84e195bbb9c56180e108d4a6274548c7be6e121c4d218d2d4a0023100fae8668bb2003f0da1dc90bec67d354ccbb899432599c3198b96c5ca4bd2324c46998f4fb76a123467cf24570b1b6916",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 389,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3139323636343130393230",
+          "sig" : "30650230061f185633291b9a768e15ec03a2b7c356c757b023b61e313fdf0c5349d128a78668d20b2561709b3bd8451b920f12ab0231008fc5edc66410dbf20a7cbc3498e405761756ed39866856e74256ac1f255f62b0edff519762ecdbbc8395d14715c4388e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 390,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33373033393135373035",
+          "sig" : "3065023069326e047c62e8bac5c090b76bf73ae652fa9a6aecfa1ccb8702f419094c9727511264fb1aeec00e425c7a0d746793d30231009dbddd22db4a77dbe16114bc6fbb981aecba7e82a9cbc1ed385e28a51793561770fb3f9696090efca24f268d8788f2c9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 391,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3831353435373730",
+          "sig" : "306402304ca1df89b23ed5efcdf601d295c45e402d786a14d62f7261104e4cb05b8cae17abb095799e71173841749615c829411b02301bb777e0a6fee8a2337a436a6fa26a487de4640ff97d57b44b55305989803863d748c7302f2dfde8b8cedd69bb602e2d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 392,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "313935353330333737",
+          "sig" : "3065023067be1b06f67172c503a5ac50582235d30bc9079eaa4cdec69a39c096310f8d99186cc9af7c8b4369a291d3e921d60705023100ab645fc91f06b1ff7cc58fccf6f7cfac74db30d839748a78cb5f3b8fefc7a06f3b5ff0310a8580c6050bebb75eda972c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 393,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31323637383130393033",
+          "sig" : "3066023100d966442d6c29e5a4cc60e2374eccd373db3ebe405ee7c9664c4273100cd1899a1c58110487528616d8c5321dbf5227640231009bb0e4a2c041a3b7b672029fe480d155f57671ecd6eb598660d025acce1f613d03cd6cff4a214131c8c7a8ad22df1397",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 394,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131313830373230383135",
+          "sig" : "3064023008a84a2bc39b082ab82e6e45f088a36f1cb255f97ec8124eca929d4506d7dab63957c647994be2c2c7344f902de5b38f02300c9645e84a304ba0970ca5ce00b8c8a971fa0d0bcbec6a70134894c44d3075030ff04333ea3889f847a1ed769ee618ee",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 395,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "38333831383639323930",
+          "sig" : "306502310083004b034202bbf51a327d32ed3ddf67b46eda9bac695a4422744a4bd99aaac3b3e8ed80ddac6538939c9385d6c8f61602307b4e61926cb9afa8cdaaf44909df6dc6449887d59fe2acac05f7684a235fa77179bdbcc69fd8f359e8eda19e5a5d4807",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 396,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33313331323837323737",
+          "sig" : "3065023100ad93375a1d374c41e5de268a8c08c205ff5652445bfe3ddf4ca77a70f5819f9f06db861d82fc9637946f0fe38457f2bd02304bc043acbc6a68d4824ed768af9476ad5b93e4cb3bbac284fb5fbd548ae3b96c265c6d1ef4588a3e2da21b124c0d6b12",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 397,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3134333331393236353338",
+          "sig" : "30660231009e0d45d2dc93fd363dc919405818e39922f3f9dd0827bcad86d4ba80a44b45a6f60b8e593b580c91262b32859dbb1e53023100eb9b8dfe5ba4a055a974f19b488f3a6fa07161006ac94eb1fe1c12dd0e20f3a7be38a37ce96d671183c5871249b2a3c5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 398,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "333434393038323336",
+          "sig" : "306502307a5d04cd2fda59d8565c79ea2a7f1289ab79cae9fde060094c805c591a2534e4393e28c3fd858529bf17643846aceb830231008de0d8c0092fd02d554afe25f814744beaaa17c6946a6387ec7046b602db8a6c900246c2fb63fcef2ac8d9394444a0fc",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 399,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36383239383335393239",
+          "sig" : "3065023100a564eea0cdac051a769f8ff1e0c834a288ce514f67d138113727b53a1a6fc95ce237367b91f1b91b2f65d589adc8288e0230182e5b47b6fbd8e741a04e809487ba5fcb8a5f2f1b9af6ce214128623a4768e38e6ddc958ff39078c36c04a314708427",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 400,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33343435313538303233",
+          "sig" : "306402306758867cd1ca1446cc41043d1625c967a0ae04d9db17bbb42fa9c076b3593125d63cd3e7471ee6cdba5235a21cec2f220230563db387adb537e1d89231d935ac790316925aeb29132b9f87bee91116c33bf50943fe39b671ce9535dca0a5d22bbfa4",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 401,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3132363937393837363434",
+          "sig" : "3066023100cde033e38d3f791db87d8a6907516bd8021acd47e897df683fda529d48050f8b5688f6361daf1b14bc3f45fc7f76150f023100e14f4811a667c85335a4709a589ea46bac72055b794eaea92d28e834d5bc459c605fe4f27c1ab18d186d59e7d205cb67",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 402,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "333939323432353533",
+          "sig" : "3065023100f2384468b55553c68f9764d8248cfd7358d604fa377ebb13828c43a8ebdf308fbbbebfa49a9458bfda957d2068d24e3f02301fdf4891d56e3e90c02b05c14c27c17f56f8e6aa144f02328c90109e1f70c9e3f582f0d299c44da505c543cc89c6a990",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 403,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31363031393737393737",
+          "sig" : "3065023100b1ccafedcc21ba90b342fa23c0149f3d12a939ab6c3342b36ae61fddbdc753927a7c3e978bd780cf25cd78c8c5efe28002304c32a73f3157bbe2384095eb67726b9cd3c2623b98a182a3b4f00e8db933e1113b7ada2695a7d79b471026462b20e289",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 404,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130383738373535313435",
+          "sig" : "3066023100f3ed170e449758299ae55eb85244745e1876621c1f708e07e55c0d2d9ab5f9af9e0a8b3c7bdf8936ab3c9ebd1908e9dc023100da62ccdb658868147286d7269bcbd4addb4dec9ea3d5d79fdbe0ccffa40d055170bddeb4ef4c5e0bc99fae5db62b4477",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 405,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37303034323532393939",
+          "sig" : "306502310083455fc4629e7693c8e495fec2d29bb23bb6db79180fcfa83a4f9310d9db27e29297dee27ee80a71ab2f7a2d59f48b8802307736c056c8f2bb57e9fb6b8de0ab6d09879f6611e737634e7b6337aa5c5a01f515d5e3702dec9a702177c816e32bac67",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 406,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31353635333235323833",
+          "sig" : "3065023074961587cbe49bbf0a73fea82b8b2242f67b0ea09224774639f437c60378a36b2d511a9145d576b440dffd1f02286a8b0231008fb95d46c22889085cc1d3e20bcfbcbc52f4532445f76f08efae2de8b56fe8525204643330dfd23cce946687a0aef046",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 407,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3233383236333432333530",
+          "sig" : "3065023100a3fd322330d0f0efccc54bd7d73c3159eb1bcca08cec369a4a08fd00f9ec6d482ced58eb08a0d7c2113bd5575de4917d0230164e3232a628c40fbba1de82bfb9627cec78a8040cf325a5a8bb8f864c2ac19e3524ac93f4db5713ce62ba256176e05e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 408,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31343437383437303635",
+          "sig" : "306502304c862ff9e4ff88f9a58e9fceaaf9bbb30740d3f6c8c6a69b5627fe234b144f8cdf09520735cfd708f5e341a78cc4873d023100a861972514a0e975cf2da214125ec93288524cc77492ed63c516424278e5ec8d41724467cb7c3111fa34c69193abb435",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 409,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3134323630323035353434",
+          "sig" : "3065023062225e4e492a9773397870336168960a66b9e50391ef7289cb2d3878f32252dc1b904f6682545e14564e415bd93e01170231009f4d0327f79e043505c691e361fa2e00f87f41324777eca6966f4bea2fa0858876aa01980b2cad7f66037524de49bf65",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 410,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31393933383335323835",
+          "sig" : "30640230450c65d2d88ba464eee3a5ce9310b519d5dcf608799fb2275eee987a67c2c4d7ac53716987cc5139c18c67ef07b1e20702301ee0439311a7bce1c4fed0a3152d1b354d96536c6ca0c9188ac1f1afcc5cd7305b5611ef0d19d8bd57c5059976dc5e68",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 411,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34323932313533353233",
+          "sig" : "3066023100aa2575fb5bea0effb5247d20c3d0165d575831840b5c18b0245a99a61b7ad5d7bf8a8cfcc375e095a84e781025bee3ee0231009c8b7797ad330abc206060b28b6ca1c639d89f59582528bda1527e3ab081697a2ab576f9d09c2ee329dd73231667308d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 412,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34343539393031343936",
+          "sig" : "3064023001fc45285aa2c2e50458199ade2ded0dd36b1de03e8969175be4a6f09f9719b195ded8d9eb4ea132d95d19a3528fd6c9023059609a358c5919fef4781061804d4d64a067edecdcfd14620161aae3ef2735095a558e4f8ae345040123f093e5f70af2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 413,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31333933393731313731",
+          "sig" : "3065023100d8e1f6b19e5b92e36060e59e53eeb788a4758c2c8ee9519f3949d5f3315abafbe937b8ed44d47e886a07c107aa8ac9f4023012550574318371e5168d0a339f20fcacaec87db211bba4d4e7c7e055b63b75fd31790ad285f4cc061378692b0a248e34",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 414,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32333930363936343935",
+          "sig" : "306402304815aec44a7a6b86ae87fc2556accd77832fa33a4710e02ec5ef6f41f68a910e6af4d173ae462a759bd98079b371bf5d02306e78d562f9e8be65e8d7a74a7305e5d6cf2f3c4c980f2b18dfb8e9c8b0134ec86548053b3d125e56d5872294d2d14ebc",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 415,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131343436303536323634",
+          "sig" : "3065023100d302f9db6b2d94e194412f0d40a135a554aee014bd939b3d7e45c1221ef7ce45c2aed875f9a2bc43dbc8264d92e444a5023004e7247b258c6e7739979c0a07282f62958ac45e52dd76a41d5e1aca31a5cda73d7b026d67b4d609803001cb661d74c6",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 416,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "363835303034373530",
+          "sig" : "3065023100889f0e2a6ae2ddcad1cde3f65b61d4dd40985917ba841b47a1f802491f5af5067722b7683df0fca7ee19d2b73724c8fd02301f989bac23b51c49e5d7dcc319eed2fc767e9b432bf75af92814d9e67a5d4b3398eb15e98b70527abbc029abc1bea524",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 417,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3232323035333630363139",
+          "sig" : "3066023100e69c70c679795ca7d2b66e2632529651c120055fa3cf25435fe8bb28987c02412ce73e6ca5ca7e0b42e9670c0a588175023100edd8513bff40cdca9e22659238fbcea2de2caeef53c5287a515db9168b3008ec446c9b94f28a6e021c69bc6637fc4634",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 418,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36323135363635313234",
+          "sig" : "30640230068cbecfd47bfd688f495df05e45fd5fced6d8e240605c5b2be5e69368740b694b9b1ea034af3180e571dd38a86369ef02301a1d2976f748d1621128013c61abda5398a3e24f0073d1a6e07a1e96c12be4f1e2e7b144f9b5a350500acfc5cb0698d9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 419,
+          "comment" : "Signature generated without truncating the hash",
+          "flags" : [
+            "Untruncatedhash"
+          ],
           "msg" : "313233343030",
-          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffe023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "306402300e2c56eb5f6612f0c2b22ab03d57d9a443075a2b7a0b460883e4f4876121e9b6f1ed67de20b79f028f7f66ed0281db7102303916b72b12d035a307b7c45a9878333a8c61445aad2330dc49a12b92e2e5dab72e53e5789f40afb90aea0ea4431f2dd1",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
+        "uncompressed" : "04ca5ee479ad6624ab5870539a56a23b3816eef7bbc67156836dfb58c425fdb7213e31770f12b43152e887d88a3afb4b182aceec92b3139aca8396402a8f81bb5014e748eab2e2059f8656a883e62d78b9dc988b98332627f95232d37df26585d3",
+        "wx" : "00ca5ee479ad6624ab5870539a56a23b3816eef7bbc67156836dfb58c425fdb7213e31770f12b43152e887d88a3afb4b18",
+        "wy" : "2aceec92b3139aca8396402a8f81bb5014e748eab2e2059f8656a883e62d78b9dc988b98332627f95232d37df26585d3"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004ca5ee479ad6624ab5870539a56a23b3816eef7bbc67156836dfb58c425fdb7213e31770f12b43152e887d88a3afb4b182aceec92b3139aca8396402a8f81bb5014e748eab2e2059f8656a883e62d78b9dc988b98332627f95232d37df26585d3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEyl7kea1mJKtYcFOaVqI7OBbu97vGcVaD\nbftYxCX9tyE+MXcPErQxUuiH2Io6+0sYKs7skrMTmsqDlkAqj4G7UBTnSOqy4gWf\nhlaog+YteLncmIuYMyYn+VIy033yZYXT\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 420,
+          "comment" : "k*G has a large x-coordinate",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304d0218389cb27e0bc8d21fa7e5f24cb74f58851313e696333ad68b023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 421,
+          "comment" : "r too large",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffeffffffff0000000000000000fffffffe023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52970",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
         "uncompressed" : "0470e6a90b4e076bf51dfa01fa44de49b448f7afa0f3d07677f1682ca776d404b2a0feef66b005ea28ba99b6ce21d0ca12424f7d179951fb89156cdf04aed6db056c98592c651b5a881abc34e2401127fb81c64e90cee83269c5141f9a3c7bce78",
         "wx" : "70e6a90b4e076bf51dfa01fa44de49b448f7afa0f3d07677f1682ca776d404b2a0feef66b005ea28ba99b6ce21d0ca12",
         "wy" : "424f7d179951fb89156cdf04aed6db056c98592c651b5a881abc34e2401127fb81c64e90cee83269c5141f9a3c7bce78"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000470e6a90b4e076bf51dfa01fa44de49b448f7afa0f3d07677f1682ca776d404b2a0feef66b005ea28ba99b6ce21d0ca12424f7d179951fb89156cdf04aed6db056c98592c651b5a881abc34e2401127fb81c64e90cee83269c5141f9a3c7bce78",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEcOapC04Ha/Ud+gH6RN5JtEj3r6Dz0HZ3\n8Wgsp3bUBLKg/u9msAXqKLqZts4h0MoSQk99F5lR+4kVbN8ErtbbBWyYWSxlG1qI\nGrw04kARJ/uBxk6QzugyacUUH5o8e854\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000470e6a90b4e076bf51dfa01fa44de49b448f7afa0f3d07677f1682ca776d404b2a0feef66b005ea28ba99b6ce21d0ca12424f7d179951fb89156cdf04aed6db056c98592c651b5a881abc34e2401127fb81c64e90cee83269c5141f9a3c7bce78",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEcOapC04Ha/Ud+gH6RN5JtEj3r6Dz0HZ3\n8Wgsp3bUBLKg/u9msAXqKLqZts4h0MoSQk99F5lR+4kVbN8ErtbbBWyYWSxlG1qI\nGrw04kARJ/uBxk6QzugyacUUH5o8e854\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 343,
+          "tcId" : 422,
           "comment" : "r,s are large",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3066023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52972023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52971",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "045a568474805fbf9acc1e5756d296696290b73d4d1c3b197f48aff03b919f0111823f90ea024af1c78e7c803e2297662d4c1c79edc9c694620c1f5b5cc7dd9ff89a42442747857cace26b6ebc99962ec3a68a8e4072226d6d98a2a866dd97c203",
         "wx" : "5a568474805fbf9acc1e5756d296696290b73d4d1c3b197f48aff03b919f0111823f90ea024af1c78e7c803e2297662d",
         "wy" : "4c1c79edc9c694620c1f5b5cc7dd9ff89a42442747857cace26b6ebc99962ec3a68a8e4072226d6d98a2a866dd97c203"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200045a568474805fbf9acc1e5756d296696290b73d4d1c3b197f48aff03b919f0111823f90ea024af1c78e7c803e2297662d4c1c79edc9c694620c1f5b5cc7dd9ff89a42442747857cace26b6ebc99962ec3a68a8e4072226d6d98a2a866dd97c203",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEWlaEdIBfv5rMHldW0pZpYpC3PU0cOxl/\nSK/wO5GfARGCP5DqAkrxx458gD4il2YtTBx57cnGlGIMH1tcx92f+JpCRCdHhXys\n4mtuvJmWLsOmio5AciJtbZiiqGbdl8ID\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200045a568474805fbf9acc1e5756d296696290b73d4d1c3b197f48aff03b919f0111823f90ea024af1c78e7c803e2297662d4c1c79edc9c694620c1f5b5cc7dd9ff89a42442747857cace26b6ebc99962ec3a68a8e4072226d6d98a2a866dd97c203",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEWlaEdIBfv5rMHldW0pZpYpC3PU0cOxl/\nSK/wO5GfARGCP5DqAkrxx458gD4il2YtTBx57cnGlGIMH1tcx92f+JpCRCdHhXys\n4mtuvJmWLsOmio5AciJtbZiiqGbdl8ID\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 344,
+          "tcId" : 423,
           "comment" : "r and s^-1 have a large Hamming weight",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100d1aee55fdc2a716ba2fabcb57020b72e539bf05c7902f98e105bf83d4cc10c2a159a3cf7e01d749d2205f4da6bd8fcf1",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0488531382963bfe4e179f0b457ecd446528b98d349edbd8e7d0f6c1673b4ae2a7629b3345a7eae2e7c48358c13bdbe0389375c849dd571d91f2a3bf8994f53f82261f38172806c4d725de2029e887bfe036f38d6985ea5a22c52169db6e4213da",
-        "wx" : "088531382963bfe4e179f0b457ecd446528b98d349edbd8e7d0f6c1673b4ae2a7629b3345a7eae2e7c48358c13bdbe038",
-        "wy" : "09375c849dd571d91f2a3bf8994f53f82261f38172806c4d725de2029e887bfe036f38d6985ea5a22c52169db6e4213da"
+        "wx" : "0088531382963bfe4e179f0b457ecd446528b98d349edbd8e7d0f6c1673b4ae2a7629b3345a7eae2e7c48358c13bdbe038",
+        "wy" : "009375c849dd571d91f2a3bf8994f53f82261f38172806c4d725de2029e887bfe036f38d6985ea5a22c52169db6e4213da"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000488531382963bfe4e179f0b457ecd446528b98d349edbd8e7d0f6c1673b4ae2a7629b3345a7eae2e7c48358c13bdbe0389375c849dd571d91f2a3bf8994f53f82261f38172806c4d725de2029e887bfe036f38d6985ea5a22c52169db6e4213da",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEiFMTgpY7/k4XnwtFfs1EZSi5jTSe29jn\n0PbBZztK4qdimzNFp+ri58SDWME72+A4k3XISd1XHZHyo7+JlPU/giYfOBcoBsTX\nJd4gKeiHv+A2841phepaIsUhadtuQhPa\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000488531382963bfe4e179f0b457ecd446528b98d349edbd8e7d0f6c1673b4ae2a7629b3345a7eae2e7c48358c13bdbe0389375c849dd571d91f2a3bf8994f53f82261f38172806c4d725de2029e887bfe036f38d6985ea5a22c52169db6e4213da",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEiFMTgpY7/k4XnwtFfs1EZSi5jTSe29jn\n0PbBZztK4qdimzNFp+ri58SDWME72+A4k3XISd1XHZHyo7+JlPU/giYfOBcoBsTX\nJd4gKeiHv+A2841phepaIsUhadtuQhPa\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 345,
+          "tcId" : 424,
           "comment" : "r and s^-1 have a large Hamming weight",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100b6b681dc484f4f020fd3f7e626d88edc6ded1b382ef3e143d60887b51394260832d4d8f2ef70458f9fa90e38c2e19e4f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04080da57d67dba48eb50eef484cf668d981e1bf30c357c3fd21a43cdc41f267c3f186bf87e3680239bac09930f144263c5f28777ad8bcbfc3eb0369e0f7b18392a12397a4fbe15a2a1f6e2e5b4067c82681c89c73db25eca18c6b25768429cef0",
         "wx" : "080da57d67dba48eb50eef484cf668d981e1bf30c357c3fd21a43cdc41f267c3f186bf87e3680239bac09930f144263c",
         "wy" : "5f28777ad8bcbfc3eb0369e0f7b18392a12397a4fbe15a2a1f6e2e5b4067c82681c89c73db25eca18c6b25768429cef0"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004080da57d67dba48eb50eef484cf668d981e1bf30c357c3fd21a43cdc41f267c3f186bf87e3680239bac09930f144263c5f28777ad8bcbfc3eb0369e0f7b18392a12397a4fbe15a2a1f6e2e5b4067c82681c89c73db25eca18c6b25768429cef0",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAECA2lfWfbpI61Du9ITPZo2YHhvzDDV8P9\nIaQ83EHyZ8Pxhr+H42gCObrAmTDxRCY8Xyh3eti8v8PrA2ng97GDkqEjl6T74Voq\nH24uW0BnyCaByJxz2yXsoYxrJXaEKc7w\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004080da57d67dba48eb50eef484cf668d981e1bf30c357c3fd21a43cdc41f267c3f186bf87e3680239bac09930f144263c5f28777ad8bcbfc3eb0369e0f7b18392a12397a4fbe15a2a1f6e2e5b4067c82681c89c73db25eca18c6b25768429cef0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAECA2lfWfbpI61Du9ITPZo2YHhvzDDV8P9\nIaQ83EHyZ8Pxhr+H42gCObrAmTDxRCY8Xyh3eti8v8PrA2ng97GDkqEjl6T74Voq\nH24uW0BnyCaByJxz2yXsoYxrJXaEKc7w\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 346,
+          "tcId" : 425,
           "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3006020102020101",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "040e74a096d7f6ee1be9b4160d6b79baba4d25b4fb6fbdd38f5a9ed5cc1ac79943be71ede093e504c7dc0832daeb898a05a8d005b30c894686f6ecb2bc696e25effaccd3c9e4b48122db567c0118a0b983b757c2f40082dc374f8f6117a8e76fc0",
         "wx" : "0e74a096d7f6ee1be9b4160d6b79baba4d25b4fb6fbdd38f5a9ed5cc1ac79943be71ede093e504c7dc0832daeb898a05",
-        "wy" : "0a8d005b30c894686f6ecb2bc696e25effaccd3c9e4b48122db567c0118a0b983b757c2f40082dc374f8f6117a8e76fc0"
+        "wy" : "00a8d005b30c894686f6ecb2bc696e25effaccd3c9e4b48122db567c0118a0b983b757c2f40082dc374f8f6117a8e76fc0"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200040e74a096d7f6ee1be9b4160d6b79baba4d25b4fb6fbdd38f5a9ed5cc1ac79943be71ede093e504c7dc0832daeb898a05a8d005b30c894686f6ecb2bc696e25effaccd3c9e4b48122db567c0118a0b983b757c2f40082dc374f8f6117a8e76fc0",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEDnSgltf27hvptBYNa3m6uk0ltPtvvdOP\nWp7VzBrHmUO+ce3gk+UEx9wIMtrriYoFqNAFswyJRob27LK8aW4l7/rM08nktIEi\n21Z8ARiguYO3V8L0AILcN0+PYReo52/A\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200040e74a096d7f6ee1be9b4160d6b79baba4d25b4fb6fbdd38f5a9ed5cc1ac79943be71ede093e504c7dc0832daeb898a05a8d005b30c894686f6ecb2bc696e25effaccd3c9e4b48122db567c0118a0b983b757c2f40082dc374f8f6117a8e76fc0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEDnSgltf27hvptBYNa3m6uk0ltPtvvdOP\nWp7VzBrHmUO+ce3gk+UEx9wIMtrriYoFqNAFswyJRob27LK8aW4l7/rM08nktIEi\n21Z8ARiguYO3V8L0AILcN0+PYReo52/A\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 347,
+          "tcId" : 426,
           "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3006020102020102",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04a2ad0e27b40410d16077ddc5e415f109d328bf75e73a0f56876fef731285f83188b207a68690a40e76ed23e2c5e49fcf604f1c5d7d7df365005d40e209f4da7bb06f310d5a1660ad6236577fbb47955261f507d23b83013ffb951bd76908e76c",
-        "wx" : "0a2ad0e27b40410d16077ddc5e415f109d328bf75e73a0f56876fef731285f83188b207a68690a40e76ed23e2c5e49fcf",
+        "wx" : "00a2ad0e27b40410d16077ddc5e415f109d328bf75e73a0f56876fef731285f83188b207a68690a40e76ed23e2c5e49fcf",
         "wy" : "604f1c5d7d7df365005d40e209f4da7bb06f310d5a1660ad6236577fbb47955261f507d23b83013ffb951bd76908e76c"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004a2ad0e27b40410d16077ddc5e415f109d328bf75e73a0f56876fef731285f83188b207a68690a40e76ed23e2c5e49fcf604f1c5d7d7df365005d40e209f4da7bb06f310d5a1660ad6236577fbb47955261f507d23b83013ffb951bd76908e76c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEoq0OJ7QEENFgd93F5BXxCdMov3XnOg9W\nh2/vcxKF+DGIsgemhpCkDnbtI+LF5J/PYE8cXX1982UAXUDiCfTae7BvMQ1aFmCt\nYjZXf7tHlVJh9QfSO4MBP/uVG9dpCOds\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004a2ad0e27b40410d16077ddc5e415f109d328bf75e73a0f56876fef731285f83188b207a68690a40e76ed23e2c5e49fcf604f1c5d7d7df365005d40e209f4da7bb06f310d5a1660ad6236577fbb47955261f507d23b83013ffb951bd76908e76c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEoq0OJ7QEENFgd93F5BXxCdMov3XnOg9W\nh2/vcxKF+DGIsgemhpCkDnbtI+LF5J/PYE8cXX1982UAXUDiCfTae7BvMQ1aFmCt\nYjZXf7tHlVJh9QfSO4MBP/uVG9dpCOds\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 348,
+          "tcId" : 427,
           "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3006020102020103",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "0465825b7c85ee36e98a00fda722a70a7bca2981fb642084f896c1670107ca01f407f146251bf979724f2dcffe2dc425e1bc10124ed3f2a4acd6d1e1f1a9b7bbdc196365f3b90c90d0085246eb0a336ceeef6469619b6a44c6cde3ade84bdcb664",
+        "wx" : "65825b7c85ee36e98a00fda722a70a7bca2981fb642084f896c1670107ca01f407f146251bf979724f2dcffe2dc425e1",
+        "wy" : "00bc10124ed3f2a4acd6d1e1f1a9b7bbdc196365f3b90c90d0085246eb0a336ceeef6469619b6a44c6cde3ade84bdcb664"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000465825b7c85ee36e98a00fda722a70a7bca2981fb642084f896c1670107ca01f407f146251bf979724f2dcffe2dc425e1bc10124ed3f2a4acd6d1e1f1a9b7bbdc196365f3b90c90d0085246eb0a336ceeef6469619b6a44c6cde3ade84bdcb664",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEZYJbfIXuNumKAP2nIqcKe8opgftkIIT4\nlsFnAQfKAfQH8UYlG/l5ck8tz/4txCXhvBASTtPypKzW0eHxqbe73BljZfO5DJDQ\nCFJG6wozbO7vZGlhm2pExs3jrehL3LZk\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 428,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020103020101",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "0497d213d98a6a6b4b1fb3d20533b333b8f3d9d38458e52846ab7893763e08a69464aebecfa64750bbd2736782d5fff41320a7c0bfb103d0f13ddc7858c219139de34698b30d19b894269c13ed79842edd91fdda3e94734c79bd4258561ff0890b",
+        "wx" : "0097d213d98a6a6b4b1fb3d20533b333b8f3d9d38458e52846ab7893763e08a69464aebecfa64750bbd2736782d5fff413",
+        "wy" : "20a7c0bfb103d0f13ddc7858c219139de34698b30d19b894269c13ed79842edd91fdda3e94734c79bd4258561ff0890b"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000497d213d98a6a6b4b1fb3d20533b333b8f3d9d38458e52846ab7893763e08a69464aebecfa64750bbd2736782d5fff41320a7c0bfb103d0f13ddc7858c219139de34698b30d19b894269c13ed79842edd91fdda3e94734c79bd4258561ff0890b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEl9IT2Ypqa0sfs9IFM7MzuPPZ04RY5ShG\nq3iTdj4IppRkrr7PpkdQu9JzZ4LV//QTIKfAv7ED0PE93HhYwhkTneNGmLMNGbiU\nJpwT7XmELt2R/do+lHNMeb1CWFYf8IkL\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 429,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020103020103",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "040bfd55e9478130ae3dfaef83c7802a64701c3f3a4112a25de26a24e038036618a603a5cf784163c4f9511aed456a566198a0eba39541265c29def7f89dc8799599af95bce3006aa0841133d4fd63d06df461e00306f76ac7a64e95a779d9f7cd",
+        "wx" : "0bfd55e9478130ae3dfaef83c7802a64701c3f3a4112a25de26a24e038036618a603a5cf784163c4f9511aed456a5661",
+        "wy" : "0098a0eba39541265c29def7f89dc8799599af95bce3006aa0841133d4fd63d06df461e00306f76ac7a64e95a779d9f7cd"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200040bfd55e9478130ae3dfaef83c7802a64701c3f3a4112a25de26a24e038036618a603a5cf784163c4f9511aed456a566198a0eba39541265c29def7f89dc8799599af95bce3006aa0841133d4fd63d06df461e00306f76ac7a64e95a779d9f7cd",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEC/1V6UeBMK49+u+Dx4AqZHAcPzpBEqJd\n4mok4DgDZhimA6XPeEFjxPlRGu1FalZhmKDro5VBJlwp3vf4nch5lZmvlbzjAGqg\nhBEz1P1j0G30YeADBvdqx6ZOlad52ffN\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 430,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020103020104",
+          "result" : "valid"
         },
         {
-          "tcId" : 349,
+          "tcId" : 431,
           "comment" : "r is larger than n",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
-          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52975020103",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3036023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc52976020104",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
-        "uncompressed" : "04a233025c12d20f49dc50dc802e79f03c7ce1750b9204b51325d90b5ade08f4a74ef6efb081ed3156d64a0110d60fffabb924881891ee984cf51949dee96cfd7c9759b1ff00f0dbdc718d52117079d5d8bd6c86c6f532276af38b779bf2350d7f",
-        "wx" : "0a233025c12d20f49dc50dc802e79f03c7ce1750b9204b51325d90b5ade08f4a74ef6efb081ed3156d64a0110d60fffab",
-        "wy" : "0b924881891ee984cf51949dee96cfd7c9759b1ff00f0dbdc718d52117079d5d8bd6c86c6f532276af38b779bf2350d7f"
+        "uncompressed" : "040b2e5e46bbbe09fe974f71dee41cfb484457edebd47c50022934e248e7713f4d7fcad531a3b71224b482406125a05e2f3ecf586ad81c48a8062845cbc1147b61225112c244b1b63d434068cff7712ac4a1375a0d252759c303c522347e062872",
+        "wx" : "0b2e5e46bbbe09fe974f71dee41cfb484457edebd47c50022934e248e7713f4d7fcad531a3b71224b482406125a05e2f",
+        "wy" : "3ecf586ad81c48a8062845cbc1147b61225112c244b1b63d434068cff7712ac4a1375a0d252759c303c522347e062872"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004a233025c12d20f49dc50dc802e79f03c7ce1750b9204b51325d90b5ade08f4a74ef6efb081ed3156d64a0110d60fffabb924881891ee984cf51949dee96cfd7c9759b1ff00f0dbdc718d52117079d5d8bd6c86c6f532276af38b779bf2350d7f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEojMCXBLSD0ncUNyALnnwPHzhdQuSBLUT\nJdkLWt4I9KdO9u+wge0xVtZKARDWD/+ruSSIGJHumEz1GUne6Wz9fJdZsf8A8Nvc\ncY1SEXB51di9bIbG9TInavOLd5vyNQ1/\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200040b2e5e46bbbe09fe974f71dee41cfb484457edebd47c50022934e248e7713f4d7fcad531a3b71224b482406125a05e2f3ecf586ad81c48a8062845cbc1147b61225112c244b1b63d434068cff7712ac4a1375a0d252759c303c522347e062872",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAECy5eRru+Cf6XT3He5Bz7SERX7evUfFAC\nKTTiSOdxP01/ytUxo7cSJLSCQGEloF4vPs9YatgcSKgGKEXLwRR7YSJREsJEsbY9\nQ0Boz/dxKsShN1oNJSdZwwPFIjR+Bihy\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 350,
+          "tcId" : 432,
           "comment" : "s is larger than n",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
-          "sig" : "3036020102023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accd7fffa",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3036020103023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accd7fffa",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "043c9bb63607cdea0585f38d9780c9ac3e9a5a58153e2aacc4bc7a1d638d12e32c4d3a90c0c114b232c6f16e23e4bebb24da2ac2ccedc5494fe534a9abaea3013de0176f1b0e91bcd62154bdf3f604091a5008b2466702d0e2f93e4a4b6c601a54",
         "wx" : "3c9bb63607cdea0585f38d9780c9ac3e9a5a58153e2aacc4bc7a1d638d12e32c4d3a90c0c114b232c6f16e23e4bebb24",
-        "wy" : "0da2ac2ccedc5494fe534a9abaea3013de0176f1b0e91bcd62154bdf3f604091a5008b2466702d0e2f93e4a4b6c601a54"
+        "wy" : "00da2ac2ccedc5494fe534a9abaea3013de0176f1b0e91bcd62154bdf3f604091a5008b2466702d0e2f93e4a4b6c601a54"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200043c9bb63607cdea0585f38d9780c9ac3e9a5a58153e2aacc4bc7a1d638d12e32c4d3a90c0c114b232c6f16e23e4bebb24da2ac2ccedc5494fe534a9abaea3013de0176f1b0e91bcd62154bdf3f604091a5008b2466702d0e2f93e4a4b6c601a54",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEPJu2NgfN6gWF842XgMmsPppaWBU+KqzE\nvHodY40S4yxNOpDAwRSyMsbxbiPkvrsk2irCzO3FSU/lNKmrrqMBPeAXbxsOkbzW\nIVS98/YECRpQCLJGZwLQ4vk+SktsYBpU\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200043c9bb63607cdea0585f38d9780c9ac3e9a5a58153e2aacc4bc7a1d638d12e32c4d3a90c0c114b232c6f16e23e4bebb24da2ac2ccedc5494fe534a9abaea3013de0176f1b0e91bcd62154bdf3f604091a5008b2466702d0e2f93e4a4b6c601a54",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEPJu2NgfN6gWF842XgMmsPppaWBU+KqzE\nvHodY40S4yxNOpDAwRSyMsbxbiPkvrsk2irCzO3FSU/lNKmrrqMBPeAXbxsOkbzW\nIVS98/YECRpQCLJGZwLQ4vk+SktsYBpU\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 351,
+          "tcId" : 433,
           "comment" : "small r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3036020201000230489122448912244891224489122448912244891224489122347ce79bc437f4d071aaa92c7d6c882ae8734dc18cb0d553",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04559a66ef77752fd856976f36ed315619932204599bd7ef91d1a53ac1e7c90b3969cab8143b7a53c4bf5a3fe39f649eb61f00f86dd8b8556c4815b2a01c59eb6cc03c97b94b6db4318249fe489e36ac9635876b1ca2ec0999caef5e1a6a58a70d",
         "wx" : "559a66ef77752fd856976f36ed315619932204599bd7ef91d1a53ac1e7c90b3969cab8143b7a53c4bf5a3fe39f649eb6",
         "wy" : "1f00f86dd8b8556c4815b2a01c59eb6cc03c97b94b6db4318249fe489e36ac9635876b1ca2ec0999caef5e1a6a58a70d"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004559a66ef77752fd856976f36ed315619932204599bd7ef91d1a53ac1e7c90b3969cab8143b7a53c4bf5a3fe39f649eb61f00f86dd8b8556c4815b2a01c59eb6cc03c97b94b6db4318249fe489e36ac9635876b1ca2ec0999caef5e1a6a58a70d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEVZpm73d1L9hWl2827TFWGZMiBFmb1++R\n0aU6wefJCzlpyrgUO3pTxL9aP+OfZJ62HwD4bdi4VWxIFbKgHFnrbMA8l7lLbbQx\ngkn+SJ42rJY1h2scouwJmcrvXhpqWKcN\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004559a66ef77752fd856976f36ed315619932204599bd7ef91d1a53ac1e7c90b3969cab8143b7a53c4bf5a3fe39f649eb61f00f86dd8b8556c4815b2a01c59eb6cc03c97b94b6db4318249fe489e36ac9635876b1ca2ec0999caef5e1a6a58a70d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEVZpm73d1L9hWl2827TFWGZMiBFmb1++R\n0aU6wefJCzlpyrgUO3pTxL9aP+OfZJ62HwD4bdi4VWxIFbKgHFnrbMA8l7lLbbQx\ngkn+SJ42rJY1h2scouwJmcrvXhpqWKcN\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 352,
+          "tcId" : 434,
           "comment" : "smallish r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "303c02072d9b4d347952cd023100ce751512561b6f57c75342848a3ff98ccf9c3f0219b6b68d00449e6c971a85d2e2ce73554b59219d54d2083b46327351",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "040548e79a17fd3a114d830ea88f218ee1ef7aa3f8dc139e0a8b9b60e25049a816ef449e8bd5dae867446495fdf20f47700363a1e8afefb02ebfd59df90b6d23ff7d5f706f9b26daebae1d4657ac342844ee9c2e0e9269f7efe7ab91e0303c115d",
-        "wx" : "548e79a17fd3a114d830ea88f218ee1ef7aa3f8dc139e0a8b9b60e25049a816ef449e8bd5dae867446495fdf20f4770",
-        "wy" : "363a1e8afefb02ebfd59df90b6d23ff7d5f706f9b26daebae1d4657ac342844ee9c2e0e9269f7efe7ab91e0303c115d"
+        "wx" : "0548e79a17fd3a114d830ea88f218ee1ef7aa3f8dc139e0a8b9b60e25049a816ef449e8bd5dae867446495fdf20f4770",
+        "wy" : "0363a1e8afefb02ebfd59df90b6d23ff7d5f706f9b26daebae1d4657ac342844ee9c2e0e9269f7efe7ab91e0303c115d"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200040548e79a17fd3a114d830ea88f218ee1ef7aa3f8dc139e0a8b9b60e25049a816ef449e8bd5dae867446495fdf20f47700363a1e8afefb02ebfd59df90b6d23ff7d5f706f9b26daebae1d4657ac342844ee9c2e0e9269f7efe7ab91e0303c115d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEBUjnmhf9OhFNgw6ojyGO4e96o/jcE54K\ni5tg4lBJqBbvRJ6L1droZ0Rklf3yD0dwA2Oh6K/vsC6/1Z35C20j/31fcG+bJtrr\nrh1GV6w0KETunC4Okmn37+erkeAwPBFd\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200040548e79a17fd3a114d830ea88f218ee1ef7aa3f8dc139e0a8b9b60e25049a816ef449e8bd5dae867446495fdf20f47700363a1e8afefb02ebfd59df90b6d23ff7d5f706f9b26daebae1d4657ac342844ee9c2e0e9269f7efe7ab91e0303c115d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEBUjnmhf9OhFNgw6ojyGO4e96o/jcE54K\ni5tg4lBJqBbvRJ6L1droZ0Rklf3yD0dwA2Oh6K/vsC6/1Z35C20j/31fcG+bJtrr\nrh1GV6w0KETunC4Okmn37+erkeAwPBFd\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 353,
+          "tcId" : 435,
           "comment" : "100-bit r and small s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3041020d1033e67e37b32b445580bf4efb02302ad52ad52ad52ad52ad52ad52ad52ad52ad52ad52ad52ad5215c51b320e460542f9cc38968ccdf4263684004eb79a452",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04a0eb670630f9bbbd963c5750de7bcbae4ddfd37b13fe7690eec6861a3c56c8efb87dbbf85ccd953c659d382c3d7df76afb08840635a16ac7ecf3de2dc28a77c8af9d49e5a832551e3354a2b311e52be86720d9b2fbb78d11a8aec61606a29f0d",
-        "wx" : "0a0eb670630f9bbbd963c5750de7bcbae4ddfd37b13fe7690eec6861a3c56c8efb87dbbf85ccd953c659d382c3d7df76a",
-        "wy" : "0fb08840635a16ac7ecf3de2dc28a77c8af9d49e5a832551e3354a2b311e52be86720d9b2fbb78d11a8aec61606a29f0d"
+        "wx" : "00a0eb670630f9bbbd963c5750de7bcbae4ddfd37b13fe7690eec6861a3c56c8efb87dbbf85ccd953c659d382c3d7df76a",
+        "wy" : "00fb08840635a16ac7ecf3de2dc28a77c8af9d49e5a832551e3354a2b311e52be86720d9b2fbb78d11a8aec61606a29f0d"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004a0eb670630f9bbbd963c5750de7bcbae4ddfd37b13fe7690eec6861a3c56c8efb87dbbf85ccd953c659d382c3d7df76afb08840635a16ac7ecf3de2dc28a77c8af9d49e5a832551e3354a2b311e52be86720d9b2fbb78d11a8aec61606a29f0d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEoOtnBjD5u72WPFdQ3nvLrk3f03sT/naQ\n7saGGjxWyO+4fbv4XM2VPGWdOCw9ffdq+wiEBjWhasfs894twop3yK+dSeWoMlUe\nM1SisxHlK+hnINmy+7eNEaiuxhYGop8N\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004a0eb670630f9bbbd963c5750de7bcbae4ddfd37b13fe7690eec6861a3c56c8efb87dbbf85ccd953c659d382c3d7df76afb08840635a16ac7ecf3de2dc28a77c8af9d49e5a832551e3354a2b311e52be86720d9b2fbb78d11a8aec61606a29f0d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEoOtnBjD5u72WPFdQ3nvLrk3f03sT/naQ\n7saGGjxWyO+4fbv4XM2VPGWdOCw9ffdq+wiEBjWhasfs894twop3yK+dSeWoMlUe\nM1SisxHlK+hnINmy+7eNEaiuxhYGop8N\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 354,
+          "tcId" : 436,
           "comment" : "small r and 100 bit s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "303602020100023077a172dfe37a2c53f0b92ab60f0a8f085f49dbfd930719d6f9e587ea68ae57cb49cd35a88cf8c6acec02f057a3807a5b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04254bce3041b00468445cb9ae597bc76c1279a8506142ce2427185b1d7f753d1c0aad94156b531a2071aa61c83ec842a3710d6c8c96766ae8b63396133e5872805e47d9ba39113e122d676d54dbb2460b59d986bdd33be346c021e8a71bb41ba9",
         "wx" : "254bce3041b00468445cb9ae597bc76c1279a8506142ce2427185b1d7f753d1c0aad94156b531a2071aa61c83ec842a3",
         "wy" : "710d6c8c96766ae8b63396133e5872805e47d9ba39113e122d676d54dbb2460b59d986bdd33be346c021e8a71bb41ba9"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004254bce3041b00468445cb9ae597bc76c1279a8506142ce2427185b1d7f753d1c0aad94156b531a2071aa61c83ec842a3710d6c8c96766ae8b63396133e5872805e47d9ba39113e122d676d54dbb2460b59d986bdd33be346c021e8a71bb41ba9",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJUvOMEGwBGhEXLmuWXvHbBJ5qFBhQs4k\nJxhbHX91PRwKrZQVa1MaIHGqYcg+yEKjcQ1sjJZ2aui2M5YTPlhygF5H2bo5ET4S\nLWdtVNuyRgtZ2Ya90zvjRsAh6KcbtBup\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004254bce3041b00468445cb9ae597bc76c1279a8506142ce2427185b1d7f753d1c0aad94156b531a2071aa61c83ec842a3710d6c8c96766ae8b63396133e5872805e47d9ba39113e122d676d54dbb2460b59d986bdd33be346c021e8a71bb41ba9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJUvOMEGwBGhEXLmuWXvHbBJ5qFBhQs4k\nJxhbHX91PRwKrZQVa1MaIHGqYcg+yEKjcQ1sjJZ2aui2M5YTPlhygF5H2bo5ET4S\nLWdtVNuyRgtZ2Ya90zvjRsAh6KcbtBup\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 355,
+          "tcId" : 437,
           "comment" : "100-bit r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3041020d062522bbd3ecbe7c39e93e7c24023077a172dfe37a2c53f0b92ab60f0a8f085f49dbfd930719d6f9e587ea68ae57cb49cd35a88cf8c6acec02f057a3807a5b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "049129db4446c2c598c4f81070f70f66c37c39323e01418c095de9902e0e1b20f26bc3e011ba84c10626ffdce836690c9f8e4a104fec4aaa4350c238617ee50456accc49efc3b73eb9548e1600c2483f1c4bae9ddf3ff92af17afd19f86274589c",
-        "wx" : "09129db4446c2c598c4f81070f70f66c37c39323e01418c095de9902e0e1b20f26bc3e011ba84c10626ffdce836690c9f",
-        "wy" : "08e4a104fec4aaa4350c238617ee50456accc49efc3b73eb9548e1600c2483f1c4bae9ddf3ff92af17afd19f86274589c"
+        "wx" : "009129db4446c2c598c4f81070f70f66c37c39323e01418c095de9902e0e1b20f26bc3e011ba84c10626ffdce836690c9f",
+        "wy" : "008e4a104fec4aaa4350c238617ee50456accc49efc3b73eb9548e1600c2483f1c4bae9ddf3ff92af17afd19f86274589c"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200049129db4446c2c598c4f81070f70f66c37c39323e01418c095de9902e0e1b20f26bc3e011ba84c10626ffdce836690c9f8e4a104fec4aaa4350c238617ee50456accc49efc3b73eb9548e1600c2483f1c4bae9ddf3ff92af17afd19f86274589c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEkSnbREbCxZjE+BBw9w9mw3w5Mj4BQYwJ\nXemQLg4bIPJrw+ARuoTBBib/3Og2aQyfjkoQT+xKqkNQwjhhfuUEVqzMSe/Dtz65\nVI4WAMJIPxxLrp3fP/kq8Xr9GfhidFic\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200049129db4446c2c598c4f81070f70f66c37c39323e01418c095de9902e0e1b20f26bc3e011ba84c10626ffdce836690c9f8e4a104fec4aaa4350c238617ee50456accc49efc3b73eb9548e1600c2483f1c4bae9ddf3ff92af17afd19f86274589c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEkSnbREbCxZjE+BBw9w9mw3w5Mj4BQYwJ\nXemQLg4bIPJrw+ARuoTBBib/3Og2aQyfjkoQT+xKqkNQwjhhfuUEVqzMSe/Dtz65\nVI4WAMJIPxxLrp3fP/kq8Xr9GfhidFic\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 356,
+          "tcId" : 438,
           "comment" : "r and s^-1 are close to n",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100ffffffffffffffffffffffffffffffffffffffffffffffffc7634d81f4372ddf581a0db248b0a77aecec196accc528f3023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
-        "uncompressed" : "04a701a8111cdf97ced74a00a4514b2b526be8113e7df6cf7163aaee465880d26275b833b186d80f1862dc67ff768dde43e5a991f16f8f777311b17eabdc90b6ece3b5da776cfbebbc504382ca1abae1c6aa6a64d9c41110d97950514e99578ed8",
-        "wx" : "0a701a8111cdf97ced74a00a4514b2b526be8113e7df6cf7163aaee465880d26275b833b186d80f1862dc67ff768dde43",
-        "wy" : "0e5a991f16f8f777311b17eabdc90b6ece3b5da776cfbebbc504382ca1abae1c6aa6a64d9c41110d97950514e99578ed8"
+        "uncompressed" : "04a5d6896125b332992cdbd8ad948ff1242d5f13a22712715735801acbb8942547f03e3b0afaf8b82c3b5e643b5f17e40bcdfbca7338f6ab3b2e6e9061944063aff32d704cf8aaa0da261b93375a8ea7feb0490c7a1e77199f1b00273c2311c11b",
+        "wx" : "00a5d6896125b332992cdbd8ad948ff1242d5f13a22712715735801acbb8942547f03e3b0afaf8b82c3b5e643b5f17e40b",
+        "wy" : "00cdfbca7338f6ab3b2e6e9061944063aff32d704cf8aaa0da261b93375a8ea7feb0490c7a1e77199f1b00273c2311c11b"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004a701a8111cdf97ced74a00a4514b2b526be8113e7df6cf7163aaee465880d26275b833b186d80f1862dc67ff768dde43e5a991f16f8f777311b17eabdc90b6ece3b5da776cfbebbc504382ca1abae1c6aa6a64d9c41110d97950514e99578ed8",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEpwGoERzfl87XSgCkUUsrUmvoET599s9x\nY6ruRliA0mJ1uDOxhtgPGGLcZ/92jd5D5amR8W+Pd3MRsX6r3JC27OO12nds++u8\nUEOCyhq64caqamTZxBEQ2XlQUU6ZV47Y\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004a5d6896125b332992cdbd8ad948ff1242d5f13a22712715735801acbb8942547f03e3b0afaf8b82c3b5e643b5f17e40bcdfbca7338f6ab3b2e6e9061944063aff32d704cf8aaa0da261b93375a8ea7feb0490c7a1e77199f1b00273c2311c11b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEpdaJYSWzMpks29itlI/xJC1fE6InEnFX\nNYAay7iUJUfwPjsK+vi4LDteZDtfF+QLzfvKczj2qzsubpBhlEBjr/MtcEz4qqDa\nJhuTN1qOp/6wSQx6HncZnxsAJzwjEcEb\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 357,
+          "tcId" : 439,
+          "comment" : "r and s are 64-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30160209009c44febf31c3594d020900839ed28247c2b06b",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "046a50284270976040d1220218b75ced142e26e820f46c91307f05dfa4ff0972ab8099679623d7e2872d712fde8e9ebfd2b8233055606a0bd53752bcdb43306abdd67839eaaf5b41d585404d2e2b7ac1ee7cab5d4eadc9e592ba73b44095799be0",
+        "wx" : "6a50284270976040d1220218b75ced142e26e820f46c91307f05dfa4ff0972ab8099679623d7e2872d712fde8e9ebfd2",
+        "wy" : "00b8233055606a0bd53752bcdb43306abdd67839eaaf5b41d585404d2e2b7ac1ee7cab5d4eadc9e592ba73b44095799be0"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200046a50284270976040d1220218b75ced142e26e820f46c91307f05dfa4ff0972ab8099679623d7e2872d712fde8e9ebfd2b8233055606a0bd53752bcdb43306abdd67839eaaf5b41d585404d2e2b7ac1ee7cab5d4eadc9e592ba73b44095799be0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEalAoQnCXYEDRIgIYt1ztFC4m6CD0bJEw\nfwXfpP8JcquAmWeWI9fihy1xL96Onr/SuCMwVWBqC9U3UrzbQzBqvdZ4OeqvW0HV\nhUBNLit6we58q11OrcnlkrpztECVeZvg\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 440,
+          "comment" : "r and s are 100-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "301e020d09df8b682430beef6f5fd7c7d0020d0fd0a62e13778f4222a0d61c8a",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "045219117ecd2995d6b740e1b036e73415e131f816584105aebe9d17b870a8b660d64fe90446caff673fdafd54ab93086db8690fc241f3ec981e77de6761fa8a4fc3bba9b95421011eb7bd736fe1fd2b52fa892793dab7d76bdfde99e7b9882bc9",
+        "wx" : "5219117ecd2995d6b740e1b036e73415e131f816584105aebe9d17b870a8b660d64fe90446caff673fdafd54ab93086d",
+        "wy" : "00b8690fc241f3ec981e77de6761fa8a4fc3bba9b95421011eb7bd736fe1fd2b52fa892793dab7d76bdfde99e7b9882bc9"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200045219117ecd2995d6b740e1b036e73415e131f816584105aebe9d17b870a8b660d64fe90446caff673fdafd54ab93086db8690fc241f3ec981e77de6761fa8a4fc3bba9b95421011eb7bd736fe1fd2b52fa892793dab7d76bdfde99e7b9882bc9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEUhkRfs0plda3QOGwNuc0FeEx+BZYQQWu\nvp0XuHCotmDWT+kERsr/Zz/a/VSrkwhtuGkPwkHz7Jged95nYfqKT8O7qblUIQEe\nt71zb+H9K1L6iSeT2rfXa9/emee5iCvJ\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 441,
+          "comment" : "r and s are 128-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260211008a598e563a89f526c32ebec8de26367a02110084f633e2042630e99dd0f1e16f7a04bf",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04733ffd3c9ec93fd00cde0ca95a6ef8be688da4a6db9a3d2eb04626407d24edd0112cda1a3259c526cd09ee1c914810933f58096e7bfc680f0cafc632064be165c315a2fee3dbb0870898c69ad63aebb74b916aaf7cfa1432696a8d6f71eeafbe",
+        "wx" : "733ffd3c9ec93fd00cde0ca95a6ef8be688da4a6db9a3d2eb04626407d24edd0112cda1a3259c526cd09ee1c91481093",
+        "wy" : "3f58096e7bfc680f0cafc632064be165c315a2fee3dbb0870898c69ad63aebb74b916aaf7cfa1432696a8d6f71eeafbe"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004733ffd3c9ec93fd00cde0ca95a6ef8be688da4a6db9a3d2eb04626407d24edd0112cda1a3259c526cd09ee1c914810933f58096e7bfc680f0cafc632064be165c315a2fee3dbb0870898c69ad63aebb74b916aaf7cfa1432696a8d6f71eeafbe",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEcz/9PJ7JP9AM3gypWm74vmiNpKbbmj0u\nsEYmQH0k7dARLNoaMlnFJs0J7hyRSBCTP1gJbnv8aA8Mr8YyBkvhZcMVov7j27CH\nCJjGmtY667dLkWqvfPoUMmlqjW9x7q++\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 442,
+          "comment" : "r and s are 160-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302e021500aa6eeb5823f7fa31b466bb473797f0d0314c0be0021500e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04a701a8111cdf97ced74a00a4514b2b526be8113e7df6cf7163aaee465880d26275b833b186d80f1862dc67ff768dde43e5a991f16f8f777311b17eabdc90b6ece3b5da776cfbebbc504382ca1abae1c6aa6a64d9c41110d97950514e99578ed8",
+        "wx" : "00a701a8111cdf97ced74a00a4514b2b526be8113e7df6cf7163aaee465880d26275b833b186d80f1862dc67ff768dde43",
+        "wy" : "00e5a991f16f8f777311b17eabdc90b6ece3b5da776cfbebbc504382ca1abae1c6aa6a64d9c41110d97950514e99578ed8"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004a701a8111cdf97ced74a00a4514b2b526be8113e7df6cf7163aaee465880d26275b833b186d80f1862dc67ff768dde43e5a991f16f8f777311b17eabdc90b6ece3b5da776cfbebbc504382ca1abae1c6aa6a64d9c41110d97950514e99578ed8",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEpwGoERzfl87XSgCkUUsrUmvoET599s9x\nY6ruRliA0mJ1uDOxhtgPGGLcZ/92jd5D5amR8W+Pd3MRsX6r3JC27OO12nds++u8\nUEOCyhq64caqamTZxBEQ2XlQUU6ZV47Y\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 443,
           "comment" : "s == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3035023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326020101",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 358,
+          "tcId" : 444,
           "comment" : "s == 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3035023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326020100",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
+        "uncompressed" : "04e612db39a8729a85c937a41e1fcd770cdd6489e209fdda6ab0630b9c44209d6cb1702f5498aa90e05ac99925426dda327eeaf17d8574e781c091fea1e078fd17f82c2c451a6ac11a137f3a81b763a0a42c9f6905691a9c2fba28cabe670ff8d4",
+        "wx" : "00e612db39a8729a85c937a41e1fcd770cdd6489e209fdda6ab0630b9c44209d6cb1702f5498aa90e05ac99925426dda32",
+        "wy" : "7eeaf17d8574e781c091fea1e078fd17f82c2c451a6ac11a137f3a81b763a0a42c9f6905691a9c2fba28cabe670ff8d4"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004e612db39a8729a85c937a41e1fcd770cdd6489e209fdda6ab0630b9c44209d6cb1702f5498aa90e05ac99925426dda327eeaf17d8574e781c091fea1e078fd17f82c2c451a6ac11a137f3a81b763a0a42c9f6905691a9c2fba28cabe670ff8d4",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE5hLbOahymoXJN6QeH813DN1kieIJ/dpq\nsGMLnEQgnWyxcC9UmKqQ4FrJmSVCbdoyfurxfYV054HAkf6h4Hj9F/gsLEUaasEa\nE386gbdjoKQsn2kFaRqcL7ooyr5nD/jU\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 445,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec63260230427f8227a67d9422557647d27945a90ae1d2ec2931f90113cd5b407099e3d8f5a889d62069e64c0e1c4efe29690b0992",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04a90271cd61b20ccbac718c99c175f6383acf6ac89ce4cd548338346d1774ece7ad501b4af6802c08236d7be4a4ea3b374f449063c4e74600828b6f4e372633b5c5ac8493476979a9af58d4111ff2b8ac62e191e415a49d4dc209432e9f5dd507",
+        "wx" : "00a90271cd61b20ccbac718c99c175f6383acf6ac89ce4cd548338346d1774ece7ad501b4af6802c08236d7be4a4ea3b37",
+        "wy" : "4f449063c4e74600828b6f4e372633b5c5ac8493476979a9af58d4111ff2b8ac62e191e415a49d4dc209432e9f5dd507"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004a90271cd61b20ccbac718c99c175f6383acf6ac89ce4cd548338346d1774ece7ad501b4af6802c08236d7be4a4ea3b374f449063c4e74600828b6f4e372633b5c5ac8493476979a9af58d4111ff2b8ac62e191e415a49d4dc209432e9f5dd507",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqQJxzWGyDMuscYyZwXX2ODrPasic5M1U\ngzg0bRd07OetUBtK9oAsCCNte+Sk6js3T0SQY8TnRgCCi29ONyYztcWshJNHaXmp\nr1jUER/yuKxi4ZHkFaSdTcIJQy6fXdUH\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 446,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec63260230369cf68bb2919c11d0f82315e1ee68a7ee8c17858bd334bf84536b2b74756a77e4eee10ecc5a6416a8263b5429afcba4",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "048b326acd923571636a8f4202869ae942407eafc1362d06dcd1b4665b00b1f9a94a4bbd45653443a638d952d70879abbfbd8e6393772edb0d245c008c3fa8ea3af4299bd6c4b073afbac6bb43bf3332855c035492f6608a075ed567ed422582b5",
+        "wx" : "008b326acd923571636a8f4202869ae942407eafc1362d06dcd1b4665b00b1f9a94a4bbd45653443a638d952d70879abbf",
+        "wy" : "00bd8e6393772edb0d245c008c3fa8ea3af4299bd6c4b073afbac6bb43bf3332855c035492f6608a075ed567ed422582b5"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200048b326acd923571636a8f4202869ae942407eafc1362d06dcd1b4665b00b1f9a94a4bbd45653443a638d952d70879abbfbd8e6393772edb0d245c008c3fa8ea3af4299bd6c4b073afbac6bb43bf3332855c035492f6608a075ed567ed422582b5",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEizJqzZI1cWNqj0IChprpQkB+r8E2LQbc\n0bRmWwCx+alKS71FZTRDpjjZUtcIeau/vY5jk3cu2w0kXACMP6jqOvQpm9bEsHOv\nusa7Q78zMoVcA1SS9mCKB17VZ+1CJYK1\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 447,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec632602302111832a45fc5967f7bf78ccdfe98d4e707484aad43f67cf5ac8aa2afbde0d1d8b7fe5cfc5012feb033dffdec623dfbf",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04a1e8b1972502dac2049f0e319b6185d799d08f1e806c162e3fd135c12177008a1aeb9fc5fb81c0ec71dbbfed300a27dee29a49d89b68642e11b83c58a521b761b44f1e41c557919a528e2866fa6a7019365729a8418824592859e7c64e454fc2",
+        "wx" : "00a1e8b1972502dac2049f0e319b6185d799d08f1e806c162e3fd135c12177008a1aeb9fc5fb81c0ec71dbbfed300a27de",
+        "wy" : "00e29a49d89b68642e11b83c58a521b761b44f1e41c557919a528e2866fa6a7019365729a8418824592859e7c64e454fc2"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004a1e8b1972502dac2049f0e319b6185d799d08f1e806c162e3fd135c12177008a1aeb9fc5fb81c0ec71dbbfed300a27dee29a49d89b68642e11b83c58a521b761b44f1e41c557919a528e2866fa6a7019365729a8418824592859e7c64e454fc2",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEoeixlyUC2sIEnw4xm2GF15nQjx6AbBYu\nP9E1wSF3AIoa65/F+4HA7HHbv+0wCife4ppJ2JtoZC4RuDxYpSG3YbRPHkHFV5Ga\nUo4oZvpqcBk2VymoQYgkWShZ58ZORU/C\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 448,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023020cd002ab7dca06b798fecef3f06a222c2d2a65e9ec92f74659a8d82fe7d75e9af739f0b532e17d6c5f622c4b591442b",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04870649ff8d3a7a14f6952be825beb0711483bffdceed1f556be0b29c4e62d73238f19507038687a69481b7ae37c4c7541de0fbcd8cb50014d338d1c83cb4d2f901450af7f435fa6790bbcb66ea87db25fb8ba878c00bb88e20c379576b6d3e8a",
+        "wx" : "00870649ff8d3a7a14f6952be825beb0711483bffdceed1f556be0b29c4e62d73238f19507038687a69481b7ae37c4c754",
+        "wy" : "1de0fbcd8cb50014d338d1c83cb4d2f901450af7f435fa6790bbcb66ea87db25fb8ba878c00bb88e20c379576b6d3e8a"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004870649ff8d3a7a14f6952be825beb0711483bffdceed1f556be0b29c4e62d73238f19507038687a69481b7ae37c4c7541de0fbcd8cb50014d338d1c83cb4d2f901450af7f435fa6790bbcb66ea87db25fb8ba878c00bb88e20c379576b6d3e8a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEhwZJ/406ehT2lSvoJb6wcRSDv/3O7R9V\na+CynE5i1zI48ZUHA4aHppSBt643xMdUHeD7zYy1ABTTONHIPLTS+QFFCvf0Nfpn\nkLvLZuqH2yX7i6h4wAu4jiDDeVdrbT6K\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 449,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec632602303276fe55314e426a8ed83c4c38dc27c8fe8cbba0b39bad7cfc35e963adf10ab37251ea6829b8d255a77dd0b655cf9ff8",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04dee7e74e4eb4b7b064ce3ee571fe8c5b79c12234c63193e8efe4466a07c601dbd260d33d3ed36adde0e8e33aa98f1ae9c4817f36e6b2c98e6807c37d93f4903f65283ef372da1a8cb837d2727e6476513b36e1b2c1aae9a6af4d05666bdbb97a",
+        "wx" : "00dee7e74e4eb4b7b064ce3ee571fe8c5b79c12234c63193e8efe4466a07c601dbd260d33d3ed36adde0e8e33aa98f1ae9",
+        "wy" : "00c4817f36e6b2c98e6807c37d93f4903f65283ef372da1a8cb837d2727e6476513b36e1b2c1aae9a6af4d05666bdbb97a"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004dee7e74e4eb4b7b064ce3ee571fe8c5b79c12234c63193e8efe4466a07c601dbd260d33d3ed36adde0e8e33aa98f1ae9c4817f36e6b2c98e6807c37d93f4903f65283ef372da1a8cb837d2727e6476513b36e1b2c1aae9a6af4d05666bdbb97a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE3ufnTk60t7Bkzj7lcf6MW3nBIjTGMZPo\n7+RGagfGAdvSYNM9PtNq3eDo4zqpjxrpxIF/NuayyY5oB8N9k/SQP2UoPvNy2hqM\nuDfScn5kdlE7NuGywarppq9NBWZr27l6\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 450,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec632602301a80b4a3d6c88775821e26784463080eb7de510762ab0d98223e532364c7089b07af73746ae4cf076c5277dcc80cf8c2",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "049a2141e20e0f5f4a2ac77c20115c29d39fe510acceadcd8750bbfae9f9ad68c8671b6505d2baf770d1e4fd5f314d26fd27477d03efa31a797e42835f867b89986523ca02063fb1d8854f57dbecb69352834caaeb272bd7d59a42bf08e33998ce",
+        "wx" : "009a2141e20e0f5f4a2ac77c20115c29d39fe510acceadcd8750bbfae9f9ad68c8671b6505d2baf770d1e4fd5f314d26fd",
+        "wy" : "27477d03efa31a797e42835f867b89986523ca02063fb1d8854f57dbecb69352834caaeb272bd7d59a42bf08e33998ce"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200049a2141e20e0f5f4a2ac77c20115c29d39fe510acceadcd8750bbfae9f9ad68c8671b6505d2baf770d1e4fd5f314d26fd27477d03efa31a797e42835f867b89986523ca02063fb1d8854f57dbecb69352834caaeb272bd7d59a42bf08e33998ce",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEmiFB4g4PX0oqx3wgEVwp05/lEKzOrc2H\nULv66fmtaMhnG2UF0rr3cNHk/V8xTSb9J0d9A++jGnl+QoNfhnuJmGUjygIGP7HY\nhU9X2+y2k1KDTKrrJyvX1ZpCvwjjOZjO\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 451,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023074e780e38b3a7cd6cfe17d5c9ac615895bd97dd4076b5f8218ae758b83d195fba64eb9aead39a790ca0f8b8387376265",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04e7fbcf59900e281e939172f1ea7a4ac9e5c6bb9f30f15f8379b15d739b302293ba8ec4ceec1a6ddf6605bcb25f2a8e2ec06626028702ee8f45fedb501cbd47e16235e1e4386eadea5661ce71cd200876e7d0a467ce6104eaf8e526ad67a41d51",
+        "wx" : "00e7fbcf59900e281e939172f1ea7a4ac9e5c6bb9f30f15f8379b15d739b302293ba8ec4ceec1a6ddf6605bcb25f2a8e2e",
+        "wy" : "00c06626028702ee8f45fedb501cbd47e16235e1e4386eadea5661ce71cd200876e7d0a467ce6104eaf8e526ad67a41d51"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004e7fbcf59900e281e939172f1ea7a4ac9e5c6bb9f30f15f8379b15d739b302293ba8ec4ceec1a6ddf6605bcb25f2a8e2ec06626028702ee8f45fedb501cbd47e16235e1e4386eadea5661ce71cd200876e7d0a467ce6104eaf8e526ad67a41d51",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE5/vPWZAOKB6TkXLx6npKyeXGu58w8V+D\nebFdc5swIpO6jsTO7Bpt32YFvLJfKo4uwGYmAocC7o9F/ttQHL1H4WI14eQ4bq3q\nVmHOcc0gCHbn0KRnzmEE6vjlJq1npB1R\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 452,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec632602306ee5f8daae12c862e1f7f8b59294ac90448c4461e29b36ed623a719dd69bb17b3a4b7c29b9eb5c39ca6168bf6b597c6a",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "047134832af3c609b17b40641039152600d9b318b3a41578f26106a4e97443b0d204bca2dff9aa4ca0d9b86a6192fc2c912407202d2a51192674661b402d8957197c439e65b2b20b6631f5b771696da43099c29a1002b71bf99437eb5413fd9d50",
+        "wx" : "7134832af3c609b17b40641039152600d9b318b3a41578f26106a4e97443b0d204bca2dff9aa4ca0d9b86a6192fc2c91",
+        "wy" : "2407202d2a51192674661b402d8957197c439e65b2b20b6631f5b771696da43099c29a1002b71bf99437eb5413fd9d50"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200047134832af3c609b17b40641039152600d9b318b3a41578f26106a4e97443b0d204bca2dff9aa4ca0d9b86a6192fc2c912407202d2a51192674661b402d8957197c439e65b2b20b6631f5b771696da43099c29a1002b71bf99437eb5413fd9d50",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEcTSDKvPGCbF7QGQQORUmANmzGLOkFXjy\nYQak6XRDsNIEvKLf+apMoNm4amGS/CyRJAcgLSpRGSZ0ZhtALYlXGXxDnmWysgtm\nMfW3cWltpDCZwpoQArcb+ZQ361QT/Z1Q\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 453,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec632602305426ca20a25b0cfb1ef230c62f91e98005f346e229233f1803e8944bf421fef150a4a109e48cefaa4ea23eea627fca41",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04d3bc62d583ad855a35ae39f4116ba97ab2f25157c55075d177a083912fa749500e9ba7b2801fa8529817c66d9ae8bc334f2db63f152c5795a2aa623a999aed8628ea305161b90bcf0c43c1757534c6472f683c9ec310b3e15c1beb8d4937fb84",
+        "wx" : "00d3bc62d583ad855a35ae39f4116ba97ab2f25157c55075d177a083912fa749500e9ba7b2801fa8529817c66d9ae8bc33",
+        "wy" : "4f2db63f152c5795a2aa623a999aed8628ea305161b90bcf0c43c1757534c6472f683c9ec310b3e15c1beb8d4937fb84"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004d3bc62d583ad855a35ae39f4116ba97ab2f25157c55075d177a083912fa749500e9ba7b2801fa8529817c66d9ae8bc334f2db63f152c5795a2aa623a999aed8628ea305161b90bcf0c43c1757534c6472f683c9ec310b3e15c1beb8d4937fb84",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE07xi1YOthVo1rjn0EWuperLyUVfFUHXR\nd6CDkS+nSVAOm6eygB+oUpgXxm2a6LwzTy22PxUsV5WiqmI6mZrthijqMFFhuQvP\nDEPBdXU0xkcvaDyewxCz4Vwb641JN/uE\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 454,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023039fd1a0ae3964735554c61daf085c66bcc2e9e5350131086023aa99549fc5f9057c848e75a1b8e58069fe0b9b23fa3c9",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "0426bf1d7f97f412d6e940565a881eddc1b026569265f02cd415e82fbd4190da9a86c79f9ef221f1f95368e57ab0ecd2b376e2ffd121f572c21fc83261361aaa716dfe9b6f1fb48fd7fbbde14d284fcb723b3f6252bf34a3c92171e86ab0c24948",
+        "wx" : "26bf1d7f97f412d6e940565a881eddc1b026569265f02cd415e82fbd4190da9a86c79f9ef221f1f95368e57ab0ecd2b3",
+        "wy" : "76e2ffd121f572c21fc83261361aaa716dfe9b6f1fb48fd7fbbde14d284fcb723b3f6252bf34a3c92171e86ab0c24948"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000426bf1d7f97f412d6e940565a881eddc1b026569265f02cd415e82fbd4190da9a86c79f9ef221f1f95368e57ab0ecd2b376e2ffd121f572c21fc83261361aaa716dfe9b6f1fb48fd7fbbde14d284fcb723b3f6252bf34a3c92171e86ab0c24948",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEJr8df5f0EtbpQFZaiB7dwbAmVpJl8CzU\nFegvvUGQ2pqGx5+e8iHx+VNo5Xqw7NKzduL/0SH1csIfyDJhNhqqcW3+m28ftI/X\n+73hTShPy3I7P2JSvzSjySFx6GqwwklI\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 455,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec63260230707a37cfb7367c2e551ea1f0caeac6c0fdd2b562e1bd8f1c7c51a5dd78f21da8cb179bd832cac3d3aee21fda54729e66",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04f31fdd34ed4e15da354326e13ae48005d0166b1a3db26cd6b9d62c4d7db29c450091d15093828dc4543ff578ca198c841f5f7ceda1a4a3b8dbbc1bc4a60d98d748418c7bfee7cd418243ef5d8c346b0f825d2b1c06084d67b7471167921dec05",
+        "wx" : "00f31fdd34ed4e15da354326e13ae48005d0166b1a3db26cd6b9d62c4d7db29c450091d15093828dc4543ff578ca198c84",
+        "wy" : "1f5f7ceda1a4a3b8dbbc1bc4a60d98d748418c7bfee7cd418243ef5d8c346b0f825d2b1c06084d67b7471167921dec05"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004f31fdd34ed4e15da354326e13ae48005d0166b1a3db26cd6b9d62c4d7db29c450091d15093828dc4543ff578ca198c841f5f7ceda1a4a3b8dbbc1bc4a60d98d748418c7bfee7cd418243ef5d8c346b0f825d2b1c06084d67b7471167921dec05",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8x/dNO1OFdo1QybhOuSABdAWaxo9smzW\nudYsTX2ynEUAkdFQk4KNxFQ/9XjKGYyEH1987aGko7jbvBvEpg2Y10hBjHv+581B\ngkPvXYw0aw+CXSscBghNZ7dHEWeSHewF\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 456,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023015c99e2ae11f429e74fe2e758bc53ffea26eb6368dd60d10daf860f9c79fa8cc6cb98fee9b87dd38353e970539a50a9e",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "044bb7245b1960c5ef4d9670242b6e0478162644cc3416543b9dd79c04e57a90f981aa48bb110edd54c657056f7fd9cd4661524656f1aa505d7f53497165cd63e7ab8727760955f87e66fa627543d156423577109e8e2aace4bd57ad87efd51946",
+        "wx" : "4bb7245b1960c5ef4d9670242b6e0478162644cc3416543b9dd79c04e57a90f981aa48bb110edd54c657056f7fd9cd46",
+        "wy" : "61524656f1aa505d7f53497165cd63e7ab8727760955f87e66fa627543d156423577109e8e2aace4bd57ad87efd51946"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200044bb7245b1960c5ef4d9670242b6e0478162644cc3416543b9dd79c04e57a90f981aa48bb110edd54c657056f7fd9cd4661524656f1aa505d7f53497165cd63e7ab8727760955f87e66fa627543d156423577109e8e2aace4bd57ad87efd51946",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAES7ckWxlgxe9NlnAkK24EeBYmRMw0FlQ7\nndecBOV6kPmBqki7EQ7dVMZXBW9/2c1GYVJGVvGqUF1/U0lxZc1j56uHJ3YJVfh+\nZvpidUPRVkI1dxCejiqs5L1XrYfv1RlG\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 457,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec63260230148c732596feaabb01be1be3a220740e84bbfabe6d82ad0db1c396fa047603beeb95a1cd37fc708a9451d3cc29a45b32",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "049ed91f3bd77cafc98d2152f5a10e947af87c4863359877e178ec977050f5e289322469d439506eed00bad84eaf79f03c4956440e4f468ccd298dee1b41aec2829da1b33f33e39624e659b6a831b06593e4365707b8d66fecfad0fc7beab3b15d",
+        "wx" : "009ed91f3bd77cafc98d2152f5a10e947af87c4863359877e178ec977050f5e289322469d439506eed00bad84eaf79f03c",
+        "wy" : "4956440e4f468ccd298dee1b41aec2829da1b33f33e39624e659b6a831b06593e4365707b8d66fecfad0fc7beab3b15d"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200049ed91f3bd77cafc98d2152f5a10e947af87c4863359877e178ec977050f5e289322469d439506eed00bad84eaf79f03c4956440e4f468ccd298dee1b41aec2829da1b33f33e39624e659b6a831b06593e4365707b8d66fecfad0fc7beab3b15d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEntkfO9d8r8mNIVL1oQ6Uevh8SGM1mHfh\neOyXcFD14okyJGnUOVBu7QC62E6vefA8SVZEDk9GjM0pje4bQa7Cgp2hsz8z45Yk\n5lm2qDGwZZPkNlcHuNZv7PrQ/Hvqs7Fd\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 458,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec632602306b3cc62a449ae5ef68bec8672f186d5418cc18d039af91b45f8a8fae4210ef06d3f0d226f89945b314d9df72e01a02bb",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "04ea03e9823cc5e5a4891651b2c56fcd7e2e357e21835f559f7a8800dee1cf6b70a7051193b4c00b948444a3f127bd4a3ff7bfd49aa2fa48827364851480d22c92070bed72f1aa9a3d12313b6ec9ba8f028f660e10150e7abb0bdb32fec5f3e4d0",
+        "wx" : "00ea03e9823cc5e5a4891651b2c56fcd7e2e357e21835f559f7a8800dee1cf6b70a7051193b4c00b948444a3f127bd4a3f",
+        "wy" : "00f7bfd49aa2fa48827364851480d22c92070bed72f1aa9a3d12313b6ec9ba8f028f660e10150e7abb0bdb32fec5f3e4d0"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004ea03e9823cc5e5a4891651b2c56fcd7e2e357e21835f559f7a8800dee1cf6b70a7051193b4c00b948444a3f127bd4a3ff7bfd49aa2fa48827364851480d22c92070bed72f1aa9a3d12313b6ec9ba8f028f660e10150e7abb0bdb32fec5f3e4d0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE6gPpgjzF5aSJFlGyxW/Nfi41fiGDX1Wf\neogA3uHPa3CnBRGTtMALlIREo/EnvUo/97/UmqL6SIJzZIUUgNIskgcL7XLxqpo9\nEjE7bsm6jwKPZg4QFQ56uwvbMv7F8+TQ\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 459,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec632602307db7901f053b9cefacfda88dd7791c01fd569ed9a5243385eccae12ba992af55832a2e5dc8065e018399a70730035bd8",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
         "uncompressed" : "04b6815ba05413bcf34f4c0704af590c1998d7fcd169541e1efe1567ca1dd71a22e35ac838b20c75281582044a57b58f456cdceb10612062779abadd8742c6e93ed74adf306f3b3a0f96b70dd1134b7558b64b55b200c5732c50f05aa032ae7c00",
-        "wx" : "0b6815ba05413bcf34f4c0704af590c1998d7fcd169541e1efe1567ca1dd71a22e35ac838b20c75281582044a57b58f45",
+        "wx" : "00b6815ba05413bcf34f4c0704af590c1998d7fcd169541e1efe1567ca1dd71a22e35ac838b20c75281582044a57b58f45",
         "wy" : "6cdceb10612062779abadd8742c6e93ed74adf306f3b3a0f96b70dd1134b7558b64b55b200c5732c50f05aa032ae7c00"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004b6815ba05413bcf34f4c0704af590c1998d7fcd169541e1efe1567ca1dd71a22e35ac838b20c75281582044a57b58f456cdceb10612062779abadd8742c6e93ed74adf306f3b3a0f96b70dd1134b7558b64b55b200c5732c50f05aa032ae7c00",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEtoFboFQTvPNPTAcEr1kMGZjX/NFpVB4e\n/hVnyh3XGiLjWsg4sgx1KBWCBEpXtY9FbNzrEGEgYneaut2HQsbpPtdK3zBvOzoP\nlrcN0RNLdVi2S1WyAMVzLFDwWqAyrnwA\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004b6815ba05413bcf34f4c0704af590c1998d7fcd169541e1efe1567ca1dd71a22e35ac838b20c75281582044a57b58f456cdceb10612062779abadd8742c6e93ed74adf306f3b3a0f96b70dd1134b7558b64b55b200c5732c50f05aa032ae7c00",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEtoFboFQTvPNPTAcEr1kMGZjX/NFpVB4e\n/hVnyh3XGiLjWsg4sgx1KBWCBEpXtY9FbNzrEGEgYneaut2HQsbpPtdK3zBvOzoP\nlrcN0RNLdVi2S1WyAMVzLFDwWqAyrnwA\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 359,
+          "tcId" : 460,
           "comment" : "point at infinity during verify",
+          "flags" : [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307fffffffffffffffffffffffffffffffffffffffffffffffe3b1a6c0fa1b96efac0d06d9245853bd76760cb5666294b9023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
+        "uncompressed" : "041af19841ff3df8bdc4f8cce957e0dab763efe413929b279f1d46dde1c6f2bbc55af1bb1d8011fc587a4d599a4ae7cd8d5f663860c43c88e08399f00ef6641123787956a2b7012883b5ff7c46bd156d96d3c02a63ef86e060a2a0fa5b80d0c0e5",
+        "wx" : "1af19841ff3df8bdc4f8cce957e0dab763efe413929b279f1d46dde1c6f2bbc55af1bb1d8011fc587a4d599a4ae7cd8d",
+        "wy" : "5f663860c43c88e08399f00ef6641123787956a2b7012883b5ff7c46bd156d96d3c02a63ef86e060a2a0fa5b80d0c0e5"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200041af19841ff3df8bdc4f8cce957e0dab763efe413929b279f1d46dde1c6f2bbc55af1bb1d8011fc587a4d599a4ae7cd8d5f663860c43c88e08399f00ef6641123787956a2b7012883b5ff7c46bd156d96d3c02a63ef86e060a2a0fa5b80d0c0e5",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEGvGYQf89+L3E+MzpV+Dat2Pv5BOSmyef\nHUbd4cbyu8Va8bsdgBH8WHpNWZpK582NX2Y4YMQ8iOCDmfAO9mQRI3h5VqK3ASiD\ntf98Rr0VbZbTwCpj74bgYKKg+luA0MDl\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 461,
+          "comment" : "edge case for signature malleability",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306402307fffffffffffffffffffffffffffffffffffffffffffffffe3b1a6c0fa1b96efac0d06d9245853bd76760cb5666294b902307fffffffffffffffffffffffffffffffffffffffffffffffe3b1a6c0fa1b96efac0d06d9245853bd76760cb5666294b9",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
+        "uncompressed" : "046836084fddfcfd527cb3847fb8b911c0fa002537fa460ca8f5d40f025603a4d89aa6ec640fde0cc4b31c46239a1d0bb76beed7019892e87287e23f0d35093ab14c4d41c0efe8463ede3494230a384eb1bc410de918c5484a25640741acb8cc0d",
+        "wx" : "6836084fddfcfd527cb3847fb8b911c0fa002537fa460ca8f5d40f025603a4d89aa6ec640fde0cc4b31c46239a1d0bb7",
+        "wy" : "6beed7019892e87287e23f0d35093ab14c4d41c0efe8463ede3494230a384eb1bc410de918c5484a25640741acb8cc0d"
+      },
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200046836084fddfcfd527cb3847fb8b911c0fa002537fa460ca8f5d40f025603a4d89aa6ec640fde0cc4b31c46239a1d0bb76beed7019892e87287e23f0d35093ab14c4d41c0efe8463ede3494230a384eb1bc410de918c5484a25640741acb8cc0d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEaDYIT938/VJ8s4R/uLkRwPoAJTf6Rgyo\n9dQPAlYDpNiapuxkD94MxLMcRiOaHQu3a+7XAZiS6HKH4j8NNQk6sUxNQcDv6EY+\n3jSUIwo4TrG8QQ3pGMVISiVkB0GsuMwN\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 462,
+          "comment" : "edge case for signature malleability",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "306402307fffffffffffffffffffffffffffffffffffffffffffffffe3b1a6c0fa1b96efac0d06d9245853bd76760cb5666294b902307fffffffffffffffffffffffffffffffffffffffffffffffe3b1a6c0fa1b96efac0d06d9245853bd76760cb5666294ba",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp384r1",
+        "keySize" : 384,
         "uncompressed" : "04b4b2d5a8b50ffabd34748e94498c1d4728d084f943fbddd4b3b6ee16eaa4da91613a82c98017132c94cd6fe4b87232f16d612228ed5d7d08bf0c8699677e3b8f3e718073b945a6c108d97a3b1433c79052b2655a18a3b2e621baa88198cb5f3c",
-        "wx" : "0b4b2d5a8b50ffabd34748e94498c1d4728d084f943fbddd4b3b6ee16eaa4da91613a82c98017132c94cd6fe4b87232f1",
+        "wx" : "00b4b2d5a8b50ffabd34748e94498c1d4728d084f943fbddd4b3b6ee16eaa4da91613a82c98017132c94cd6fe4b87232f1",
         "wy" : "6d612228ed5d7d08bf0c8699677e3b8f3e718073b945a6c108d97a3b1433c79052b2655a18a3b2e621baa88198cb5f3c"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004b4b2d5a8b50ffabd34748e94498c1d4728d084f943fbddd4b3b6ee16eaa4da91613a82c98017132c94cd6fe4b87232f16d612228ed5d7d08bf0c8699677e3b8f3e718073b945a6c108d97a3b1433c79052b2655a18a3b2e621baa88198cb5f3c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEtLLVqLUP+r00dI6USYwdRyjQhPlD+93U\ns7buFuqk2pFhOoLJgBcTLJTNb+S4cjLxbWEiKO1dfQi/DIaZZ347jz5xgHO5RabB\nCNl6OxQzx5BSsmVaGKOy5iG6qIGYy188\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004b4b2d5a8b50ffabd34748e94498c1d4728d084f943fbddd4b3b6ee16eaa4da91613a82c98017132c94cd6fe4b87232f16d612228ed5d7d08bf0c8699677e3b8f3e718073b945a6c108d97a3b1433c79052b2655a18a3b2e621baa88198cb5f3c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEtLLVqLUP+r00dI6USYwdRyjQhPlD+93U\ns7buFuqk2pFhOoLJgBcTLJTNb+S4cjLxbWEiKO1dfQi/DIaZZ347jz5xgHO5RabB\nCNl6OxQzx5BSsmVaGKOy5iG6qIGYy188\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 360,
+          "tcId" : 463,
           "comment" : "u1 == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b023210281757b30e19218a37cbd612086fbc158ca",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04842b3d89e54d9a4b5694d9251bba20ae4854c510dc0b6ef7033e4045ba4e64b6ddcd36299aac554dbac6db3e27c98123868258190297e1d6bae648a6dee2285886233afd1c3d6f196ad1db14262a579d74cf7855fffc65f5abd242b135ae87df",
-        "wx" : "0842b3d89e54d9a4b5694d9251bba20ae4854c510dc0b6ef7033e4045ba4e64b6ddcd36299aac554dbac6db3e27c98123",
-        "wy" : "0868258190297e1d6bae648a6dee2285886233afd1c3d6f196ad1db14262a579d74cf7855fffc65f5abd242b135ae87df"
+        "wx" : "00842b3d89e54d9a4b5694d9251bba20ae4854c510dc0b6ef7033e4045ba4e64b6ddcd36299aac554dbac6db3e27c98123",
+        "wy" : "00868258190297e1d6bae648a6dee2285886233afd1c3d6f196ad1db14262a579d74cf7855fffc65f5abd242b135ae87df"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004842b3d89e54d9a4b5694d9251bba20ae4854c510dc0b6ef7033e4045ba4e64b6ddcd36299aac554dbac6db3e27c98123868258190297e1d6bae648a6dee2285886233afd1c3d6f196ad1db14262a579d74cf7855fffc65f5abd242b135ae87df",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEhCs9ieVNmktWlNklG7ogrkhUxRDcC273\nAz5ARbpOZLbdzTYpmqxVTbrG2z4nyYEjhoJYGQKX4da65kim3uIoWIYjOv0cPW8Z\natHbFCYqV510z3hV//xl9avSQrE1roff\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004842b3d89e54d9a4b5694d9251bba20ae4854c510dc0b6ef7033e4045ba4e64b6ddcd36299aac554dbac6db3e27c98123868258190297e1d6bae648a6dee2285886233afd1c3d6f196ad1db14262a579d74cf7855fffc65f5abd242b135ae87df",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEhCs9ieVNmktWlNklG7ogrkhUxRDcC273\nAz5ARbpOZLbdzTYpmqxVTbrG2z4nyYEjhoJYGQKX4da65kim3uIoWIYjOv0cPW8Z\natHbFCYqV510z3hV//xl9avSQrE1roff\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 361,
+          "tcId" : 464,
           "comment" : "u1 == n - 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023100bc07ff041506dc73a75086a43252fb43b6327af3c6b2cc7d322ff6d1d1162b5de29edcd0b69803fe2f8af8e3d103d0a9",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "049ab73dcfffc820e739a3ed9c316c6f15d27a032f8aa59325f7842cf4a34198ac6ff09eb1a311ce226bf1abb49d8085110135f4b0c2b6b195da9bbe1993e985b8607664f1a4b3d499ea1a112b6afc7e6b88357c9348b614ddfdc846a3f38bbdca",
-        "wx" : "09ab73dcfffc820e739a3ed9c316c6f15d27a032f8aa59325f7842cf4a34198ac6ff09eb1a311ce226bf1abb49d808511",
-        "wy" : "135f4b0c2b6b195da9bbe1993e985b8607664f1a4b3d499ea1a112b6afc7e6b88357c9348b614ddfdc846a3f38bbdca"
+        "wx" : "009ab73dcfffc820e739a3ed9c316c6f15d27a032f8aa59325f7842cf4a34198ac6ff09eb1a311ce226bf1abb49d808511",
+        "wy" : "0135f4b0c2b6b195da9bbe1993e985b8607664f1a4b3d499ea1a112b6afc7e6b88357c9348b614ddfdc846a3f38bbdca"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200049ab73dcfffc820e739a3ed9c316c6f15d27a032f8aa59325f7842cf4a34198ac6ff09eb1a311ce226bf1abb49d8085110135f4b0c2b6b195da9bbe1993e985b8607664f1a4b3d499ea1a112b6afc7e6b88357c9348b614ddfdc846a3f38bbdca",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEmrc9z//IIOc5o+2cMWxvFdJ6Ay+KpZMl\n94Qs9KNBmKxv8J6xoxHOImvxq7SdgIURATX0sMK2sZXam74Zk+mFuGB2ZPGks9SZ\n6hoRK2r8fmuINXyTSLYU3f3IRqPzi73K\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200049ab73dcfffc820e739a3ed9c316c6f15d27a032f8aa59325f7842cf4a34198ac6ff09eb1a311ce226bf1abb49d8085110135f4b0c2b6b195da9bbe1993e985b8607664f1a4b3d499ea1a112b6afc7e6b88357c9348b614ddfdc846a3f38bbdca",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEmrc9z//IIOc5o+2cMWxvFdJ6Ay+KpZMl\n94Qs9KNBmKxv8J6xoxHOImvxq7SdgIURATX0sMK2sZXam74Zk+mFuGB2ZPGks9SZ\n6hoRK2r8fmuINXyTSLYU3f3IRqPzi73K\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 362,
+          "tcId" : 465,
           "comment" : "u2 == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0428771b137fb7d74c0ed0290416f47c8118997923c7b3b717fbbd5308a4bb0e494714bd3f1ff5e9e368887377284272ebf92e5df476a2fa0906ce4fad121c641abb539ab4ef270cd8f0497cc3e6e05b18561b730670f010741238a5d07b077045",
         "wx" : "28771b137fb7d74c0ed0290416f47c8118997923c7b3b717fbbd5308a4bb0e494714bd3f1ff5e9e368887377284272eb",
-        "wy" : "0f92e5df476a2fa0906ce4fad121c641abb539ab4ef270cd8f0497cc3e6e05b18561b730670f010741238a5d07b077045"
+        "wy" : "00f92e5df476a2fa0906ce4fad121c641abb539ab4ef270cd8f0497cc3e6e05b18561b730670f010741238a5d07b077045"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000428771b137fb7d74c0ed0290416f47c8118997923c7b3b717fbbd5308a4bb0e494714bd3f1ff5e9e368887377284272ebf92e5df476a2fa0906ce4fad121c641abb539ab4ef270cd8f0497cc3e6e05b18561b730670f010741238a5d07b077045",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEKHcbE3+310wO0CkEFvR8gRiZeSPHs7cX\n+71TCKS7DklHFL0/H/Xp42iIc3coQnLr+S5d9Hai+gkGzk+tEhxkGrtTmrTvJwzY\n8El8w+bgWxhWG3MGcPAQdBI4pdB7B3BF\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000428771b137fb7d74c0ed0290416f47c8118997923c7b3b717fbbd5308a4bb0e494714bd3f1ff5e9e368887377284272ebf92e5df476a2fa0906ce4fad121c641abb539ab4ef270cd8f0497cc3e6e05b18561b730670f010741238a5d07b077045",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEKHcbE3+310wO0CkEFvR8gRiZeSPHs7cX\n+71TCKS7DklHFL0/H/Xp42iIc3coQnLr+S5d9Hai+gkGzk+tEhxkGrtTmrTvJwzY\n8El8w+bgWxhWG3MGcPAQdBI4pdB7B3BF\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 363,
+          "tcId" : 466,
           "comment" : "u2 == n - 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023100aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa84ecde56a2cf73ea3abc092185cb1a51f34810f1ddd8c64d",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "049d1baad217829d5f2d7db5bd085e9126232e8c49c58707cb153db1d1e20a109c90f7bcbae4f2c74d6595207cb0e5dd271eea30752a1425905d0811d0f42019e5088142b41945bee03948f206f2e7c3c1081ba9a297180e36b247ee9e70832035",
-        "wx" : "09d1baad217829d5f2d7db5bd085e9126232e8c49c58707cb153db1d1e20a109c90f7bcbae4f2c74d6595207cb0e5dd27",
+        "wx" : "009d1baad217829d5f2d7db5bd085e9126232e8c49c58707cb153db1d1e20a109c90f7bcbae4f2c74d6595207cb0e5dd27",
         "wy" : "1eea30752a1425905d0811d0f42019e5088142b41945bee03948f206f2e7c3c1081ba9a297180e36b247ee9e70832035"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200049d1baad217829d5f2d7db5bd085e9126232e8c49c58707cb153db1d1e20a109c90f7bcbae4f2c74d6595207cb0e5dd271eea30752a1425905d0811d0f42019e5088142b41945bee03948f206f2e7c3c1081ba9a297180e36b247ee9e70832035",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEnRuq0heCnV8tfbW9CF6RJiMujEnFhwfL\nFT2x0eIKEJyQ97y65PLHTWWVIHyw5d0nHuowdSoUJZBdCBHQ9CAZ5QiBQrQZRb7g\nOUjyBvLnw8EIG6milxgONrJH7p5wgyA1\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200049d1baad217829d5f2d7db5bd085e9126232e8c49c58707cb153db1d1e20a109c90f7bcbae4f2c74d6595207cb0e5dd271eea30752a1425905d0811d0f42019e5088142b41945bee03948f206f2e7c3c1081ba9a297180e36b247ee9e70832035",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEnRuq0heCnV8tfbW9CF6RJiMujEnFhwfL\nFT2x0eIKEJyQ97y65PLHTWWVIHyw5d0nHuowdSoUJZBdCBHQ9CAZ5QiBQrQZRb7g\nOUjyBvLnw8EIG6milxgONrJH7p5wgyA1\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 364,
+          "tcId" : 467,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100c152aafea3a8612ec83a7dc9448f01941899d7041319bbd60bfdfb3c03da74c00c8fc4176128a6263268711edc6e8e90",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "048e39e1e44f782b810ea93037c344371c4fb141c8bf196ea618f3a176547139a6d02121d2794cbe6481061694db579315c3184e8cd9b6c16b37699633d87f5600654b44cbcb5ab50ba872dfa001769eb765b2d1902e01d2e8af4e1fd6e9c0f30f",
-        "wx" : "08e39e1e44f782b810ea93037c344371c4fb141c8bf196ea618f3a176547139a6d02121d2794cbe6481061694db579315",
-        "wy" : "0c3184e8cd9b6c16b37699633d87f5600654b44cbcb5ab50ba872dfa001769eb765b2d1902e01d2e8af4e1fd6e9c0f30f"
+        "wx" : "008e39e1e44f782b810ea93037c344371c4fb141c8bf196ea618f3a176547139a6d02121d2794cbe6481061694db579315",
+        "wy" : "00c3184e8cd9b6c16b37699633d87f5600654b44cbcb5ab50ba872dfa001769eb765b2d1902e01d2e8af4e1fd6e9c0f30f"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200048e39e1e44f782b810ea93037c344371c4fb141c8bf196ea618f3a176547139a6d02121d2794cbe6481061694db579315c3184e8cd9b6c16b37699633d87f5600654b44cbcb5ab50ba872dfa001769eb765b2d1902e01d2e8af4e1fd6e9c0f30f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEjjnh5E94K4EOqTA3w0Q3HE+xQci/GW6m\nGPOhdlRxOabQISHSeUy+ZIEGFpTbV5MVwxhOjNm2wWs3aZYz2H9WAGVLRMvLWrUL\nqHLfoAF2nrdlstGQLgHS6K9OH9bpwPMP\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200048e39e1e44f782b810ea93037c344371c4fb141c8bf196ea618f3a176547139a6d02121d2794cbe6481061694db579315c3184e8cd9b6c16b37699633d87f5600654b44cbcb5ab50ba872dfa001769eb765b2d1902e01d2e8af4e1fd6e9c0f30f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEjjnh5E94K4EOqTA3w0Q3HE+xQci/GW6m\nGPOhdlRxOabQISHSeUy+ZIEGFpTbV5MVwxhOjNm2wWs3aZYz2H9WAGVLRMvLWrUL\nqHLfoAF2nrdlstGQLgHS6K9OH9bpwPMP\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 365,
+          "tcId" : 468,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02304764eeac3e7a08daacfad7d1e1e3696042164b06f77bd78c3213ddea6f9fd449a34c97b9e560a6bf7195da41333c7565",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04b96fca0e3f6ebf7326f0a8ce8bdf226a2560c22526bf154f7b467010f3a46baca73414070db0f7ab039f345548452ae26f7b744274e9bd6c791f47513e6b51eb42fea3816b3032b33a81695f04d4e775be06484cf7e6a69cba8bacbcb597b3e3",
-        "wx" : "0b96fca0e3f6ebf7326f0a8ce8bdf226a2560c22526bf154f7b467010f3a46baca73414070db0f7ab039f345548452ae2",
+        "wx" : "00b96fca0e3f6ebf7326f0a8ce8bdf226a2560c22526bf154f7b467010f3a46baca73414070db0f7ab039f345548452ae2",
         "wy" : "6f7b744274e9bd6c791f47513e6b51eb42fea3816b3032b33a81695f04d4e775be06484cf7e6a69cba8bacbcb597b3e3"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004b96fca0e3f6ebf7326f0a8ce8bdf226a2560c22526bf154f7b467010f3a46baca73414070db0f7ab039f345548452ae26f7b744274e9bd6c791f47513e6b51eb42fea3816b3032b33a81695f04d4e775be06484cf7e6a69cba8bacbcb597b3e3",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEuW/KDj9uv3Mm8KjOi98iaiVgwiUmvxVP\ne0ZwEPOka6ynNBQHDbD3qwOfNFVIRSrib3t0QnTpvWx5H0dRPmtR60L+o4FrMDKz\nOoFpXwTU53W+BkhM9+amnLqLrLy1l7Pj\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004b96fca0e3f6ebf7326f0a8ce8bdf226a2560c22526bf154f7b467010f3a46baca73414070db0f7ab039f345548452ae26f7b744274e9bd6c791f47513e6b51eb42fea3816b3032b33a81695f04d4e775be06484cf7e6a69cba8bacbcb597b3e3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEuW/KDj9uv3Mm8KjOi98iaiVgwiUmvxVP\ne0ZwEPOka6ynNBQHDbD3qwOfNFVIRSrib3t0QnTpvWx5H0dRPmtR60L+o4FrMDKz\nOoFpXwTU53W+BkhM9+amnLqLrLy1l7Pj\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 366,
+          "tcId" : 469,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100cb4d5c0ff0abe29b2771fe9f179a5614e2e4c3cc1134a7aad08d8ec3fd8fcd07fd34b3473ca65ead1c7bb20bcf3ea5c9",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "044fd52b11ff747b59ef609e065a462cd85b73172d20f406fdd845d4eaa3ec173e06ee58a58e1810f051b275bbaa47ccb484d2382b9e72c526dc3764a11a4a962a7a4c7355e6f057fc976ab73cc384f9a29da50769809ecbf37358dd83c74fc25f",
         "wx" : "4fd52b11ff747b59ef609e065a462cd85b73172d20f406fdd845d4eaa3ec173e06ee58a58e1810f051b275bbaa47ccb4",
-        "wy" : "084d2382b9e72c526dc3764a11a4a962a7a4c7355e6f057fc976ab73cc384f9a29da50769809ecbf37358dd83c74fc25f"
+        "wy" : "0084d2382b9e72c526dc3764a11a4a962a7a4c7355e6f057fc976ab73cc384f9a29da50769809ecbf37358dd83c74fc25f"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200044fd52b11ff747b59ef609e065a462cd85b73172d20f406fdd845d4eaa3ec173e06ee58a58e1810f051b275bbaa47ccb484d2382b9e72c526dc3764a11a4a962a7a4c7355e6f057fc976ab73cc384f9a29da50769809ecbf37358dd83c74fc25f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAET9UrEf90e1nvYJ4GWkYs2FtzFy0g9Ab9\n2EXU6qPsFz4G7liljhgQ8FGydbuqR8y0hNI4K55yxSbcN2ShGkqWKnpMc1Xm8Ff8\nl2q3PMOE+aKdpQdpgJ7L83NY3YPHT8Jf\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200044fd52b11ff747b59ef609e065a462cd85b73172d20f406fdd845d4eaa3ec173e06ee58a58e1810f051b275bbaa47ccb484d2382b9e72c526dc3764a11a4a962a7a4c7355e6f057fc976ab73cc384f9a29da50769809ecbf37358dd83c74fc25f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAET9UrEf90e1nvYJ4GWkYs2FtzFy0g9Ab9\n2EXU6qPsFz4G7liljhgQ8FGydbuqR8y0hNI4K55yxSbcN2ShGkqWKnpMc1Xm8Ff8\nl2q3PMOE+aKdpQdpgJ7L83NY3YPHT8Jf\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 367,
+          "tcId" : 470,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02306e441db253bf798dbc07ff041506dc73a75086a43252fb439dd016110475d8381f65f7f27f9e1cfc9b48f06a2dfa8eb6",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "047d123e3dbab9913d698891023e28654cba2a94dc408a0dc386e63d8d22ff0f33358a231860b7c2e4f8429e9e8c9a1c5be7c95d1875f24ecdfeffc6136cf56f800f5434490f234f14d78505c2d4aea51e2a3a6a5d1693e72c4b1dd2a8746b875a",
         "wx" : "7d123e3dbab9913d698891023e28654cba2a94dc408a0dc386e63d8d22ff0f33358a231860b7c2e4f8429e9e8c9a1c5b",
-        "wy" : "0e7c95d1875f24ecdfeffc6136cf56f800f5434490f234f14d78505c2d4aea51e2a3a6a5d1693e72c4b1dd2a8746b875a"
+        "wy" : "00e7c95d1875f24ecdfeffc6136cf56f800f5434490f234f14d78505c2d4aea51e2a3a6a5d1693e72c4b1dd2a8746b875a"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200047d123e3dbab9913d698891023e28654cba2a94dc408a0dc386e63d8d22ff0f33358a231860b7c2e4f8429e9e8c9a1c5be7c95d1875f24ecdfeffc6136cf56f800f5434490f234f14d78505c2d4aea51e2a3a6a5d1693e72c4b1dd2a8746b875a",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEfRI+Pbq5kT1piJECPihlTLoqlNxAig3D\nhuY9jSL/DzM1iiMYYLfC5PhCnp6Mmhxb58ldGHXyTs3+/8YTbPVvgA9UNEkPI08U\n14UFwtSupR4qOmpdFpPnLEsd0qh0a4da\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200047d123e3dbab9913d698891023e28654cba2a94dc408a0dc386e63d8d22ff0f33358a231860b7c2e4f8429e9e8c9a1c5be7c95d1875f24ecdfeffc6136cf56f800f5434490f234f14d78505c2d4aea51e2a3a6a5d1693e72c4b1dd2a8746b875a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEfRI+Pbq5kT1piJECPihlTLoqlNxAig3D\nhuY9jSL/DzM1iiMYYLfC5PhCnp6Mmhxb58ldGHXyTs3+/8YTbPVvgA9UNEkPI08U\n14UFwtSupR4qOmpdFpPnLEsd0qh0a4da\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 368,
+          "tcId" : 471,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023041db253bf798dbc07ff041506dc73a75086a43252fb43b63191efcd0914b6afb4bf8c77d008dbeac04277ef4aa59c394",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04608ce23a383452f8f4dcc5c0085d6793ec518985f0276a3409a23d7b7ca7e7dcb163601aca73840c3bd470aff70250bf674005a0be08939339363e314dca7ea67adfb60cd530628fe35f05416da8f20d5fb3b0ccd183a21dbb41c4e195d6303d",
         "wx" : "608ce23a383452f8f4dcc5c0085d6793ec518985f0276a3409a23d7b7ca7e7dcb163601aca73840c3bd470aff70250bf",
         "wy" : "674005a0be08939339363e314dca7ea67adfb60cd530628fe35f05416da8f20d5fb3b0ccd183a21dbb41c4e195d6303d"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004608ce23a383452f8f4dcc5c0085d6793ec518985f0276a3409a23d7b7ca7e7dcb163601aca73840c3bd470aff70250bf674005a0be08939339363e314dca7ea67adfb60cd530628fe35f05416da8f20d5fb3b0ccd183a21dbb41c4e195d6303d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEYIziOjg0Uvj03MXACF1nk+xRiYXwJ2o0\nCaI9e3yn59yxY2AaynOEDDvUcK/3AlC/Z0AFoL4Ik5M5Nj4xTcp+pnrftgzVMGKP\n418FQW2o8g1fs7DM0YOiHbtBxOGV1jA9\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004608ce23a383452f8f4dcc5c0085d6793ec518985f0276a3409a23d7b7ca7e7dcb163601aca73840c3bd470aff70250bf674005a0be08939339363e314dca7ea67adfb60cd530628fe35f05416da8f20d5fb3b0ccd183a21dbb41c4e195d6303d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEYIziOjg0Uvj03MXACF1nk+xRiYXwJ2o0\nCaI9e3yn59yxY2AaynOEDDvUcK/3AlC/Z0AFoL4Ik5M5Nj4xTcp+pnrftgzVMGKP\n418FQW2o8g1fs7DM0YOiHbtBxOGV1jA9\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 369,
+          "tcId" : 472,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02310083b64a77ef31b780ffe082a0db8e74ea10d4864a5f6876c6323df9a12296d5f697f18efa011b7d58084efde954b38728",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0448d23de1869475a1de532399da1240bab560eb74a6c7b0871bf8ac8fb6cc17cf7b34fcd7c79fd99c76c605bdf3fcbe18e15b66ab91d0a03e203c2ff914d4bedc38c1ec5dcd1d12db9b43ef6f44581632683bf785aa4326566227ece3c16be796",
         "wx" : "48d23de1869475a1de532399da1240bab560eb74a6c7b0871bf8ac8fb6cc17cf7b34fcd7c79fd99c76c605bdf3fcbe18",
-        "wy" : "0e15b66ab91d0a03e203c2ff914d4bedc38c1ec5dcd1d12db9b43ef6f44581632683bf785aa4326566227ece3c16be796"
+        "wy" : "00e15b66ab91d0a03e203c2ff914d4bedc38c1ec5dcd1d12db9b43ef6f44581632683bf785aa4326566227ece3c16be796"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000448d23de1869475a1de532399da1240bab560eb74a6c7b0871bf8ac8fb6cc17cf7b34fcd7c79fd99c76c605bdf3fcbe18e15b66ab91d0a03e203c2ff914d4bedc38c1ec5dcd1d12db9b43ef6f44581632683bf785aa4326566227ece3c16be796",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAESNI94YaUdaHeUyOZ2hJAurVg63Smx7CH\nG/isj7bMF897NPzXx5/ZnHbGBb3z/L4Y4Vtmq5HQoD4gPC/5FNS+3DjB7F3NHRLb\nm0Pvb0RYFjJoO/eFqkMmVmIn7OPBa+eW\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000448d23de1869475a1de532399da1240bab560eb74a6c7b0871bf8ac8fb6cc17cf7b34fcd7c79fd99c76c605bdf3fcbe18e15b66ab91d0a03e203c2ff914d4bedc38c1ec5dcd1d12db9b43ef6f44581632683bf785aa4326566227ece3c16be796",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAESNI94YaUdaHeUyOZ2hJAurVg63Smx7CH\nG/isj7bMF897NPzXx5/ZnHbGBb3z/L4Y4Vtmq5HQoD4gPC/5FNS+3DjB7F3NHRLb\nm0Pvb0RYFjJoO/eFqkMmVmIn7OPBa+eW\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 370,
+          "tcId" : 473,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023053bf798dbc07ff041506dc73a75086a43252fb43b6327af3b42da6d3e9a72cde0b5c2de6bf072e780e94ad12dcab270a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "045d5eb470f9c6a0bb18e8960b67011acf9f01df405ac5b4bf9f4611d6a8af1a26b11b0790e93ae2361525dde51bacac94d42ce151793b80cee679c848362ec272000316590ebc91547b3b6608dfbade21e04de1548ebb45cc4721eb64a16b8318",
         "wx" : "5d5eb470f9c6a0bb18e8960b67011acf9f01df405ac5b4bf9f4611d6a8af1a26b11b0790e93ae2361525dde51bacac94",
-        "wy" : "0d42ce151793b80cee679c848362ec272000316590ebc91547b3b6608dfbade21e04de1548ebb45cc4721eb64a16b8318"
+        "wy" : "00d42ce151793b80cee679c848362ec272000316590ebc91547b3b6608dfbade21e04de1548ebb45cc4721eb64a16b8318"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200045d5eb470f9c6a0bb18e8960b67011acf9f01df405ac5b4bf9f4611d6a8af1a26b11b0790e93ae2361525dde51bacac94d42ce151793b80cee679c848362ec272000316590ebc91547b3b6608dfbade21e04de1548ebb45cc4721eb64a16b8318",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEXV60cPnGoLsY6JYLZwEaz58B30BaxbS/\nn0YR1qivGiaxGweQ6TriNhUl3eUbrKyU1CzhUXk7gM7mechINi7CcgADFlkOvJFU\neztmCN+63iHgTeFUjrtFzEch62Sha4MY\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200045d5eb470f9c6a0bb18e8960b67011acf9f01df405ac5b4bf9f4611d6a8af1a26b11b0790e93ae2361525dde51bacac94d42ce151793b80cee679c848362ec272000316590ebc91547b3b6608dfbade21e04de1548ebb45cc4721eb64a16b8318",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEXV60cPnGoLsY6JYLZwEaz58B30BaxbS/\nn0YR1qivGiaxGweQ6TriNhUl3eUbrKyU1CzhUXk7gM7mechINi7CcgADFlkOvJFU\neztmCN+63iHgTeFUjrtFzEch62Sha4MY\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 371,
+          "tcId" : 474,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023024c53b0a00cf087a9a20a2b78bc81d5b383d04ba9b55a567405239d224387344c41cceff0f68ffc930dbaa0b3d346f45",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "041da34a149ed562c8ec13e84cb067107bc28b50bfa47575d5a9948cde5a3d7357c38ea41fcfcdd1ab1a1bd9b6592b33d9e14aedfd0cfffcfecbdc21276e6a2c78b8729412c48339ae538b799b7d8e61163047a64cfcec9018aa00f99ae740e3f3",
         "wx" : "1da34a149ed562c8ec13e84cb067107bc28b50bfa47575d5a9948cde5a3d7357c38ea41fcfcdd1ab1a1bd9b6592b33d9",
-        "wy" : "0e14aedfd0cfffcfecbdc21276e6a2c78b8729412c48339ae538b799b7d8e61163047a64cfcec9018aa00f99ae740e3f3"
+        "wy" : "00e14aedfd0cfffcfecbdc21276e6a2c78b8729412c48339ae538b799b7d8e61163047a64cfcec9018aa00f99ae740e3f3"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200041da34a149ed562c8ec13e84cb067107bc28b50bfa47575d5a9948cde5a3d7357c38ea41fcfcdd1ab1a1bd9b6592b33d9e14aedfd0cfffcfecbdc21276e6a2c78b8729412c48339ae538b799b7d8e61163047a64cfcec9018aa00f99ae740e3f3",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEHaNKFJ7VYsjsE+hMsGcQe8KLUL+kdXXV\nqZSM3lo9c1fDjqQfz83Rqxob2bZZKzPZ4Urt/Qz//P7L3CEnbmoseLhylBLEgzmu\nU4t5m32OYRYwR6ZM/OyQGKoA+ZrnQOPz\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200041da34a149ed562c8ec13e84cb067107bc28b50bfa47575d5a9948cde5a3d7357c38ea41fcfcdd1ab1a1bd9b6592b33d9e14aedfd0cfffcfecbdc21276e6a2c78b8729412c48339ae538b799b7d8e61163047a64cfcec9018aa00f99ae740e3f3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEHaNKFJ7VYsjsE+hMsGcQe8KLUL+kdXXV\nqZSM3lo9c1fDjqQfz83Rqxob2bZZKzPZ4Urt/Qz//P7L3CEnbmoseLhylBLEgzmu\nU4t5m32OYRYwR6ZM/OyQGKoA+ZrnQOPz\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 372,
+          "tcId" : 475,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100c600ccb39bb3e2d85d880d76d1d519205f050c4b93deae0c5d63e8898ca8d7a5babbb944debe0f3c44332aae5770cb7b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "048b8675211b321f8b318ba60337cde32a6b04243979546383127a068a8749cb5e98c4231b198de62a2b069d3a94d1c7b19d33468a130b4fef66a59d4aee00ca40bdbeaf044b8b22841bb4c8ba419f891b3855f4bddf8dae3577d97120b9d3fa44",
-        "wx" : "08b8675211b321f8b318ba60337cde32a6b04243979546383127a068a8749cb5e98c4231b198de62a2b069d3a94d1c7b1",
-        "wy" : "09d33468a130b4fef66a59d4aee00ca40bdbeaf044b8b22841bb4c8ba419f891b3855f4bddf8dae3577d97120b9d3fa44"
+        "wx" : "008b8675211b321f8b318ba60337cde32a6b04243979546383127a068a8749cb5e98c4231b198de62a2b069d3a94d1c7b1",
+        "wy" : "009d33468a130b4fef66a59d4aee00ca40bdbeaf044b8b22841bb4c8ba419f891b3855f4bddf8dae3577d97120b9d3fa44"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200048b8675211b321f8b318ba60337cde32a6b04243979546383127a068a8749cb5e98c4231b198de62a2b069d3a94d1c7b19d33468a130b4fef66a59d4aee00ca40bdbeaf044b8b22841bb4c8ba419f891b3855f4bddf8dae3577d97120b9d3fa44",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEi4Z1IRsyH4sxi6YDN83jKmsEJDl5VGOD\nEnoGiodJy16YxCMbGY3mKisGnTqU0cexnTNGihMLT+9mpZ1K7gDKQL2+rwRLiyKE\nG7TIukGfiRs4VfS9342uNXfZcSC50/pE\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200048b8675211b321f8b318ba60337cde32a6b04243979546383127a068a8749cb5e98c4231b198de62a2b069d3a94d1c7b19d33468a130b4fef66a59d4aee00ca40bdbeaf044b8b22841bb4c8ba419f891b3855f4bddf8dae3577d97120b9d3fa44",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEi4Z1IRsyH4sxi6YDN83jKmsEJDl5VGOD\nEnoGiodJy16YxCMbGY3mKisGnTqU0cexnTNGihMLT+9mpZ1K7gDKQL2+rwRLiyKE\nG7TIukGfiRs4VfS9342uNXfZcSC50/pE\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 373,
+          "tcId" : 476,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02303ead55015c579ed137c58236bb70fe6be76628fbece64429bb655245f05cb91f4b8a499ae7880154ba83a84bf0569ae3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04442766bdb8b2cf4fef5f65d5d86b61681ec89220c983b51f15bfe12fb0bf9780e0c38bbcc888afb3c55ee828774b86f756b7f399c534c7acd46be4bc8bb38f087b0023b8f5166ab34192ca0b1cad62d663aa474c6f9286c8a054ef94ea42e3c7",
         "wx" : "442766bdb8b2cf4fef5f65d5d86b61681ec89220c983b51f15bfe12fb0bf9780e0c38bbcc888afb3c55ee828774b86f7",
         "wy" : "56b7f399c534c7acd46be4bc8bb38f087b0023b8f5166ab34192ca0b1cad62d663aa474c6f9286c8a054ef94ea42e3c7"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004442766bdb8b2cf4fef5f65d5d86b61681ec89220c983b51f15bfe12fb0bf9780e0c38bbcc888afb3c55ee828774b86f756b7f399c534c7acd46be4bc8bb38f087b0023b8f5166ab34192ca0b1cad62d663aa474c6f9286c8a054ef94ea42e3c7",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERCdmvbiyz0/vX2XV2GthaB7IkiDJg7Uf\nFb/hL7C/l4Dgw4u8yIivs8Ve6Ch3S4b3VrfzmcU0x6zUa+S8i7OPCHsAI7j1Fmqz\nQZLKCxytYtZjqkdMb5KGyKBU75TqQuPH\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004442766bdb8b2cf4fef5f65d5d86b61681ec89220c983b51f15bfe12fb0bf9780e0c38bbcc888afb3c55ee828774b86f756b7f399c534c7acd46be4bc8bb38f087b0023b8f5166ab34192ca0b1cad62d663aa474c6f9286c8a054ef94ea42e3c7",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERCdmvbiyz0/vX2XV2GthaB7IkiDJg7Uf\nFb/hL7C/l4Dgw4u8yIivs8Ve6Ch3S4b3VrfzmcU0x6zUa+S8i7OPCHsAI7j1Fmqz\nQZLKCxytYtZjqkdMb5KGyKBU75TqQuPH\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 374,
+          "tcId" : 477,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100de03ff820a836e39d3a8435219297da1db193d79e359663e7cc9a229e2a6ac9e9d5c75417fa455bc8e3b89274ee47d0e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0411342b314f31648931abb897c1371dd3a23e91f2405c4a81744be18e753919752208779de2d54e865eeefbb0bfb4998af533d7a4d6fc6cb5cb98915ce08d0f656e37a502e78f8c1b8baca728c2ecb05a2156f01cff16595b363cdb49c00c1aa2",
         "wx" : "11342b314f31648931abb897c1371dd3a23e91f2405c4a81744be18e753919752208779de2d54e865eeefbb0bfb4998a",
-        "wy" : "0f533d7a4d6fc6cb5cb98915ce08d0f656e37a502e78f8c1b8baca728c2ecb05a2156f01cff16595b363cdb49c00c1aa2"
+        "wy" : "00f533d7a4d6fc6cb5cb98915ce08d0f656e37a502e78f8c1b8baca728c2ecb05a2156f01cff16595b363cdb49c00c1aa2"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000411342b314f31648931abb897c1371dd3a23e91f2405c4a81744be18e753919752208779de2d54e865eeefbb0bfb4998af533d7a4d6fc6cb5cb98915ce08d0f656e37a502e78f8c1b8baca728c2ecb05a2156f01cff16595b363cdb49c00c1aa2",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEETQrMU8xZIkxq7iXwTcd06I+kfJAXEqB\ndEvhjnU5GXUiCHed4tVOhl7u+7C/tJmK9TPXpNb8bLXLmJFc4I0PZW43pQLnj4wb\ni6ynKMLssFohVvAc/xZZWzY820nADBqi\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000411342b314f31648931abb897c1371dd3a23e91f2405c4a81744be18e753919752208779de2d54e865eeefbb0bfb4998af533d7a4d6fc6cb5cb98915ce08d0f656e37a502e78f8c1b8baca728c2ecb05a2156f01cff16595b363cdb49c00c1aa2",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEETQrMU8xZIkxq7iXwTcd06I+kfJAXEqB\ndEvhjnU5GXUiCHed4tVOhl7u+7C/tJmK9TPXpNb8bLXLmJFc4I0PZW43pQLnj4wb\ni6ynKMLssFohVvAc/xZZWzY820nADBqi\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 375,
+          "tcId" : 478,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100e5a6ae07f855f14d93b8ff4f8bcd2b0a717261e6089a53d54bf86e22f8e37d73aaa7607cc2ab831404b3e5bb4e01e79e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "043c96b49ff60ff05951b7b1aca65664f13128b714da620697ef0d90bfc01ef643baa5c608f16ca885038322a443aed3e6169a27f2ea7a36376ef92a900e5389a7b441fd051d693ce65250b881cfdd6487370372292c84369742b18106188b05c0",
         "wx" : "3c96b49ff60ff05951b7b1aca65664f13128b714da620697ef0d90bfc01ef643baa5c608f16ca885038322a443aed3e6",
         "wy" : "169a27f2ea7a36376ef92a900e5389a7b441fd051d693ce65250b881cfdd6487370372292c84369742b18106188b05c0"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200043c96b49ff60ff05951b7b1aca65664f13128b714da620697ef0d90bfc01ef643baa5c608f16ca885038322a443aed3e6169a27f2ea7a36376ef92a900e5389a7b441fd051d693ce65250b881cfdd6487370372292c84369742b18106188b05c0",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEPJa0n/YP8FlRt7GsplZk8TEotxTaYgaX\n7w2Qv8Ae9kO6pcYI8WyohQODIqRDrtPmFpon8up6Njdu+SqQDlOJp7RB/QUdaTzm\nUlC4gc/dZIc3A3IpLIQ2l0KxgQYYiwXA\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200043c96b49ff60ff05951b7b1aca65664f13128b714da620697ef0d90bfc01ef643baa5c608f16ca885038322a443aed3e6169a27f2ea7a36376ef92a900e5389a7b441fd051d693ce65250b881cfdd6487370372292c84369742b18106188b05c0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEPJa0n/YP8FlRt7GsplZk8TEotxTaYgaX\n7w2Qv8Ae9kO6pcYI8WyohQODIqRDrtPmFpon8up6Njdu+SqQDlOJp7RB/QUdaTzm\nUlC4gc/dZIc3A3IpLIQ2l0KxgQYYiwXA\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 376,
+          "tcId" : 479,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02307fffffffffffffffffffffffffffffffffffffffffffffffed2119d5fc12649fc808af3b6d9037d3a44eb32399970dd0",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04388dae49ea48afb558456fdb1d0b04d4f8f1c46f14d22de25862d35069a28ae9284d7a8074546e779ad2c5f17ce9b89bb353298f3c526aa0a10ed23bcb1ed9788812c8a3a6cbea82a3d9d8d465a4cca59dbd3d3d8a36098d644f1b45d36df537",
         "wx" : "388dae49ea48afb558456fdb1d0b04d4f8f1c46f14d22de25862d35069a28ae9284d7a8074546e779ad2c5f17ce9b89b",
-        "wy" : "0b353298f3c526aa0a10ed23bcb1ed9788812c8a3a6cbea82a3d9d8d465a4cca59dbd3d3d8a36098d644f1b45d36df537"
+        "wy" : "00b353298f3c526aa0a10ed23bcb1ed9788812c8a3a6cbea82a3d9d8d465a4cca59dbd3d3d8a36098d644f1b45d36df537"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004388dae49ea48afb558456fdb1d0b04d4f8f1c46f14d22de25862d35069a28ae9284d7a8074546e779ad2c5f17ce9b89bb353298f3c526aa0a10ed23bcb1ed9788812c8a3a6cbea82a3d9d8d465a4cca59dbd3d3d8a36098d644f1b45d36df537",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOI2uSepIr7VYRW/bHQsE1PjxxG8U0i3i\nWGLTUGmiiukoTXqAdFRud5rSxfF86bibs1MpjzxSaqChDtI7yx7ZeIgSyKOmy+qC\no9nY1GWkzKWdvT09ijYJjWRPG0XTbfU3\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004388dae49ea48afb558456fdb1d0b04d4f8f1c46f14d22de25862d35069a28ae9284d7a8074546e779ad2c5f17ce9b89bb353298f3c526aa0a10ed23bcb1ed9788812c8a3a6cbea82a3d9d8d465a4cca59dbd3d3d8a36098d644f1b45d36df537",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOI2uSepIr7VYRW/bHQsE1PjxxG8U0i3i\nWGLTUGmiiukoTXqAdFRud5rSxfF86bibs1MpjzxSaqChDtI7yx7ZeIgSyKOmy+qC\no9nY1GWkzKWdvT09ijYJjWRPG0XTbfU3\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 377,
+          "tcId" : 480,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023079b95c013b0472de04d8faeec3b779c39fe729ea84fb554cd091c7178c2f054eabbc62c3e1cfbac2c2e69d7aa45d9072",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04c85200ac6411423573e3ebc1b7aea95e74add5ce3b41282baa885972acc085c8365c05c539ce47e799afc353d6788ce868cfce1eb2bfe009990084fb03c0919ab892313d7a12efc3514e8273685b9071892faefca4306adf7854afcebafffbf4",
-        "wx" : "0c85200ac6411423573e3ebc1b7aea95e74add5ce3b41282baa885972acc085c8365c05c539ce47e799afc353d6788ce8",
+        "wx" : "00c85200ac6411423573e3ebc1b7aea95e74add5ce3b41282baa885972acc085c8365c05c539ce47e799afc353d6788ce8",
         "wy" : "68cfce1eb2bfe009990084fb03c0919ab892313d7a12efc3514e8273685b9071892faefca4306adf7854afcebafffbf4"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004c85200ac6411423573e3ebc1b7aea95e74add5ce3b41282baa885972acc085c8365c05c539ce47e799afc353d6788ce868cfce1eb2bfe009990084fb03c0919ab892313d7a12efc3514e8273685b9071892faefca4306adf7854afcebafffbf4",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEyFIArGQRQjVz4+vBt66pXnSt1c47QSgr\nqohZcqzAhcg2XAXFOc5H55mvw1PWeIzoaM/OHrK/4AmZAIT7A8CRmriSMT16Eu/D\nUU6Cc2hbkHGJL678pDBq33hUr866//v0\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004c85200ac6411423573e3ebc1b7aea95e74add5ce3b41282baa885972acc085c8365c05c539ce47e799afc353d6788ce868cfce1eb2bfe009990084fb03c0919ab892313d7a12efc3514e8273685b9071892faefca4306adf7854afcebafffbf4",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEyFIArGQRQjVz4+vBt66pXnSt1c47QSgr\nqohZcqzAhcg2XAXFOc5H55mvw1PWeIzoaM/OHrK/4AmZAIT7A8CRmriSMT16Eu/D\nUU6Cc2hbkHGJL678pDBq33hUr866//v0\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 378,
+          "tcId" : 481,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100bfd40d0caa4d9d42381f3d72a25683f52b03a1ed96fb72d03f08dcb9a8bc8f23c1a459deab03bcd39396c0d1e9053c81",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04e63ae2881ed60884ef1aef52178a297bdfedf67f4e3c1d876ad10b42c03b5e67f7f8cfaf4dfea4def7ab82fde3ed9b910e2be22bc3fa46a2ed094ebd7c86a9512c8c40cd542fb539c34347ef2be4e7f1543af960fd2347354a7a1df71a237d51",
-        "wx" : "0e63ae2881ed60884ef1aef52178a297bdfedf67f4e3c1d876ad10b42c03b5e67f7f8cfaf4dfea4def7ab82fde3ed9b91",
+        "wx" : "00e63ae2881ed60884ef1aef52178a297bdfedf67f4e3c1d876ad10b42c03b5e67f7f8cfaf4dfea4def7ab82fde3ed9b91",
         "wy" : "0e2be22bc3fa46a2ed094ebd7c86a9512c8c40cd542fb539c34347ef2be4e7f1543af960fd2347354a7a1df71a237d51"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004e63ae2881ed60884ef1aef52178a297bdfedf67f4e3c1d876ad10b42c03b5e67f7f8cfaf4dfea4def7ab82fde3ed9b910e2be22bc3fa46a2ed094ebd7c86a9512c8c40cd542fb539c34347ef2be4e7f1543af960fd2347354a7a1df71a237d51",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE5jriiB7WCITvGu9SF4ope9/t9n9OPB2H\natELQsA7Xmf3+M+vTf6k3vergv3j7ZuRDiviK8P6RqLtCU69fIapUSyMQM1UL7U5\nw0NH7yvk5/FUOvlg/SNHNUp6HfcaI31R\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004e63ae2881ed60884ef1aef52178a297bdfedf67f4e3c1d876ad10b42c03b5e67f7f8cfaf4dfea4def7ab82fde3ed9b910e2be22bc3fa46a2ed094ebd7c86a9512c8c40cd542fb539c34347ef2be4e7f1543af960fd2347354a7a1df71a237d51",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE5jriiB7WCITvGu9SF4ope9/t9n9OPB2H\natELQsA7Xmf3+M+vTf6k3vergv3j7ZuRDiviK8P6RqLtCU69fIapUSyMQM1UL7U5\nw0NH7yvk5/FUOvlg/SNHNUp6HfcaI31R\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 379,
+          "tcId" : 482,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02304c7d219db9af94ce7fffffffffffffffffffffffffffffffef15cf1058c8d8ba1e634c4122db95ec1facd4bb13ebf09a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04e9c415f8a72055239570c3c370cf9380cdfabb6ebdbd8058e2fc65193080707895ea1566eeb26149603f4b4d4c1e79d496ae17a001424d21eae4eaa01067048bcd919625fdd7efd896d980633a0e2ca1f8c9b02c99b69a1e4fa53468a2fe244d",
-        "wx" : "0e9c415f8a72055239570c3c370cf9380cdfabb6ebdbd8058e2fc65193080707895ea1566eeb26149603f4b4d4c1e79d4",
-        "wy" : "096ae17a001424d21eae4eaa01067048bcd919625fdd7efd896d980633a0e2ca1f8c9b02c99b69a1e4fa53468a2fe244d"
+        "wx" : "00e9c415f8a72055239570c3c370cf9380cdfabb6ebdbd8058e2fc65193080707895ea1566eeb26149603f4b4d4c1e79d4",
+        "wy" : "0096ae17a001424d21eae4eaa01067048bcd919625fdd7efd896d980633a0e2ca1f8c9b02c99b69a1e4fa53468a2fe244d"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004e9c415f8a72055239570c3c370cf9380cdfabb6ebdbd8058e2fc65193080707895ea1566eeb26149603f4b4d4c1e79d496ae17a001424d21eae4eaa01067048bcd919625fdd7efd896d980633a0e2ca1f8c9b02c99b69a1e4fa53468a2fe244d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE6cQV+KcgVSOVcMPDcM+TgM36u269vYBY\n4vxlGTCAcHiV6hVm7rJhSWA/S01MHnnUlq4XoAFCTSHq5OqgEGcEi82RliX91+/Y\nltmAYzoOLKH4ybAsmbaaHk+lNGii/iRN\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004e9c415f8a72055239570c3c370cf9380cdfabb6ebdbd8058e2fc65193080707895ea1566eeb26149603f4b4d4c1e79d496ae17a001424d21eae4eaa01067048bcd919625fdd7efd896d980633a0e2ca1f8c9b02c99b69a1e4fa53468a2fe244d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE6cQV+KcgVSOVcMPDcM+TgM36u269vYBY\n4vxlGTCAcHiV6hVm7rJhSWA/S01MHnnUlq4XoAFCTSHq5OqgEGcEi82RliX91+/Y\nltmAYzoOLKH4ybAsmbaaHk+lNGii/iRN\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 380,
+          "tcId" : 483,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100d219db9af94ce7ffffffffffffffffffffffffffffffffffd189bdb6d9ef7be8504ca374756ea5b8f15e44067d209b9b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04637223a93dd63af6b348f246e7b3bcb30beaa1dcc888af8e12e5086aa00f7792fbe457463c52422d435f430ad1bb4b21f9a1e01758d1e025b162d09d3df8b403226ed3b35e414c41651740d509d8cf6b5e558118607d10669902abebda3ca28d",
         "wx" : "637223a93dd63af6b348f246e7b3bcb30beaa1dcc888af8e12e5086aa00f7792fbe457463c52422d435f430ad1bb4b21",
-        "wy" : "0f9a1e01758d1e025b162d09d3df8b403226ed3b35e414c41651740d509d8cf6b5e558118607d10669902abebda3ca28d"
+        "wy" : "00f9a1e01758d1e025b162d09d3df8b403226ed3b35e414c41651740d509d8cf6b5e558118607d10669902abebda3ca28d"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004637223a93dd63af6b348f246e7b3bcb30beaa1dcc888af8e12e5086aa00f7792fbe457463c52422d435f430ad1bb4b21f9a1e01758d1e025b162d09d3df8b403226ed3b35e414c41651740d509d8cf6b5e558118607d10669902abebda3ca28d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEY3IjqT3WOvazSPJG57O8swvqodzIiK+O\nEuUIaqAPd5L75FdGPFJCLUNfQwrRu0sh+aHgF1jR4CWxYtCdPfi0AyJu07NeQUxB\nZRdA1QnYz2teVYEYYH0QZpkCq+vaPKKN\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004637223a93dd63af6b348f246e7b3bcb30beaa1dcc888af8e12e5086aa00f7792fbe457463c52422d435f430ad1bb4b21f9a1e01758d1e025b162d09d3df8b403226ed3b35e414c41651740d509d8cf6b5e558118607d10669902abebda3ca28d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEY3IjqT3WOvazSPJG57O8swvqodzIiK+O\nEuUIaqAPd5L75FdGPFJCLUNfQwrRu0sh+aHgF1jR4CWxYtCdPfi0AyJu07NeQUxB\nZRdA1QnYz2teVYEYYH0QZpkCq+vaPKKN\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 381,
+          "tcId" : 484,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100a433b735f299cfffffffffffffffffffffffffffffffffffdbb02debbfa7c9f1487f3936a22ca3f6f5d06ea22d7c0dc3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "047f4dc23982ecc8b84f54241715c7e94e950f596ce033237639a15fefa5eb5c37cb2e562d6d5b3051ea15600e3341a565fed2b55b89d2793321374887b78827ee4ca2216eac2993b1b095844db76adc560450135c072ac1a2c4167520237fbc9d",
         "wx" : "7f4dc23982ecc8b84f54241715c7e94e950f596ce033237639a15fefa5eb5c37cb2e562d6d5b3051ea15600e3341a565",
-        "wy" : "0fed2b55b89d2793321374887b78827ee4ca2216eac2993b1b095844db76adc560450135c072ac1a2c4167520237fbc9d"
+        "wy" : "00fed2b55b89d2793321374887b78827ee4ca2216eac2993b1b095844db76adc560450135c072ac1a2c4167520237fbc9d"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200047f4dc23982ecc8b84f54241715c7e94e950f596ce033237639a15fefa5eb5c37cb2e562d6d5b3051ea15600e3341a565fed2b55b89d2793321374887b78827ee4ca2216eac2993b1b095844db76adc560450135c072ac1a2c4167520237fbc9d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEf03COYLsyLhPVCQXFcfpTpUPWWzgMyN2\nOaFf76XrXDfLLlYtbVswUeoVYA4zQaVl/tK1W4nSeTMhN0iHt4gn7kyiIW6sKZOx\nsJWETbdq3FYEUBNcByrBosQWdSAjf7yd\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200047f4dc23982ecc8b84f54241715c7e94e950f596ce033237639a15fefa5eb5c37cb2e562d6d5b3051ea15600e3341a565fed2b55b89d2793321374887b78827ee4ca2216eac2993b1b095844db76adc560450135c072ac1a2c4167520237fbc9d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEf03COYLsyLhPVCQXFcfpTpUPWWzgMyN2\nOaFf76XrXDfLLlYtbVswUeoVYA4zQaVl/tK1W4nSeTMhN0iHt4gn7kyiIW6sKZOx\nsJWETbdq3FYEUBNcByrBosQWdSAjf7yd\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 382,
+          "tcId" : 485,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100b9af94ce7fffffffffffffffffffffffffffffffffffffffd6efeefc876c9f23217b443c80637ef939e911219f96c179",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04a0ae8c949f63f1b6a5d024c99e0a296ecd12d196d3b1625d4a76600082a14d455aab267c68f571d89ad0619cb8e476a134634336611e1fd1d728bcea588d0e1b652bbca0e52c1bfbd4387a6337ff41ce13a65c8306915d2a39897b985d909b36",
-        "wx" : "0a0ae8c949f63f1b6a5d024c99e0a296ecd12d196d3b1625d4a76600082a14d455aab267c68f571d89ad0619cb8e476a1",
+        "wx" : "00a0ae8c949f63f1b6a5d024c99e0a296ecd12d196d3b1625d4a76600082a14d455aab267c68f571d89ad0619cb8e476a1",
         "wy" : "34634336611e1fd1d728bcea588d0e1b652bbca0e52c1bfbd4387a6337ff41ce13a65c8306915d2a39897b985d909b36"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004a0ae8c949f63f1b6a5d024c99e0a296ecd12d196d3b1625d4a76600082a14d455aab267c68f571d89ad0619cb8e476a134634336611e1fd1d728bcea588d0e1b652bbca0e52c1bfbd4387a6337ff41ce13a65c8306915d2a39897b985d909b36",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEoK6MlJ9j8bal0CTJngopbs0S0ZbTsWJd\nSnZgAIKhTUVaqyZ8aPVx2JrQYZy45HahNGNDNmEeH9HXKLzqWI0OG2UrvKDlLBv7\n1Dh6Yzf/Qc4TplyDBpFdKjmJe5hdkJs2\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004a0ae8c949f63f1b6a5d024c99e0a296ecd12d196d3b1625d4a76600082a14d455aab267c68f571d89ad0619cb8e476a134634336611e1fd1d728bcea588d0e1b652bbca0e52c1bfbd4387a6337ff41ce13a65c8306915d2a39897b985d909b36",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEoK6MlJ9j8bal0CTJngopbs0S0ZbTsWJd\nSnZgAIKhTUVaqyZ8aPVx2JrQYZy45HahNGNDNmEeH9HXKLzqWI0OG2UrvKDlLBv7\n1Dh6Yzf/Qc4TplyDBpFdKjmJe5hdkJs2\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 383,
+          "tcId" : 486,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100a276276276276276276276276276276276276276276276273d7228d4f84b769be0fd57b97e4c1ebcae9a5f635e80e9df",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "047cad1637721f5988cb7967238b1f47fd0b63f30f207a165951fc6fb74ba868e5b462628595edc80f75182e564a89c7a0fc04c405938aab3d6828e72e86bc59a400719270f8ee3cb5ef929ab53287bb308b51abd2e3ffbc3d93b87471bc2e3730",
         "wx" : "7cad1637721f5988cb7967238b1f47fd0b63f30f207a165951fc6fb74ba868e5b462628595edc80f75182e564a89c7a0",
-        "wy" : "0fc04c405938aab3d6828e72e86bc59a400719270f8ee3cb5ef929ab53287bb308b51abd2e3ffbc3d93b87471bc2e3730"
+        "wy" : "00fc04c405938aab3d6828e72e86bc59a400719270f8ee3cb5ef929ab53287bb308b51abd2e3ffbc3d93b87471bc2e3730"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200047cad1637721f5988cb7967238b1f47fd0b63f30f207a165951fc6fb74ba868e5b462628595edc80f75182e564a89c7a0fc04c405938aab3d6828e72e86bc59a400719270f8ee3cb5ef929ab53287bb308b51abd2e3ffbc3d93b87471bc2e3730",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEfK0WN3IfWYjLeWcjix9H/Qtj8w8gehZZ\nUfxvt0uoaOW0YmKFle3ID3UYLlZKiceg/ATEBZOKqz1oKOcuhrxZpABxknD47jy1\n75KatTKHuzCLUavS4/+8PZO4dHG8Ljcw\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200047cad1637721f5988cb7967238b1f47fd0b63f30f207a165951fc6fb74ba868e5b462628595edc80f75182e564a89c7a0fc04c405938aab3d6828e72e86bc59a400719270f8ee3cb5ef929ab53287bb308b51abd2e3ffbc3d93b87471bc2e3730",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEfK0WN3IfWYjLeWcjix9H/Qtj8w8gehZZ\nUfxvt0uoaOW0YmKFle3ID3UYLlZKiceg/ATEBZOKqz1oKOcuhrxZpABxknD47jy1\n75KatTKHuzCLUavS4/+8PZO4dHG8Ljcw\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 384,
+          "tcId" : 487,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023073333333333333333333333333333333333333333333333316e4d9f42d4eca22df403a0c578b86f0a9a93fe89995c7ed",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "042024ecde0e61262955b0301ae6b0a4fbd7771762feb2de35eed1823d2636c6e001f7bfcdbc4e65b1ea40224090411906d55362a570e80a2126f01d919b608440294039be03419d518b13cca6a1595414717f1b4ddb842b2c9d4f543e683b86a0",
         "wx" : "2024ecde0e61262955b0301ae6b0a4fbd7771762feb2de35eed1823d2636c6e001f7bfcdbc4e65b1ea40224090411906",
-        "wy" : "0d55362a570e80a2126f01d919b608440294039be03419d518b13cca6a1595414717f1b4ddb842b2c9d4f543e683b86a0"
+        "wy" : "00d55362a570e80a2126f01d919b608440294039be03419d518b13cca6a1595414717f1b4ddb842b2c9d4f543e683b86a0"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200042024ecde0e61262955b0301ae6b0a4fbd7771762feb2de35eed1823d2636c6e001f7bfcdbc4e65b1ea40224090411906d55362a570e80a2126f01d919b608440294039be03419d518b13cca6a1595414717f1b4ddb842b2c9d4f543e683b86a0",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEICTs3g5hJilVsDAa5rCk+9d3F2L+st41\n7tGCPSY2xuAB97/NvE5lsepAIkCQQRkG1VNipXDoCiEm8B2Rm2CEQClAOb4DQZ1R\nixPMpqFZVBRxfxtN24QrLJ1PVD5oO4ag\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200042024ecde0e61262955b0301ae6b0a4fbd7771762feb2de35eed1823d2636c6e001f7bfcdbc4e65b1ea40224090411906d55362a570e80a2126f01d919b608440294039be03419d518b13cca6a1595414717f1b4ddb842b2c9d4f543e683b86a0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEICTs3g5hJilVsDAa5rCk+9d3F2L+st41\n7tGCPSY2xuAB97/NvE5lsepAIkCQQRkG1VNipXDoCiEm8B2Rm2CEQClAOb4DQZ1R\nixPMpqFZVBRxfxtN24QrLJ1PVD5oO4ag\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 385,
+          "tcId" : 488,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02307fffffffffffffffffffffffffffffffffffffffffffffffda4233abf824c93f90115e76db206fa7489d6647332e1ba3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0440c5f2608956380c39695c7457ddce0880b5e8fab0a9a3726d0c8535b2ff6ca15814d83ed82c0ab33aba76e05e5c0476c9d15a2a0b2041237ff61c26519d1d74b141d7a4499fbdefc414a900937a8faf6ef560550c73cdb7edfe9314c480bb2b",
         "wx" : "40c5f2608956380c39695c7457ddce0880b5e8fab0a9a3726d0c8535b2ff6ca15814d83ed82c0ab33aba76e05e5c0476",
-        "wy" : "0c9d15a2a0b2041237ff61c26519d1d74b141d7a4499fbdefc414a900937a8faf6ef560550c73cdb7edfe9314c480bb2b"
+        "wy" : "00c9d15a2a0b2041237ff61c26519d1d74b141d7a4499fbdefc414a900937a8faf6ef560550c73cdb7edfe9314c480bb2b"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000440c5f2608956380c39695c7457ddce0880b5e8fab0a9a3726d0c8535b2ff6ca15814d83ed82c0ab33aba76e05e5c0476c9d15a2a0b2041237ff61c26519d1d74b141d7a4499fbdefc414a900937a8faf6ef560550c73cdb7edfe9314c480bb2b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEQMXyYIlWOAw5aVx0V93OCIC16PqwqaNy\nbQyFNbL/bKFYFNg+2CwKszq6duBeXAR2ydFaKgsgQSN/9hwmUZ0ddLFB16RJn73v\nxBSpAJN6j69u9WBVDHPNt+3+kxTEgLsr\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000440c5f2608956380c39695c7457ddce0880b5e8fab0a9a3726d0c8535b2ff6ca15814d83ed82c0ab33aba76e05e5c0476c9d15a2a0b2041237ff61c26519d1d74b141d7a4499fbdefc414a900937a8faf6ef560550c73cdb7edfe9314c480bb2b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEQMXyYIlWOAw5aVx0V93OCIC16PqwqaNy\nbQyFNbL/bKFYFNg+2CwKszq6duBeXAR2ydFaKgsgQSN/9hwmUZ0ddLFB16RJn73v\nxBSpAJN6j69u9WBVDHPNt+3+kxTEgLsr\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 386,
+          "tcId" : 489,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306402307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd02303fffffffffffffffffffffffffffffffffffffffffffffffe3b1a6c0fa1b96efac0d06d9245853bd76760cb5666294bb",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0474acdfd2ab763c593bca30d248f2bf26f1843acf9eb89b4dfcb8451d59683812cf3cbe9a264ea435912a8969c53d7cb8496dcb0a4efed69b87110fda20e68eb6feed2d5101a4955d43759f10b73e8ffc3131e0c12a765b68bd216ed1ec4f5d2f",
         "wx" : "74acdfd2ab763c593bca30d248f2bf26f1843acf9eb89b4dfcb8451d59683812cf3cbe9a264ea435912a8969c53d7cb8",
         "wy" : "496dcb0a4efed69b87110fda20e68eb6feed2d5101a4955d43759f10b73e8ffc3131e0c12a765b68bd216ed1ec4f5d2f"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000474acdfd2ab763c593bca30d248f2bf26f1843acf9eb89b4dfcb8451d59683812cf3cbe9a264ea435912a8969c53d7cb8496dcb0a4efed69b87110fda20e68eb6feed2d5101a4955d43759f10b73e8ffc3131e0c12a765b68bd216ed1ec4f5d2f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEdKzf0qt2PFk7yjDSSPK/JvGEOs+euJtN\n/LhFHVloOBLPPL6aJk6kNZEqiWnFPXy4SW3LCk7+1puHEQ/aIOaOtv7tLVEBpJVd\nQ3WfELc+j/wxMeDBKnZbaL0hbtHsT10v\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000474acdfd2ab763c593bca30d248f2bf26f1843acf9eb89b4dfcb8451d59683812cf3cbe9a264ea435912a8969c53d7cb8496dcb0a4efed69b87110fda20e68eb6feed2d5101a4955d43759f10b73e8ffc3131e0c12a765b68bd216ed1ec4f5d2f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEdKzf0qt2PFk7yjDSSPK/JvGEOs+euJtN\n/LhFHVloOBLPPL6aJk6kNZEqiWnFPXy4SW3LCk7+1puHEQ/aIOaOtv7tLVEBpJVd\nQ3WfELc+j/wxMeDBKnZbaL0hbtHsT10v\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 387,
+          "tcId" : 490,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "306502307ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd023100dfea06865526cea11c0f9eb9512b41fa9581d0f6cb7db9680336151dce79de818cdf33c879da322740416d1e5ae532fa",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04da35d6a82818ae5254cb65fc86ac42a47873ab247a5ca664e9f095e8de9a57fe721860e66cbc6bd499431a48a3991734945baab27ca6383737b7dd45023f997aff5e165f0fd7d8e5c0b5f9c5e731588af2fe5bd8976a0b871c132edf21f363af",
-        "wx" : "0da35d6a82818ae5254cb65fc86ac42a47873ab247a5ca664e9f095e8de9a57fe721860e66cbc6bd499431a48a3991734",
-        "wy" : "0945baab27ca6383737b7dd45023f997aff5e165f0fd7d8e5c0b5f9c5e731588af2fe5bd8976a0b871c132edf21f363af"
+        "wx" : "00da35d6a82818ae5254cb65fc86ac42a47873ab247a5ca664e9f095e8de9a57fe721860e66cbc6bd499431a48a3991734",
+        "wy" : "00945baab27ca6383737b7dd45023f997aff5e165f0fd7d8e5c0b5f9c5e731588af2fe5bd8976a0b871c132edf21f363af"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004da35d6a82818ae5254cb65fc86ac42a47873ab247a5ca664e9f095e8de9a57fe721860e66cbc6bd499431a48a3991734945baab27ca6383737b7dd45023f997aff5e165f0fd7d8e5c0b5f9c5e731588af2fe5bd8976a0b871c132edf21f363af",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE2jXWqCgYrlJUy2X8hqxCpHhzqyR6XKZk\n6fCV6N6aV/5yGGDmbLxr1JlDGkijmRc0lFuqsnymODc3t91FAj+Zev9eFl8P19jl\nwLX5xecxWIry/lvYl2oLhxwTLt8h82Ov\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004da35d6a82818ae5254cb65fc86ac42a47873ab247a5ca664e9f095e8de9a57fe721860e66cbc6bd499431a48a3991734945baab27ca6383737b7dd45023f997aff5e165f0fd7d8e5c0b5f9c5e731588af2fe5bd8976a0b871c132edf21f363af",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE2jXWqCgYrlJUy2X8hqxCpHhzqyR6XKZk\n6fCV6N6aV/5yGGDmbLxr1JlDGkijmRc0lFuqsnymODc3t91FAj+Zev9eFl8P19jl\nwLX5xecxWIry/lvYl2oLhxwTLt8h82Ov\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 388,
+          "tcId" : 491,
           "comment" : "point duplication during verification",
-          "msg" : "313233343030",
-          "sig" : "3066023100b37699e0d518a4d370dbdaaaea3788850fa03f8186d1f78fdfbae6540aa670b31c8ada0fff3e737bd69520560fe0ce60023100e16043c2face20228dba6366e19ecc6db71b918bbe8a890b9dad2fcead184e071c9ac4acaee2f831a1e4cc337994f5ec",
-          "result" : "valid",
           "flags" : [
             "PointDuplication"
-          ]
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100b37699e0d518a4d370dbdaaaea3788850fa03f8186d1f78fdfbae6540aa670b31c8ada0fff3e737bd69520560fe0ce60023100e16043c2face20228dba6366e19ecc6db71b918bbe8a890b9dad2fcead184e071c9ac4acaee2f831a1e4cc337994f5ec",
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04da35d6a82818ae5254cb65fc86ac42a47873ab247a5ca664e9f095e8de9a57fe721860e66cbc6bd499431a48a39917346ba4554d8359c7c8c84822bafdc0668500a1e9a0f028271a3f4a063a18cea7740d01a4266895f478e3ecd121de0c9c50",
-        "wx" : "0da35d6a82818ae5254cb65fc86ac42a47873ab247a5ca664e9f095e8de9a57fe721860e66cbc6bd499431a48a3991734",
+        "wx" : "00da35d6a82818ae5254cb65fc86ac42a47873ab247a5ca664e9f095e8de9a57fe721860e66cbc6bd499431a48a3991734",
         "wy" : "6ba4554d8359c7c8c84822bafdc0668500a1e9a0f028271a3f4a063a18cea7740d01a4266895f478e3ecd121de0c9c50"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004da35d6a82818ae5254cb65fc86ac42a47873ab247a5ca664e9f095e8de9a57fe721860e66cbc6bd499431a48a39917346ba4554d8359c7c8c84822bafdc0668500a1e9a0f028271a3f4a063a18cea7740d01a4266895f478e3ecd121de0c9c50",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE2jXWqCgYrlJUy2X8hqxCpHhzqyR6XKZk\n6fCV6N6aV/5yGGDmbLxr1JlDGkijmRc0a6RVTYNZx8jISCK6/cBmhQCh6aDwKCca\nP0oGOhjOp3QNAaQmaJX0eOPs0SHeDJxQ\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004da35d6a82818ae5254cb65fc86ac42a47873ab247a5ca664e9f095e8de9a57fe721860e66cbc6bd499431a48a39917346ba4554d8359c7c8c84822bafdc0668500a1e9a0f028271a3f4a063a18cea7740d01a4266895f478e3ecd121de0c9c50",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE2jXWqCgYrlJUy2X8hqxCpHhzqyR6XKZk\n6fCV6N6aV/5yGGDmbLxr1JlDGkijmRc0a6RVTYNZx8jISCK6/cBmhQCh6aDwKCca\nP0oGOhjOp3QNAaQmaJX0eOPs0SHeDJxQ\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 389,
+          "tcId" : 492,
           "comment" : "duplication bug",
-          "msg" : "313233343030",
-          "sig" : "3066023100b37699e0d518a4d370dbdaaaea3788850fa03f8186d1f78fdfbae6540aa670b31c8ada0fff3e737bd69520560fe0ce60023100e16043c2face20228dba6366e19ecc6db71b918bbe8a890b9dad2fcead184e071c9ac4acaee2f831a1e4cc337994f5ec",
-          "result" : "invalid",
           "flags" : [
             "PointDuplication"
-          ]
+          ],
+          "msg" : "313233343030",
+          "sig" : "3066023100b37699e0d518a4d370dbdaaaea3788850fa03f8186d1f78fdfbae6540aa670b31c8ada0fff3e737bd69520560fe0ce60023100e16043c2face20228dba6366e19ecc6db71b918bbe8a890b9dad2fcead184e071c9ac4acaee2f831a1e4cc337994f5ec",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04820064193c71c7141fe41e711fe843a7474be6b05f50cb0be411cdf7fc78ea7ec96aeb3991ef7646bbde59152d381a32631c5adf93d488b45e67cc9890d8e779f63960193dc16bd1cc136b3e28cf499dfa8e7bff482a0115e6083987f7c042fc",
-        "wx" : "0820064193c71c7141fe41e711fe843a7474be6b05f50cb0be411cdf7fc78ea7ec96aeb3991ef7646bbde59152d381a32",
+        "wx" : "00820064193c71c7141fe41e711fe843a7474be6b05f50cb0be411cdf7fc78ea7ec96aeb3991ef7646bbde59152d381a32",
         "wy" : "631c5adf93d488b45e67cc9890d8e779f63960193dc16bd1cc136b3e28cf499dfa8e7bff482a0115e6083987f7c042fc"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004820064193c71c7141fe41e711fe843a7474be6b05f50cb0be411cdf7fc78ea7ec96aeb3991ef7646bbde59152d381a32631c5adf93d488b45e67cc9890d8e779f63960193dc16bd1cc136b3e28cf499dfa8e7bff482a0115e6083987f7c042fc",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEggBkGTxxxxQf5B5xH+hDp0dL5rBfUMsL\n5BHN9/x46n7Jaus5ke92RrveWRUtOBoyYxxa35PUiLReZ8yYkNjnefY5YBk9wWvR\nzBNrPijPSZ36jnv/SCoBFeYIOYf3wEL8\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004820064193c71c7141fe41e711fe843a7474be6b05f50cb0be411cdf7fc78ea7ec96aeb3991ef7646bbde59152d381a32631c5adf93d488b45e67cc9890d8e779f63960193dc16bd1cc136b3e28cf499dfa8e7bff482a0115e6083987f7c042fc",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEggBkGTxxxxQf5B5xH+hDp0dL5rBfUMsL\n5BHN9/x46n7Jaus5ke92RrveWRUtOBoyYxxa35PUiLReZ8yYkNjnefY5YBk9wWvR\nzBNrPijPSZ36jnv/SCoBFeYIOYf3wEL8\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 390,
+          "tcId" : 493,
           "comment" : "point with x-coordinate 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3035020101023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0452fabc58eacfd3a4828f51c413205c20888941ee45ecac076ffc23145d83542034aa01253d6ebf34eeefaa371d6cee119f340712cd78155712746578f5632ded2b2e5afb43b085f81732792108e331a4b50d27f3578252ffb0daa9d78655a0ab",
         "wx" : "52fabc58eacfd3a4828f51c413205c20888941ee45ecac076ffc23145d83542034aa01253d6ebf34eeefaa371d6cee11",
-        "wy" : "09f340712cd78155712746578f5632ded2b2e5afb43b085f81732792108e331a4b50d27f3578252ffb0daa9d78655a0ab"
+        "wy" : "009f340712cd78155712746578f5632ded2b2e5afb43b085f81732792108e331a4b50d27f3578252ffb0daa9d78655a0ab"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000452fabc58eacfd3a4828f51c413205c20888941ee45ecac076ffc23145d83542034aa01253d6ebf34eeefaa371d6cee119f340712cd78155712746578f5632ded2b2e5afb43b085f81732792108e331a4b50d27f3578252ffb0daa9d78655a0ab",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEUvq8WOrP06SCj1HEEyBcIIiJQe5F7KwH\nb/wjFF2DVCA0qgElPW6/NO7vqjcdbO4RnzQHEs14FVcSdGV49WMt7SsuWvtDsIX4\nFzJ5IQjjMaS1DSfzV4JS/7DaqdeGVaCr\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000452fabc58eacfd3a4828f51c413205c20888941ee45ecac076ffc23145d83542034aa01253d6ebf34eeefaa371d6cee119f340712cd78155712746578f5632ded2b2e5afb43b085f81732792108e331a4b50d27f3578252ffb0daa9d78655a0ab",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEUvq8WOrP06SCj1HEEyBcIIiJQe5F7KwH\nb/wjFF2DVCA0qgElPW6/NO7vqjcdbO4RnzQHEs14FVcSdGV49WMt7SsuWvtDsIX4\nFzJ5IQjjMaS1DSfzV4JS/7DaqdeGVaCr\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 391,
+          "tcId" : 494,
           "comment" : "point with x-coordinate 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023101000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000023033333333333333333333333333333333333333333333333327e0a919fda4a2c644d202bd41bcee4bc8fc05155c276eb0",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04a8fdb1a022d4e3a7ee29612bb110acbea27daecb827d344cb6c6a7acad61d371ddc7842147b74a18767e618712f04c1c64ac6daf8e08cd7b90a0c9d9123884c7a7abb4664a75b0897064c3c8956b0ca9c417237f8d5a7dd8421b0d48c9d52c7c",
-        "wx" : "0a8fdb1a022d4e3a7ee29612bb110acbea27daecb827d344cb6c6a7acad61d371ddc7842147b74a18767e618712f04c1c",
+        "wx" : "00a8fdb1a022d4e3a7ee29612bb110acbea27daecb827d344cb6c6a7acad61d371ddc7842147b74a18767e618712f04c1c",
         "wy" : "64ac6daf8e08cd7b90a0c9d9123884c7a7abb4664a75b0897064c3c8956b0ca9c417237f8d5a7dd8421b0d48c9d52c7c"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004a8fdb1a022d4e3a7ee29612bb110acbea27daecb827d344cb6c6a7acad61d371ddc7842147b74a18767e618712f04c1c64ac6daf8e08cd7b90a0c9d9123884c7a7abb4664a75b0897064c3c8956b0ca9c417237f8d5a7dd8421b0d48c9d52c7c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqP2xoCLU46fuKWErsRCsvqJ9rsuCfTRM\ntsanrK1h03Hdx4QhR7dKGHZ+YYcS8EwcZKxtr44IzXuQoMnZEjiEx6ertGZKdbCJ\ncGTDyJVrDKnEFyN/jVp92EIbDUjJ1Sx8\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004a8fdb1a022d4e3a7ee29612bb110acbea27daecb827d344cb6c6a7acad61d371ddc7842147b74a18767e618712f04c1c64ac6daf8e08cd7b90a0c9d9123884c7a7abb4664a75b0897064c3c8956b0ca9c417237f8d5a7dd8421b0d48c9d52c7c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqP2xoCLU46fuKWErsRCsvqJ9rsuCfTRM\ntsanrK1h03Hdx4QhR7dKGHZ+YYcS8EwcZKxtr44IzXuQoMnZEjiEx6ertGZKdbCJ\ncGTDyJVrDKnEFyN/jVp92EIbDUjJ1Sx8\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 392,
+          "tcId" : 495,
           "comment" : "comparison with point at infinity ",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326023033333333333333333333333333333333333333333333333327e0a919fda4a2c644d202bd41bcee4bc8fc05155c276eb0",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04878e414a5d6a0e0d1ab3c5563c44e80c3b2ef265f27a33ed5cac109ad664c1269beae9031d8d178cbfdb1bfa7cc3cc79fabbb2b6f7ce54026863b0f297a4fe3de82d5044dacafede49d5afc60bc875f4b659c06c19bb74c7c27351687f52b411",
-        "wx" : "0878e414a5d6a0e0d1ab3c5563c44e80c3b2ef265f27a33ed5cac109ad664c1269beae9031d8d178cbfdb1bfa7cc3cc79",
-        "wy" : "0fabbb2b6f7ce54026863b0f297a4fe3de82d5044dacafede49d5afc60bc875f4b659c06c19bb74c7c27351687f52b411"
+        "wx" : "00878e414a5d6a0e0d1ab3c5563c44e80c3b2ef265f27a33ed5cac109ad664c1269beae9031d8d178cbfdb1bfa7cc3cc79",
+        "wy" : "00fabbb2b6f7ce54026863b0f297a4fe3de82d5044dacafede49d5afc60bc875f4b659c06c19bb74c7c27351687f52b411"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004878e414a5d6a0e0d1ab3c5563c44e80c3b2ef265f27a33ed5cac109ad664c1269beae9031d8d178cbfdb1bfa7cc3cc79fabbb2b6f7ce54026863b0f297a4fe3de82d5044dacafede49d5afc60bc875f4b659c06c19bb74c7c27351687f52b411",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEh45BSl1qDg0as8VWPEToDDsu8mXyejPt\nXKwQmtZkwSab6ukDHY0XjL/bG/p8w8x5+ruytvfOVAJoY7Dyl6T+PegtUETayv7e\nSdWvxgvIdfS2WcBsGbt0x8JzUWh/UrQR\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004878e414a5d6a0e0d1ab3c5563c44e80c3b2ef265f27a33ed5cac109ad664c1269beae9031d8d178cbfdb1bfa7cc3cc79fabbb2b6f7ce54026863b0f297a4fe3de82d5044dacafede49d5afc60bc875f4b659c06c19bb74c7c27351687f52b411",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEh45BSl1qDg0as8VWPEToDDsu8mXyejPt\nXKwQmtZkwSab6ukDHY0XjL/bG/p8w8x5+ruytvfOVAJoY7Dyl6T+PegtUETayv7e\nSdWvxgvIdfS2WcBsGbt0x8JzUWh/UrQR\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 393,
+          "tcId" : 496,
           "comment" : "extreme value for k and edgecase s",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023008d999057ba3d2d969260045c55b97f089025959a6f434d651d207d19fb96e9e4fe0e86ebe0e64f85b96a9c75295df61023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "048faa8497ae3006b612999b03f91f7884d95543a266598e897b71e44ecfd9abd7908bfd122bb366c016a577cb1b2e2e412bb1a719289c749804ca677d14c0900fab031da8c70724723a0d54e3a0035da7dcddeef6fce80df2f81940817d27b2b5",
-        "wx" : "08faa8497ae3006b612999b03f91f7884d95543a266598e897b71e44ecfd9abd7908bfd122bb366c016a577cb1b2e2e41",
+        "wx" : "008faa8497ae3006b612999b03f91f7884d95543a266598e897b71e44ecfd9abd7908bfd122bb366c016a577cb1b2e2e41",
         "wy" : "2bb1a719289c749804ca677d14c0900fab031da8c70724723a0d54e3a0035da7dcddeef6fce80df2f81940817d27b2b5"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200048faa8497ae3006b612999b03f91f7884d95543a266598e897b71e44ecfd9abd7908bfd122bb366c016a577cb1b2e2e412bb1a719289c749804ca677d14c0900fab031da8c70724723a0d54e3a0035da7dcddeef6fce80df2f81940817d27b2b5",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEj6qEl64wBrYSmZsD+R94hNlVQ6JmWY6J\ne3HkTs/Zq9eQi/0SK7NmwBald8sbLi5BK7GnGSicdJgEymd9FMCQD6sDHajHByRy\nOg1U46ADXafc3e72/OgN8vgZQIF9J7K1\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200048faa8497ae3006b612999b03f91f7884d95543a266598e897b71e44ecfd9abd7908bfd122bb366c016a577cb1b2e2e412bb1a719289c749804ca677d14c0900fab031da8c70724723a0d54e3a0035da7dcddeef6fce80df2f81940817d27b2b5",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEj6qEl64wBrYSmZsD+R94hNlVQ6JmWY6J\ne3HkTs/Zq9eQi/0SK7NmwBald8sbLi5BK7GnGSicdJgEymd9FMCQD6sDHajHByRy\nOg1U46ADXafc3e72/OgN8vgZQIF9J7K1\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 394,
+          "tcId" : 497,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023008d999057ba3d2d969260045c55b97f089025959a6f434d651d207d19fb96e9e4fe0e86ebe0e64f85b96a9c75295df6102302492492492492492492492492492492492492492492492491c7be680477598d6c3716fabc13dcec86afd2833d41c2a7e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04c59cc648629e62dc1855f653583da0ace631e0f4b4589b7fe5cc449e12df2dceeb862cae00cd100233b999af657ae16cb138f659dcc8d342fd17664d86c5bddaa866c20b0031f65c8442a0ed62b337d09adb63a443ab14e3587b9299053717f9",
-        "wx" : "0c59cc648629e62dc1855f653583da0ace631e0f4b4589b7fe5cc449e12df2dceeb862cae00cd100233b999af657ae16c",
-        "wy" : "0b138f659dcc8d342fd17664d86c5bddaa866c20b0031f65c8442a0ed62b337d09adb63a443ab14e3587b9299053717f9"
+        "wx" : "00c59cc648629e62dc1855f653583da0ace631e0f4b4589b7fe5cc449e12df2dceeb862cae00cd100233b999af657ae16c",
+        "wy" : "00b138f659dcc8d342fd17664d86c5bddaa866c20b0031f65c8442a0ed62b337d09adb63a443ab14e3587b9299053717f9"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004c59cc648629e62dc1855f653583da0ace631e0f4b4589b7fe5cc449e12df2dceeb862cae00cd100233b999af657ae16cb138f659dcc8d342fd17664d86c5bddaa866c20b0031f65c8442a0ed62b337d09adb63a443ab14e3587b9299053717f9",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAExZzGSGKeYtwYVfZTWD2grOYx4PS0WJt/\n5cxEnhLfLc7rhiyuAM0QAjO5ma9leuFssTj2WdzI00L9F2ZNhsW92qhmwgsAMfZc\nhEKg7WKzN9Ca22OkQ6sU41h7kpkFNxf5\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004c59cc648629e62dc1855f653583da0ace631e0f4b4589b7fe5cc449e12df2dceeb862cae00cd100233b999af657ae16cb138f659dcc8d342fd17664d86c5bddaa866c20b0031f65c8442a0ed62b337d09adb63a443ab14e3587b9299053717f9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAExZzGSGKeYtwYVfZTWD2grOYx4PS0WJt/\n5cxEnhLfLc7rhiyuAM0QAjO5ma9leuFssTj2WdzI00L9F2ZNhsW92qhmwgsAMfZc\nhEKg7WKzN9Ca22OkQ6sU41h7kpkFNxf5\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 395,
+          "tcId" : 498,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023008d999057ba3d2d969260045c55b97f089025959a6f434d651d207d19fb96e9e4fe0e86ebe0e64f85b96a9c75295df6102306666666666666666666666666666666666666666666666664fc15233fb49458c89a4057a8379dc9791f80a2ab84edd61",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04386bdc98fe3c156a790eee6d556e0036a4b84853358bd5ab6856db5985b9e8ea92e8d4c1f8d04ecd1e6de4548bf288215503292c2c570f57b42f2caf5e7ab94d87817a800b2af6ffcd4f13e30edb8caaf23c6d5be22abea18c2f9450ad1a4715",
         "wx" : "386bdc98fe3c156a790eee6d556e0036a4b84853358bd5ab6856db5985b9e8ea92e8d4c1f8d04ecd1e6de4548bf28821",
         "wy" : "5503292c2c570f57b42f2caf5e7ab94d87817a800b2af6ffcd4f13e30edb8caaf23c6d5be22abea18c2f9450ad1a4715"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004386bdc98fe3c156a790eee6d556e0036a4b84853358bd5ab6856db5985b9e8ea92e8d4c1f8d04ecd1e6de4548bf288215503292c2c570f57b42f2caf5e7ab94d87817a800b2af6ffcd4f13e30edb8caaf23c6d5be22abea18c2f9450ad1a4715",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOGvcmP48FWp5Du5tVW4ANqS4SFM1i9Wr\naFbbWYW56OqS6NTB+NBOzR5t5FSL8oghVQMpLCxXD1e0LyyvXnq5TYeBeoALKvb/\nzU8T4w7bjKryPG1b4iq+oYwvlFCtGkcV\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004386bdc98fe3c156a790eee6d556e0036a4b84853358bd5ab6856db5985b9e8ea92e8d4c1f8d04ecd1e6de4548bf288215503292c2c570f57b42f2caf5e7ab94d87817a800b2af6ffcd4f13e30edb8caaf23c6d5be22abea18c2f9450ad1a4715",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEOGvcmP48FWp5Du5tVW4ANqS4SFM1i9Wr\naFbbWYW56OqS6NTB+NBOzR5t5FSL8oghVQMpLCxXD1e0LyyvXnq5TYeBeoALKvb/\nzU8T4w7bjKryPG1b4iq+oYwvlFCtGkcV\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 396,
+          "tcId" : 499,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023008d999057ba3d2d969260045c55b97f089025959a6f434d651d207d19fb96e9e4fe0e86ebe0e64f85b96a9c75295df6102310099999999999999999999999999999999999999999999999977a1fb4df8ede852ce760837c536cae35af40f4014764c12",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04294c37b3ec91a1b0500042d8b97bc9619d17f784a9ea528c0602d700783bfbac9ac49bff1e527b39bb2a49d1dc3abd471e798679b7c58f4dfa33cfe40bb62e7df6d2f190b0f3804c700fa19eba28ad7fd6edd7e3a754af852921c2705f444f0b",
         "wx" : "294c37b3ec91a1b0500042d8b97bc9619d17f784a9ea528c0602d700783bfbac9ac49bff1e527b39bb2a49d1dc3abd47",
         "wy" : "1e798679b7c58f4dfa33cfe40bb62e7df6d2f190b0f3804c700fa19eba28ad7fd6edd7e3a754af852921c2705f444f0b"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004294c37b3ec91a1b0500042d8b97bc9619d17f784a9ea528c0602d700783bfbac9ac49bff1e527b39bb2a49d1dc3abd471e798679b7c58f4dfa33cfe40bb62e7df6d2f190b0f3804c700fa19eba28ad7fd6edd7e3a754af852921c2705f444f0b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEKUw3s+yRobBQAELYuXvJYZ0X94Sp6lKM\nBgLXAHg7+6yaxJv/HlJ7ObsqSdHcOr1HHnmGebfFj036M8/kC7YuffbS8ZCw84BM\ncA+hnroorX/W7dfjp1SvhSkhwnBfRE8L\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004294c37b3ec91a1b0500042d8b97bc9619d17f784a9ea528c0602d700783bfbac9ac49bff1e527b39bb2a49d1dc3abd471e798679b7c58f4dfa33cfe40bb62e7df6d2f190b0f3804c700fa19eba28ad7fd6edd7e3a754af852921c2705f444f0b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEKUw3s+yRobBQAELYuXvJYZ0X94Sp6lKM\nBgLXAHg7+6yaxJv/HlJ7ObsqSdHcOr1HHnmGebfFj036M8/kC7YuffbS8ZCw84BM\ncA+hnroorX/W7dfjp1SvhSkhwnBfRE8L\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 397,
+          "tcId" : 500,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023008d999057ba3d2d969260045c55b97f089025959a6f434d651d207d19fb96e9e4fe0e86ebe0e64f85b96a9c75295df61023100db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6aae76701acc1950894a89e068772d8b281eef136f8a8fef5",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04bac7cd8a7755a174fab58e5374ec55a5ce5313235ec51c919c6684bd49305b7005393f72bc4d810ca864fb046d2c83415a33b77f4145680bde63b669ea1f10f3ee1836018c11a6f97155d90827c83dbac388402ac8f59368ddaf2c33548611af",
-        "wx" : "0bac7cd8a7755a174fab58e5374ec55a5ce5313235ec51c919c6684bd49305b7005393f72bc4d810ca864fb046d2c8341",
+        "wx" : "00bac7cd8a7755a174fab58e5374ec55a5ce5313235ec51c919c6684bd49305b7005393f72bc4d810ca864fb046d2c8341",
         "wy" : "5a33b77f4145680bde63b669ea1f10f3ee1836018c11a6f97155d90827c83dbac388402ac8f59368ddaf2c33548611af"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004bac7cd8a7755a174fab58e5374ec55a5ce5313235ec51c919c6684bd49305b7005393f72bc4d810ca864fb046d2c83415a33b77f4145680bde63b669ea1f10f3ee1836018c11a6f97155d90827c83dbac388402ac8f59368ddaf2c33548611af",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEusfNindVoXT6tY5TdOxVpc5TEyNexRyR\nnGaEvUkwW3AFOT9yvE2BDKhk+wRtLINBWjO3f0FFaAveY7Zp6h8Q8+4YNgGMEab5\ncVXZCCfIPbrDiEAqyPWTaN2vLDNUhhGv\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004bac7cd8a7755a174fab58e5374ec55a5ce5313235ec51c919c6684bd49305b7005393f72bc4d810ca864fb046d2c83415a33b77f4145680bde63b669ea1f10f3ee1836018c11a6f97155d90827c83dbac388402ac8f59368ddaf2c33548611af",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEusfNindVoXT6tY5TdOxVpc5TEyNexRyR\nnGaEvUkwW3AFOT9yvE2BDKhk+wRtLINBWjO3f0FFaAveY7Zp6h8Q8+4YNgGMEab5\ncVXZCCfIPbrDiEAqyPWTaN2vLDNUhhGv\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 398,
+          "tcId" : 501,
           "comment" : "extreme value for k",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023008d999057ba3d2d969260045c55b97f089025959a6f434d651d207d19fb96e9e4fe0e86ebe0e64f85b96a9c75295df6102300eb10e5ab95f2f26a40700b1300fb8c3e754d5c453d9384ecce1daa38135a48a0a96c24efc2a76d00bde1d7aeedf7f6a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04984a1c04446a52ad6a54d64f2c6c49b61f23abe7dc6f33714896aefb0befb9a52b95b048561132c28c9850e851a6d00eb4e19f9de59d30ca26801f2789a3330b081e6bf57f84f3c6107defd05a959cef5f298acea5a6b87b38e22c5409ec9f71",
-        "wx" : "0984a1c04446a52ad6a54d64f2c6c49b61f23abe7dc6f33714896aefb0befb9a52b95b048561132c28c9850e851a6d00e",
-        "wy" : "0b4e19f9de59d30ca26801f2789a3330b081e6bf57f84f3c6107defd05a959cef5f298acea5a6b87b38e22c5409ec9f71"
+        "wx" : "00984a1c04446a52ad6a54d64f2c6c49b61f23abe7dc6f33714896aefb0befb9a52b95b048561132c28c9850e851a6d00e",
+        "wy" : "00b4e19f9de59d30ca26801f2789a3330b081e6bf57f84f3c6107defd05a959cef5f298acea5a6b87b38e22c5409ec9f71"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004984a1c04446a52ad6a54d64f2c6c49b61f23abe7dc6f33714896aefb0befb9a52b95b048561132c28c9850e851a6d00eb4e19f9de59d30ca26801f2789a3330b081e6bf57f84f3c6107defd05a959cef5f298acea5a6b87b38e22c5409ec9f71",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEmEocBERqUq1qVNZPLGxJth8jq+fcbzNx\nSJau+wvvuaUrlbBIVhEywoyYUOhRptAOtOGfneWdMMomgB8niaMzCwgea/V/hPPG\nEH3v0FqVnO9fKYrOpaa4ezjiLFQJ7J9x\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004984a1c04446a52ad6a54d64f2c6c49b61f23abe7dc6f33714896aefb0befb9a52b95b048561132c28c9850e851a6d00eb4e19f9de59d30ca26801f2789a3330b081e6bf57f84f3c6107defd05a959cef5f298acea5a6b87b38e22c5409ec9f71",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEmEocBERqUq1qVNZPLGxJth8jq+fcbzNx\nSJau+wvvuaUrlbBIVhEywoyYUOhRptAOtOGfneWdMMomgB8niaMzCwgea/V/hPPG\nEH3v0FqVnO9fKYrOpaa4ezjiLFQJ7J9x\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 399,
+          "tcId" : 502,
           "comment" : "extreme value for k and edgecase s",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7023055555555555555555555555555555555555555555555555542766f2b5167b9f51d5e0490c2e58d28f9a40878eeec6326",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04f00d6327b1226eaa1b0897295eeddadf7510249e6f0f811b57d7197eb6e61199a8f1c6665ec4821d3e18675d5399fdf787bf1e3fb7fee5cb3582a4159808b75e8b1de07eaffd49d3882d15c77443ad83213d21a4be9285223aa44a840e47eb56",
-        "wx" : "0f00d6327b1226eaa1b0897295eeddadf7510249e6f0f811b57d7197eb6e61199a8f1c6665ec4821d3e18675d5399fdf7",
-        "wy" : "087bf1e3fb7fee5cb3582a4159808b75e8b1de07eaffd49d3882d15c77443ad83213d21a4be9285223aa44a840e47eb56"
+        "wx" : "00f00d6327b1226eaa1b0897295eeddadf7510249e6f0f811b57d7197eb6e61199a8f1c6665ec4821d3e18675d5399fdf7",
+        "wy" : "0087bf1e3fb7fee5cb3582a4159808b75e8b1de07eaffd49d3882d15c77443ad83213d21a4be9285223aa44a840e47eb56"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004f00d6327b1226eaa1b0897295eeddadf7510249e6f0f811b57d7197eb6e61199a8f1c6665ec4821d3e18675d5399fdf787bf1e3fb7fee5cb3582a4159808b75e8b1de07eaffd49d3882d15c77443ad83213d21a4be9285223aa44a840e47eb56",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8A1jJ7EibqobCJcpXu3a33UQJJ5vD4Eb\nV9cZfrbmEZmo8cZmXsSCHT4YZ11Tmf33h78eP7f+5cs1gqQVmAi3Xosd4H6v/UnT\niC0Vx3RDrYMhPSGkvpKFIjqkSoQOR+tW\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004f00d6327b1226eaa1b0897295eeddadf7510249e6f0f811b57d7197eb6e61199a8f1c6665ec4821d3e18675d5399fdf787bf1e3fb7fee5cb3582a4159808b75e8b1de07eaffd49d3882d15c77443ad83213d21a4be9285223aa44a840e47eb56",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE8A1jJ7EibqobCJcpXu3a33UQJJ5vD4Eb\nV9cZfrbmEZmo8cZmXsSCHT4YZ11Tmf33h78eP7f+5cs1gqQVmAi3Xosd4H6v/UnT\niC0Vx3RDrYMhPSGkvpKFIjqkSoQOR+tW\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 400,
+          "tcId" : 503,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab702302492492492492492492492492492492492492492492492491c7be680477598d6c3716fabc13dcec86afd2833d41c2a7e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04452b047743346898b087daaac5d982d378752ba534e569f21ac592c09654d0809b94ccf822045f2885cbd3b221453cd668a01f502f551af14aab35c2c30ec7bac0709f525fe7960439b1e9de53cdad245efd8930967cde6caf8d222c8200cd69",
         "wx" : "452b047743346898b087daaac5d982d378752ba534e569f21ac592c09654d0809b94ccf822045f2885cbd3b221453cd6",
         "wy" : "68a01f502f551af14aab35c2c30ec7bac0709f525fe7960439b1e9de53cdad245efd8930967cde6caf8d222c8200cd69"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004452b047743346898b087daaac5d982d378752ba534e569f21ac592c09654d0809b94ccf822045f2885cbd3b221453cd668a01f502f551af14aab35c2c30ec7bac0709f525fe7960439b1e9de53cdad245efd8930967cde6caf8d222c8200cd69",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERSsEd0M0aJiwh9qqxdmC03h1K6U05Wny\nGsWSwJZU0ICblMz4IgRfKIXL07IhRTzWaKAfUC9VGvFKqzXCww7HusBwn1Jf55YE\nObHp3lPNrSRe/YkwlnzebK+NIiyCAM1p\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004452b047743346898b087daaac5d982d378752ba534e569f21ac592c09654d0809b94ccf822045f2885cbd3b221453cd668a01f502f551af14aab35c2c30ec7bac0709f525fe7960439b1e9de53cdad245efd8930967cde6caf8d222c8200cd69",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERSsEd0M0aJiwh9qqxdmC03h1K6U05Wny\nGsWSwJZU0ICblMz4IgRfKIXL07IhRTzWaKAfUC9VGvFKqzXCww7HusBwn1Jf55YE\nObHp3lPNrSRe/YkwlnzebK+NIiyCAM1p\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 401,
+          "tcId" : 504,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab702306666666666666666666666666666666666666666666666664fc15233fb49458c89a4057a8379dc9791f80a2ab84edd61",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0444a8f54795bdb81e00fc84fa8373d125b16da6e2bf4cfa9ee1dc13d7f157394683963c170f4c15e8cf21b5466b49fa72bb5693655b3e0a85e27e3e6d265fba0131f3083bf447f62b6e3e5275496f34daa522e16195d81488a31fe982c2b75f16",
         "wx" : "44a8f54795bdb81e00fc84fa8373d125b16da6e2bf4cfa9ee1dc13d7f157394683963c170f4c15e8cf21b5466b49fa72",
-        "wy" : "0bb5693655b3e0a85e27e3e6d265fba0131f3083bf447f62b6e3e5275496f34daa522e16195d81488a31fe982c2b75f16"
+        "wy" : "00bb5693655b3e0a85e27e3e6d265fba0131f3083bf447f62b6e3e5275496f34daa522e16195d81488a31fe982c2b75f16"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000444a8f54795bdb81e00fc84fa8373d125b16da6e2bf4cfa9ee1dc13d7f157394683963c170f4c15e8cf21b5466b49fa72bb5693655b3e0a85e27e3e6d265fba0131f3083bf447f62b6e3e5275496f34daa522e16195d81488a31fe982c2b75f16",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERKj1R5W9uB4A/IT6g3PRJbFtpuK/TPqe\n4dwT1/FXOUaDljwXD0wV6M8htUZrSfpyu1aTZVs+CoXifj5tJl+6ATHzCDv0R/Yr\nbj5SdUlvNNqlIuFhldgUiKMf6YLCt18W\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000444a8f54795bdb81e00fc84fa8373d125b16da6e2bf4cfa9ee1dc13d7f157394683963c170f4c15e8cf21b5466b49fa72bb5693655b3e0a85e27e3e6d265fba0131f3083bf447f62b6e3e5275496f34daa522e16195d81488a31fe982c2b75f16",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAERKj1R5W9uB4A/IT6g3PRJbFtpuK/TPqe\n4dwT1/FXOUaDljwXD0wV6M8htUZrSfpyu1aTZVs+CoXifj5tJl+6ATHzCDv0R/Yr\nbj5SdUlvNNqlIuFhldgUiKMf6YLCt18W\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 402,
+          "tcId" : 505,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3066023100aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab702310099999999999999999999999999999999999999999999999977a1fb4df8ede852ce760837c536cae35af40f4014764c12",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0410b336b3afb80c80ff50716e734110fe83cd5b8d41d7f2f94f0dec7ecf1facc663babb8ed94e4bdf3592e37464970afa9be144d354e9b456873c6387a12a3eefd3e2feb66f7519ac72ac502c09d20d72cae9d04c88549a285c081023e1c1da08",
         "wx" : "10b336b3afb80c80ff50716e734110fe83cd5b8d41d7f2f94f0dec7ecf1facc663babb8ed94e4bdf3592e37464970afa",
-        "wy" : "09be144d354e9b456873c6387a12a3eefd3e2feb66f7519ac72ac502c09d20d72cae9d04c88549a285c081023e1c1da08"
+        "wy" : "009be144d354e9b456873c6387a12a3eefd3e2feb66f7519ac72ac502c09d20d72cae9d04c88549a285c081023e1c1da08"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000410b336b3afb80c80ff50716e734110fe83cd5b8d41d7f2f94f0dec7ecf1facc663babb8ed94e4bdf3592e37464970afa9be144d354e9b456873c6387a12a3eefd3e2feb66f7519ac72ac502c09d20d72cae9d04c88549a285c081023e1c1da08",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEELM2s6+4DID/UHFuc0EQ/oPNW41B1/L5\nTw3sfs8frMZjuruO2U5L3zWS43Rklwr6m+FE01TptFaHPGOHoSo+79Pi/rZvdRms\ncqxQLAnSDXLK6dBMiFSaKFwIECPhwdoI\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000410b336b3afb80c80ff50716e734110fe83cd5b8d41d7f2f94f0dec7ecf1facc663babb8ed94e4bdf3592e37464970afa9be144d354e9b456873c6387a12a3eefd3e2feb66f7519ac72ac502c09d20d72cae9d04c88549a285c081023e1c1da08",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEELM2s6+4DID/UHFuc0EQ/oPNW41B1/L5\nTw3sfs8frMZjuruO2U5L3zWS43Rklwr6m+FE01TptFaHPGOHoSo+79Pi/rZvdRms\ncqxQLAnSDXLK6dBMiFSaKFwIECPhwdoI\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 403,
+          "tcId" : 506,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3066023100aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7023100db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6aae76701acc1950894a89e068772d8b281eef136f8a8fef5",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "0481f92630778777a01781e7924fced35fc09018d9b00820881b14a814c1836a1f73c3641f7a17c821ffd95da902efe132221d81323509391f7b61bd796011337e6af36ae0798c17043d79e8efcdae8e724adf96a2309207c2d2cfd88e8c483acb",
-        "wx" : "081f92630778777a01781e7924fced35fc09018d9b00820881b14a814c1836a1f73c3641f7a17c821ffd95da902efe132",
+        "wx" : "0081f92630778777a01781e7924fced35fc09018d9b00820881b14a814c1836a1f73c3641f7a17c821ffd95da902efe132",
         "wy" : "221d81323509391f7b61bd796011337e6af36ae0798c17043d79e8efcdae8e724adf96a2309207c2d2cfd88e8c483acb"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000481f92630778777a01781e7924fced35fc09018d9b00820881b14a814c1836a1f73c3641f7a17c821ffd95da902efe132221d81323509391f7b61bd796011337e6af36ae0798c17043d79e8efcdae8e724adf96a2309207c2d2cfd88e8c483acb",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgfkmMHeHd6AXgeeST87TX8CQGNmwCCCI\nGxSoFMGDah9zw2QfehfIIf/ZXakC7+EyIh2BMjUJOR97Yb15YBEzfmrzauB5jBcE\nPXno782ujnJK35aiMJIHwtLP2I6MSDrL\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b810400220362000481f92630778777a01781e7924fced35fc09018d9b00820881b14a814c1836a1f73c3641f7a17c821ffd95da902efe132221d81323509391f7b61bd796011337e6af36ae0798c17043d79e8efcdae8e724adf96a2309207c2d2cfd88e8c483acb",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEgfkmMHeHd6AXgeeST87TX8CQGNmwCCCI\nGxSoFMGDah9zw2QfehfIIf/ZXakC7+EyIh2BMjUJOR97Yb15YBEzfmrzauB5jBcE\nPXno782ujnJK35aiMJIHwtLP2I6MSDrL\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 404,
+          "tcId" : 507,
           "comment" : "extreme value for k",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab702300eb10e5ab95f2f26a40700b1300fb8c3e754d5c453d9384ecce1daa38135a48a0a96c24efc2a76d00bde1d7aeedf7f6a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab73617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f",
-        "wx" : "0aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
+        "wx" : "00aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
         "wy" : "3617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab73617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqofKIr6LBTeOscce8yCtdG4dO2KLp5uY\nWfdB4IJUKjhVAvJdv1UpbDpUXjhydgq3NhfeSpYmLG9dnpi/kpLcKfj0Hb0omhR8\n6doxE7XwuMAKYLHOHX6BnXpDHXyQ6g5f\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab73617de4a96262c6f5d9e98bf9292dc29f8f41dbd289a147ce9da3113b5f0b8c00a60b1ce1d7e819d7a431d7c90ea0e5f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqofKIr6LBTeOscce8yCtdG4dO2KLp5uY\nWfdB4IJUKjhVAvJdv1UpbDpUXjhydgq3NhfeSpYmLG9dnpi/kpLcKfj0Hb0omhR8\n6doxE7XwuMAKYLHOHX6BnXpDHXyQ6g5f\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 405,
-          "comment" : "testing point duplication",
+          "tcId" : 508,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b023210281757b30e19218a37cbd612086fbc158ca02302492492492492492492492492492492492492492492492491c7be680477598d6c3716fabc13dcec86afd2833d41c2a7e",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 406,
-          "comment" : "testing point duplication",
+          "tcId" : 509,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100bc07ff041506dc73a75086a43252fb43b6327af3c6b2cc7d322ff6d1d1162b5de29edcd0b69803fe2f8af8e3d103d0a902302492492492492492492492492492492492492492492492491c7be680477598d6c3716fabc13dcec86afd2833d41c2a7e",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7c9e821b569d9d390a26167406d6d23d6070be242d765eb831625ceec4a0f473ef59f4e30e2817e6285bce2846f15f1a0",
-        "wx" : "0aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
-        "wy" : "0c9e821b569d9d390a26167406d6d23d6070be242d765eb831625ceec4a0f473ef59f4e30e2817e6285bce2846f15f1a0"
+        "wx" : "00aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7",
+        "wy" : "00c9e821b569d9d390a26167406d6d23d6070be242d765eb831625ceec4a0f473ef59f4e30e2817e6285bce2846f15f1a0"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7c9e821b569d9d390a26167406d6d23d6070be242d765eb831625ceec4a0f473ef59f4e30e2817e6285bce2846f15f1a0",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqofKIr6LBTeOscce8yCtdG4dO2KLp5uY\nWfdB4IJUKjhVAvJdv1UpbDpUXjhydgq3yeghtWnZ05CiYWdAbW0j1gcL4kLXZeuD\nFiXO7EoPRz71n04w4oF+YoW84oRvFfGg\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004aa87ca22be8b05378eb1c71ef320ad746e1d3b628ba79b9859f741e082542a385502f25dbf55296c3a545e3872760ab7c9e821b569d9d390a26167406d6d23d6070be242d765eb831625ceec4a0f473ef59f4e30e2817e6285bce2846f15f1a0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEqofKIr6LBTeOscce8yCtdG4dO2KLp5uY\nWfdB4IJUKjhVAvJdv1UpbDpUXjhydgq3yeghtWnZ05CiYWdAbW0j1gcL4kLXZeuD\nFiXO7EoPRz71n04w4oF+YoW84oRvFfGg\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 407,
-          "comment" : "testing point duplication",
+          "tcId" : 510,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "3064023043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b023210281757b30e19218a37cbd612086fbc158ca02302492492492492492492492492492492492492492492492491c7be680477598d6c3716fabc13dcec86afd2833d41c2a7e",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 408,
-          "comment" : "testing point duplication",
+          "tcId" : 511,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "3065023100bc07ff041506dc73a75086a43252fb43b6327af3c6b2cc7d322ff6d1d1162b5de29edcd0b69803fe2f8af8e3d103d0a902302492492492492492492492492492492492492492492492491c7be680477598d6c3716fabc13dcec86afd2833d41c2a7e",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
-        "uncompressed" : "0429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
-        "wx" : "29bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc",
-        "wy" : "09a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3"
-      },
-      "keyDer" : "3076301006072a8648ce3d020106052b810400220362000429bdb76d5fa741bfd70233cb3a66cc7d44beb3b0663d92a8136650478bcefb61ef182e155a54345a5e8e5e88f064e5bc9a525ab7f764dad3dae1468c2b419f3b62b9ba917d5e8c4fb1ec47404a3fc76474b2713081be9db4c00e043ada9fc4a3",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEKb23bV+nQb/XAjPLOmbMfUS+s7BmPZKo\nE2ZQR4vO+2HvGC4VWlQ0Wl6OXojwZOW8mlJat/dk2tPa4UaMK0GfO2K5upF9XoxP\nsexHQEo/x2R0snEwgb6dtMAOBDran8Sj\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-512",
-      "type" : "ECDSAVer",
-      "tests" : [
-        {
-          "tcId" : 409,
-          "comment" : "pseudorandom signature",
-          "msg" : "",
-          "sig" : "306402302290c886bbad8f53089583d543a269a727665626d6b94a3796324c62d08988f66f6011e845811a03589e92abe1f17faf023066e2cb4380997f4e7f85022541adb22d24d1196be68a3db888b03eb3d2d40b0d9a3a6a00a1a4782ee0a00e8410ba2d86",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 410,
-          "comment" : "pseudorandom signature",
-          "msg" : "4d7367",
-          "sig" : "30650231008071d8cf9df9efef696ebafc59f74db90c1f1ecf5ccde18858de22fe4d7df2a25cb3001695d706dfd7984b39df65a0f4023027291e6339c2a7fed7a174bb97ffe41d8cfdc20c1260c6ec85d7259f0cc7781bf2ae7a6e6fb4c08e0d75b7381bb7d9b8",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 411,
-          "comment" : "pseudorandom signature",
-          "msg" : "313233343030",
-          "sig" : "30650230470014ccd7a1a5e5333d301c8ea528ac3b07b01944af30cec60f4bad94db108509e45ba381818b5bdfaf9daf0d372301023100e3d49d6a05a755aa871d7cb96fffb79fed7625f83f69498ba07c0d65166a67107c9a17ae6e1028e244377a44096217b2",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 412,
-          "comment" : "pseudorandom signature",
-          "msg" : "0000000000000000000000000000000000000000",
-          "sig" : "30640230377044d343f900175ac6833071be74964cd636417039e10e837da94b6919bffc3f5a517b945a450852af3259f5cbf108023032ea25006375c153581e80c09f53ad585c736f823c70147aba4fb47bb0a224fae4d8819adad80d4c144ecc2380954a9e",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp384r1",
-        "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04ffffffffaa63f1a239ac70197c6ebfcea5756dc012123f82c51fa874d66028be00e976a1080606737cc75c40bdfe4aacacbd85389088a62a6398384c22b52d492f23f46e4a27a4724ad55551da5c483438095a247cb0c3378f1f52c3425ff9f1",
-        "wx" : "0ffffffffaa63f1a239ac70197c6ebfcea5756dc012123f82c51fa874d66028be00e976a1080606737cc75c40bdfe4aac",
-        "wy" : "0acbd85389088a62a6398384c22b52d492f23f46e4a27a4724ad55551da5c483438095a247cb0c3378f1f52c3425ff9f1"
+        "wx" : "00ffffffffaa63f1a239ac70197c6ebfcea5756dc012123f82c51fa874d66028be00e976a1080606737cc75c40bdfe4aac",
+        "wy" : "00acbd85389088a62a6398384c22b52d492f23f46e4a27a4724ad55551da5c483438095a247cb0c3378f1f52c3425ff9f1"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004ffffffffaa63f1a239ac70197c6ebfcea5756dc012123f82c51fa874d66028be00e976a1080606737cc75c40bdfe4aacacbd85389088a62a6398384c22b52d492f23f46e4a27a4724ad55551da5c483438095a247cb0c3378f1f52c3425ff9f1",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE/////6pj8aI5rHAZfG6/zqV1bcASEj+C\nxR+odNZgKL4A6XahCAYGc3zHXEC9/kqsrL2FOJCIpipjmDhMIrUtSS8j9G5KJ6Ry\nStVVUdpcSDQ4CVokfLDDN48fUsNCX/nx\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004ffffffffaa63f1a239ac70197c6ebfcea5756dc012123f82c51fa874d66028be00e976a1080606737cc75c40bdfe4aacacbd85389088a62a6398384c22b52d492f23f46e4a27a4724ad55551da5c483438095a247cb0c3378f1f52c3425ff9f1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE/////6pj8aI5rHAZfG6/zqV1bcASEj+C\nxR+odNZgKL4A6XahCAYGc3zHXEC9/kqsrL2FOJCIpipjmDhMIrUtSS8j9G5KJ6Ry\nStVVUdpcSDQ4CVokfLDDN48fUsNCX/nx\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 413,
+          "tcId" : 512,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3066023100ccb13c4dc9805a9b4e06ee25ef8c7593eaff7326c432d4b12b923163cf1cbe5fe1cfd3546c1d0761d8874e83ffd2e15d023100db1b0c082ae314b539f05e8a14ad51e5db37f29cacea9b2aab63a04917d58d008cf3f7ba41d5ea280f3b6a67be3ae8f8",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 414,
+          "tcId" : 513,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3065023100c79a30e36d2126b348dd9eb2f5db6aa98f79d80214027e51bcf3cabec188a7ebaf25cb7bbe9ec6bfed135e2a3b70e9160230241338ee2ac931adea9a56e7bfe909947128d54d5122a47b00c278e684e10102740d26e89e343290a5b2fa8b401faec6",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 415,
+          "tcId" : 514,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "306402300df82e4ec2960e3df614f8b49cec9a4ee1054365414241361feec9d9d9b6909d8775f222ec385a14afab46266db390c302300968485e854addba0f8354e677e955e1ef2df973d564c49f65f2562cb2a2b80d75e92f8784042955f7b8765f609ce221",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04d1827fc6f6f12f21992c5a409a0653b121d2ef02b2b0ab01a9161ce956280740b1e356b255701b0a6ddc9ec2ca8a9422c6ed5d2ced8d8ab7560fa5bb88c738e74541883d8a2b1c0e2ba7e36d030fc4d9bfb8b22f24db897ebac49dd400000000",
-        "wx" : "0d1827fc6f6f12f21992c5a409a0653b121d2ef02b2b0ab01a9161ce956280740b1e356b255701b0a6ddc9ec2ca8a9422",
-        "wy" : "0c6ed5d2ced8d8ab7560fa5bb88c738e74541883d8a2b1c0e2ba7e36d030fc4d9bfb8b22f24db897ebac49dd400000000"
+        "wx" : "00d1827fc6f6f12f21992c5a409a0653b121d2ef02b2b0ab01a9161ce956280740b1e356b255701b0a6ddc9ec2ca8a9422",
+        "wy" : "00c6ed5d2ced8d8ab7560fa5bb88c738e74541883d8a2b1c0e2ba7e36d030fc4d9bfb8b22f24db897ebac49dd400000000"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004d1827fc6f6f12f21992c5a409a0653b121d2ef02b2b0ab01a9161ce956280740b1e356b255701b0a6ddc9ec2ca8a9422c6ed5d2ced8d8ab7560fa5bb88c738e74541883d8a2b1c0e2ba7e36d030fc4d9bfb8b22f24db897ebac49dd400000000",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE0YJ/xvbxLyGZLFpAmgZTsSHS7wKysKsB\nqRYc6VYoB0Cx41ayVXAbCm3cnsLKipQixu1dLO2NirdWD6W7iMc450VBiD2KKxwO\nK6fjbQMPxNm/uLIvJNuJfrrEndQAAAAA\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004d1827fc6f6f12f21992c5a409a0653b121d2ef02b2b0ab01a9161ce956280740b1e356b255701b0a6ddc9ec2ca8a9422c6ed5d2ced8d8ab7560fa5bb88c738e74541883d8a2b1c0e2ba7e36d030fc4d9bfb8b22f24db897ebac49dd400000000",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE0YJ/xvbxLyGZLFpAmgZTsSHS7wKysKsB\nqRYc6VYoB0Cx41ayVXAbCm3cnsLKipQixu1dLO2NirdWD6W7iMc450VBiD2KKxwO\nK6fjbQMPxNm/uLIvJNuJfrrEndQAAAAA\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 416,
+          "tcId" : 515,
           "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "306402301fafd83d728422e1485f1e52e5b631548647cc3c76c109c3177a73751d91a19012fa4628b218f2229fc4d55f105fe00102304474f9af7b4b0bb96fdb05ae918f799024e8d5b864e49ccd047cf97e7b9f8763cce015c11cf1f461c9027cb901055101",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 417,
+          "tcId" : 516,
           "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3066023100e6025bb957ab197fb4c080d0a5c647e428afb0d7cc235c605ae97545494fd31a9979790bb2da6e1cf186789422b15c970231008ae9872291430d1bb371ef72360dad5afbb6fb001f403d9aaa1445f0326eb1eef775c9dfe1d7ef8bf4e744822108d27e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 418,
+          "tcId" : 517,
           "comment" : "y-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3066023100877d5567c18fa568259005a89c2300d1b3825b732fa14964c1477d4b3098afd09384b97d497464adba41e9df8a74d339023100c40f0760717b4b3bae75742b6dc3dcf04cc22a449cfea19d305e0658cb705fda75163e7399e0b3125ca7d1919c13851e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "041099bb45100f55f5a85cca3de2b3bd5e250f4f6fad6631a3156c2e52a33d7d615dd279f79f8b4baff7c713ac00000000e6c9b736a8929f2ed7be0c753a54cbb48b8469e0411eaf93a4a82459ba0b681bba8f5fb383b4906d4901a3303e2f1557",
         "wx" : "1099bb45100f55f5a85cca3de2b3bd5e250f4f6fad6631a3156c2e52a33d7d615dd279f79f8b4baff7c713ac00000000",
-        "wy" : "0e6c9b736a8929f2ed7be0c753a54cbb48b8469e0411eaf93a4a82459ba0b681bba8f5fb383b4906d4901a3303e2f1557"
+        "wy" : "00e6c9b736a8929f2ed7be0c753a54cbb48b8469e0411eaf93a4a82459ba0b681bba8f5fb383b4906d4901a3303e2f1557"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b81040022036200041099bb45100f55f5a85cca3de2b3bd5e250f4f6fad6631a3156c2e52a33d7d615dd279f79f8b4baff7c713ac00000000e6c9b736a8929f2ed7be0c753a54cbb48b8469e0411eaf93a4a82459ba0b681bba8f5fb383b4906d4901a3303e2f1557",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEEJm7RRAPVfWoXMo94rO9XiUPT2+tZjGj\nFWwuUqM9fWFd0nn3n4tLr/fHE6wAAAAA5sm3NqiSny7Xvgx1OlTLtIuEaeBBHq+T\npKgkWboLaBu6j1+zg7SQbUkBozA+LxVX\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b81040022036200041099bb45100f55f5a85cca3de2b3bd5e250f4f6fad6631a3156c2e52a33d7d615dd279f79f8b4baff7c713ac00000000e6c9b736a8929f2ed7be0c753a54cbb48b8469e0411eaf93a4a82459ba0b681bba8f5fb383b4906d4901a3303e2f1557",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEEJm7RRAPVfWoXMo94rO9XiUPT2+tZjGj\nFWwuUqM9fWFd0nn3n4tLr/fHE6wAAAAA5sm3NqiSny7Xvgx1OlTLtIuEaeBBHq+T\npKgkWboLaBu6j1+zg7SQbUkBozA+LxVX\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 419,
+          "tcId" : 518,
           "comment" : "x-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3065023100e706b0045a6f54bd175e2437b48767b0204f93d8a4d9d3d00838278137e5b670de4305c5c55e49059b8b5f6e264654c90230405741adff94afd9a88e08d0b1021911fa4cedb2466b1a8fd302a5b5d96566ada63ccb82b6c5e8452fde860c545e0a19",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 420,
+          "tcId" : 519,
           "comment" : "x-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "306502300c57ce2bc579fbd3a759dfbf5e84c3cef2414846a2e300453e1e4c5188f24432b14ca647a733b6ad35c980a880d36145023100f12a119e22d48b82049df611f1c851fb22795056498a873c730fcb9fd8f314728de0298b9b22c348abc6de2aba97e972",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 421,
+          "tcId" : 520,
           "comment" : "x-coordinate of the public key has many trailing 0's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30660231009a8f80697ccf2e0617612027d861a3a3a657fb75cc82810b40dd5072d39ff37eca29008390da356137e2c9babd814198023100a86537a83c3d57da50e4b29b47dcc3717c5a1ed0fff18ade8dcce4220eac63aab60b9bfed5f1bdd241dab655a9bdd75f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04000000002b089edd754169010145f263f334fc167cc19dae8225970ae19cc8cb7ec73593d6a465c370f5478b0e539d69d1951d597b56a67345acb25809581f07cd0eb78d9538a3f8a65f300e68a1eb78507df76de650e8f8ee63a5f0c5687c98",
         "wx" : "2b089edd754169010145f263f334fc167cc19dae8225970ae19cc8cb7ec73593d6a465c370f5478b0e539d69",
-        "wy" : "0d1951d597b56a67345acb25809581f07cd0eb78d9538a3f8a65f300e68a1eb78507df76de650e8f8ee63a5f0c5687c98"
+        "wy" : "00d1951d597b56a67345acb25809581f07cd0eb78d9538a3f8a65f300e68a1eb78507df76de650e8f8ee63a5f0c5687c98"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004000000002b089edd754169010145f263f334fc167cc19dae8225970ae19cc8cb7ec73593d6a465c370f5478b0e539d69d1951d597b56a67345acb25809581f07cd0eb78d9538a3f8a65f300e68a1eb78507df76de650e8f8ee63a5f0c5687c98",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEAAAAACsInt11QWkBAUXyY/M0/BZ8wZ2u\ngiWXCuGcyMt+xzWT1qRlw3D1R4sOU51p0ZUdWXtWpnNFrLJYCVgfB80Ot42VOKP4\npl8wDmih63hQffdt5lDo+O5jpfDFaHyY\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004000000002b089edd754169010145f263f334fc167cc19dae8225970ae19cc8cb7ec73593d6a465c370f5478b0e539d69d1951d597b56a67345acb25809581f07cd0eb78d9538a3f8a65f300e68a1eb78507df76de650e8f8ee63a5f0c5687c98",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEAAAAACsInt11QWkBAUXyY/M0/BZ8wZ2u\ngiWXCuGcyMt+xzWT1qRlw3D1R4sOU51p0ZUdWXtWpnNFrLJYCVgfB80Ot42VOKP4\npl8wDmih63hQffdt5lDo+O5jpfDFaHyY\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 422,
+          "tcId" : 521,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "306602310093718f6f8542725f62de7039fc193d3fcc81d622230ccc94e9e265390b385af3a3ba50c91a9d6a5b1e07d79af2bd80b2023100d08499f3d298e8afecea122265a36dbf337259020654739783c8ec8ef783d072555b5907285ce83fc8ced9c8398c6269",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 423,
+          "tcId" : 522,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3066023100ce26e42c490dec92cf59d6b1ba75c9a1400d6e5c3fd7c47e1eeb1cded30a3a3d18c81cdfdcbad2742a97293369ce21c202310094671085d941fd27d495452a4c8559a1fe24f3225f5b8ef75faf9d3fb01372c586e23b82714359d0e47144ff5d946161",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 424,
+          "tcId" : 523,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3066023100ffc4738acf71f04a13104c328c138b331fb7202aef66f583ba543ed490d12993c18f724c81ad0f7ea18dae352e5c6480023100e67d4ccdeb68a9a731f06f77eae00175be076d92529b109a62542692c8749ddfde03bed1c119a5901a4e852f2115578f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b33600000000208b3f5ad3b3937acc9d606cc5ececab4a701f75ed42957ea4d7858d33f5c26c6ae20a9cccda56996700d6b4",
-        "wx" : "0fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b336",
+        "wx" : "00fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b336",
         "wy" : "208b3f5ad3b3937acc9d606cc5ececab4a701f75ed42957ea4d7858d33f5c26c6ae20a9cccda56996700d6b4"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b33600000000208b3f5ad3b3937acc9d606cc5ececab4a701f75ed42957ea4d7858d33f5c26c6ae20a9cccda56996700d6b4",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+wG6rV8Lj3m5zRBNEqq5MQFGrdfWtMAi\n2HrmcRF4uU1hjKezrxOFSxxYiHnod7M2AAAAACCLP1rTs5N6zJ1gbMXs7KtKcB91\n7UKVfqTXhY0z9cJsauIKnMzaVplnANa0\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b33600000000208b3f5ad3b3937acc9d606cc5ececab4a701f75ed42957ea4d7858d33f5c26c6ae20a9cccda56996700d6b4",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+wG6rV8Lj3m5zRBNEqq5MQFGrdfWtMAi\n2HrmcRF4uU1hjKezrxOFSxxYiHnod7M2AAAAACCLP1rTs5N6zJ1gbMXs7KtKcB91\n7UKVfqTXhY0z9cJsauIKnMzaVplnANa0\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 425,
+          "tcId" : 524,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3065023100e6fa8455bc14e730e4ca1eb5faf6c8180f2f231069b93a0bb17d33ad5513d93a36214f5ce82ca6bd785ccbacf7249a4c02303979b4b480f496357c25aa3fc850c67ff1c5a2aabd80b6020d2eac3dd7833cf2387d0be64df54a0e9b59f12c3bebf886",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 426,
+          "tcId" : 525,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "306502301b49b037783838867fbaa57305b2aa28df1b0ec40f43140067fafdea63f87c02dfb0e6f41b760fbdf51005e90c0c3715023100e7d4eb6ee61611264ea8a668a70287e3d63489273da2b30ad0c221f1893feaea3e878c9a81c6cec865899dbda4fa79ae",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 427,
+          "tcId" : 526,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "306502310091d9da3d577408189dcaae33d95ed0a0118afd460d5228fa352b6ea671b172eb413816a70621ddaf23c5e2ef79df0c110230053dadbfcd564bddbe44e0ecb4d1e608dbd35d4e83b6634cc72afb87a2d61675ee13960c243f6be70519e167b1d3ceb0",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp384r1",
         "keySize" : 384,
-        "type" : "ECPublicKey",
         "uncompressed" : "04fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b336ffffffffdf74c0a52c4c6c8533629f933a131354b58fe08a12bd6a815b287a71cc0a3d92951df5633325a96798ff294b",
-        "wx" : "0fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b336",
-        "wy" : "0ffffffffdf74c0a52c4c6c8533629f933a131354b58fe08a12bd6a815b287a71cc0a3d92951df5633325a96798ff294b"
+        "wx" : "00fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b336",
+        "wy" : "00ffffffffdf74c0a52c4c6c8533629f933a131354b58fe08a12bd6a815b287a71cc0a3d92951df5633325a96798ff294b"
       },
-      "keyDer" : "3076301006072a8648ce3d020106052b8104002203620004fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b336ffffffffdf74c0a52c4c6c8533629f933a131354b58fe08a12bd6a815b287a71cc0a3d92951df5633325a96798ff294b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+wG6rV8Lj3m5zRBNEqq5MQFGrdfWtMAi\n2HrmcRF4uU1hjKezrxOFSxxYiHnod7M2/////990wKUsTGyFM2KfkzoTE1S1j+CK\nEr1qgVsoenHMCj2SlR31YzMlqWeY/ylL\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "3076301006072a8648ce3d020106052b8104002203620004fb01baad5f0b8f79b9cd104d12aab9310146add7d6b4c022d87ae6711178b94d618ca7b3af13854b1c588879e877b336ffffffffdf74c0a52c4c6c8533629f933a131354b58fe08a12bd6a815b287a71cc0a3d92951df5633325a96798ff294b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+wG6rV8Lj3m5zRBNEqq5MQFGrdfWtMAi\n2HrmcRF4uU1hjKezrxOFSxxYiHnod7M2/////990wKUsTGyFM2KfkzoTE1S1j+CK\nEr1qgVsoenHMCj2SlR31YzMlqWeY/ylL\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 428,
+          "tcId" : 527,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3065023100af0ed6ce6419662db80f02a2b632675445c7bf8a34bbacdc81cc5dd306c657ca4c5a3fb1b05f358d8f36fda8ae238806023046b472c0badb17e089c8f9697fd0b4ce71f0f4471b235483d4c8dd3d00aa282cde990253df38ba733b2ad82a601c7508",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 429,
+          "tcId" : 528,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3066023100e2aa9468ccaaadad8b9f43a429c97f0c6a7eedcb4d4af72d639df0fe53f610b953408a8e24e8db138551770750680f7a023100d81020846d1c50ee9ae23601dd638cb71b38d37fb555268c2fa1ad8a761fa7b27afcab2fa69224d1f976699914e09de2",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 430,
+          "tcId" : 529,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "306402306bf6fa7a663802c3382cc5fd02004ec71e5a031e3d9bfc0858fa994e88497a7782308bc265b8237a6bbbdd38658b36fc02303a9d5941a013bf70d99cc3ff255ce85573688dac40344b5db7144b19bf57bb2701e6850a8f819796b67f7d0b6aea7e50",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     }

--- a/Tests/Test Vectors/ecdsa_secp521r1_sha512_test.json
+++ b/Tests/Test Vectors/ecdsa_secp521r1_sha512_test.json
@@ -1,4800 +1,6993 @@
 {
   "algorithm" : "ECDSA",
-  "generatorVersion" : "0.4.12",
+  "schema" : "ecdsa_verify_schema.json",
+  "generatorVersion" : "0.9rc5",
+  "numberOfTests" : 529,
+  "header" : [
+    "Test vectors of type EcdsaVerify are meant for the verification",
+    "of ASN encoded ECDSA signatures."
+  ],
   "notes" : {
-    "BER" : "This is a signature with correct values for (r, s) but using some alternative BER encoding instead of DER encoding. Implementations should not accept such signatures to limit signature malleability.",
-    "EdgeCase" : "Edge case values such as r=1 and s=0 can lead to forgeries if the ECDSA implementation does not check boundaries and computes s^(-1)==0.",
-    "MissingZero" : "Some implementations of ECDSA and DSA incorrectly encode r and s by not including leading zeros in the ASN encoding of integers when necessary. Hence, some implementations (e.g. jdk) allow signatures with incorrect ASN encodings assuming that the signature is otherwise valid.",
-    "PointDuplication" : "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission."
+    "ArithmeticError" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Some implementations of ECDSA have arithmetic errors that occur when intermediate results have extreme values. This test vector has been constructed to test such occurences.",
+      "cves" : [
+        "CVE-2017-18146"
+      ]
+    },
+    "BerEncodedSignature" : {
+      "bugType" : "BER_ENCODING",
+      "description" : "ECDSA signatures are usually DER encoded. This signature contains valid values for r and s, but it uses alternative BER encoding.",
+      "effect" : "Accepting alternative BER encodings may be benign in some cases, or be an issue if protocol requires signature malleability.",
+      "cves" : [
+        "CVE-2020-14966",
+        "CVE-2020-13822",
+        "CVE-2019-14859",
+        "CVE-2016-1000342"
+      ]
+    },
+    "EdgeCasePublicKey" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vector uses a special case public key. "
+    },
+    "EdgeCaseShamirMultiplication" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Shamir proposed a fast method for computing the sum of two scalar multiplications efficiently. This test vector has been constructed so that an intermediate result is the point at infinity if Shamir's method is used."
+    },
+    "IntegerOverflow" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified, so that the original value is restored if the implementation ignores the most significant bits.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidEncoding" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "ECDSA signatures are encoded using ASN.1. This test vector contains an incorrectly encoded signature. The test vector itself was generated from a valid signature by modifying its encoding.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "InvalidSignature" : {
+      "bugType" : "AUTH_BYPASS",
+      "description" : "The signature contains special case values such as r=0 and s=0. Buggy implementations may accept such values, if the implementation does not check boundaries and computes s^(-1) == 0.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "cves" : [
+        "CVE-2022-21449",
+        "CVE-2021-43572",
+        "CVE-2022-24884"
+      ]
+    },
+    "InvalidTypesInSignature" : {
+      "bugType" : "AUTH_BYPASS",
+      "description" : "The signature contains invalid types. Dynamic typed languages sometime coerce such values of different types into integers. If an implementation is careless and has additional bugs, such as not checking integer boundaries then it may be possible that such signatures are accepted.",
+      "effect" : "Accepting such signatures can have the effect that an adversary can forge signatures without even knowning the message to sign.",
+      "cves" : [
+        "CVE-2022-21449"
+      ]
+    },
+    "ModifiedInteger" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified. The goal is to check for arithmetic errors.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModifiedSignature" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an invalid signature that was generated from a valid signature by modifying it.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "ModularInverse" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vectors contains a signature where computing the modular inverse of s hits an edge case.",
+      "effect" : "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves" : [
+        "CVE-2019-0865"
+      ]
+    },
+    "PointDuplication" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "Some implementations of ECDSA do not handle duplication and points at infinity correctly. This is a test vector that has been specially crafted to check for such an omission.",
+      "cves" : [
+        "2020-12607",
+        "CVE-2015-2730"
+      ]
+    },
+    "RangeCheck" : {
+      "bugType" : "CAN_OF_WORMS",
+      "description" : "The test vector contains an r and s that has been modified. By adding or subtracting the order of the group (or other values) the test vector checks whether signature verification verifies the range of r and s.",
+      "effect" : "Without further analysis it is unclear if the modification can be used to forge signatures."
+    },
+    "SmallRandS" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vectors contains a signature where both r and s are small integers. Some libraries cannot verify such signatures.",
+      "effect" : "While the signature in this test vector is constructed and similar cases are unlikely to occur, it is important to determine if the underlying arithmetic error can be used to forge signatures.",
+      "cves" : [
+        "2020-13895"
+      ]
+    },
+    "SpecialCaseHash" : {
+      "bugType" : "EDGE_CASE",
+      "description" : "The test vector contains a signature where the hash of the message is a special case, e.g., contains a long run of 0 or 1 bits."
+    },
+    "ValidSignature" : {
+      "bugType" : "BASIC",
+      "description" : "The test vector contains a valid signature that was generated pseudorandomly. Such signatures should not fail to verify unless some of the parameters (e.g. curve or hash function) are not supported."
+    }
   },
-  "numberOfTests" : 430,
-  "header" : [],
   "testGroups" : [
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
+        "uncompressed" : "04012a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8012333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e",
+        "wx" : "012a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8",
+        "wy" : "012333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004012a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8012333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBKpCL/Ftw4XvfrnQpSZSAi/KkLatZ\nr4sFI6Am1kCio9bTRFILYhd+LPoznKQvsIg+xCWQT72igzo7WwqaAIETZdgBIzPV\nMvj46xpiPDeKNpRlEZK72oM+O417j5Cyv8mwRfilXhtqX+FRLEAMS8nIb9fGmdZC\n9c7pu4J8iwq8DaAc7x4=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 1,
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
+          "msg" : "",
+          "sig" : "308188024201625d6115092a8e2ee21b9f8a425aa73814dec8b2335e86150ab4229f5a3421d2e6256d632c7a4365a1ee01dd2a936921bbb4551a512d1d4b5a56c314e4a02534c5024201b792d23f2649862595451055777bda1b02dc6cc8fef23231e44b921b16155cd42257441d75a790371e91819f0a9b1fd0ebd02c90b5b774527746ed9bfe743dbe2f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 2,
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
+          "msg" : "4d7367",
+          "sig" : "30818602415adc833cbc1d6141ced457bab2b01b0814054d7a28fa8bb2925d1e7525b7cf7d5c938a17abfb33426dcc05ce8d44db02f53a75ea04017dca51e1fbb14ce3311b1402415f69b2a6de129147a8437b79c72315d35173d88c2d6119085c90dae8ec05c55e067e7dfa4f681035e3dccab099291c0ecf4428332a9cb0736d16e79111ac76d766",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 3,
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081880242014141e4d94a58c1e747cbd9ee6670a41eac3c26fb4db3248e45d583179076e6b19a8e2003657a108f91f9a103157edff9b37df2b436a77dc112927d907ac9ba258702420108afa91b34bd904c680471e943af336fb90c5fb2b91401a58c9b1f467bf81af8049965dd8b45f12e152f4f7fd3780e3492f31ed2680d4777fbe655fe779ad897ab",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 4,
+          "comment" : "pseudorandom signature",
+          "flags" : [
+            "ValidSignature"
+          ],
+          "msg" : "0000000000000000000000000000000000000000",
+          "sig" : "308187024108135d3f1ae9e26fba825643ed8a29d63d7843720e93566aa09db2bdf5aaa69afbcc0c51e5295c298f305ba7b870f0a85bb5699cdf40764aab59418f77c6ffb4520242011d345256887fb351f5700961a7d47572e0d669056cb1d5619345c0c987f3331c2fe2c6df848a5c610422defd6212b64346161aa871ae55b1fe4add5f68836eb181",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
         "uncompressed" : "04005c6457ec088d532f482093965ae53ccd07e556ed59e2af945cd8c7a95c1c644f8a56a8a8a3cd77392ddd861e8a924dac99c69069093bd52a52fa6c56004a074508007878d6d42e4b4dd1e9c0696cb3e19f63033c3db4e60d473259b3ebe079aaf0a986ee6177f8217a78c68b813f7e149a4e56fd9562c07fed3d895942d7d101cb83f6",
         "wx" : "5c6457ec088d532f482093965ae53ccd07e556ed59e2af945cd8c7a95c1c644f8a56a8a8a3cd77392ddd861e8a924dac99c69069093bd52a52fa6c56004a074508",
         "wy" : "7878d6d42e4b4dd1e9c0696cb3e19f63033c3db4e60d473259b3ebe079aaf0a986ee6177f8217a78c68b813f7e149a4e56fd9562c07fed3d895942d7d101cb83f6"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004005c6457ec088d532f482093965ae53ccd07e556ed59e2af945cd8c7a95c1c644f8a56a8a8a3cd77392ddd861e8a924dac99c69069093bd52a52fa6c56004a074508007878d6d42e4b4dd1e9c0696cb3e19f63033c3db4e60d473259b3ebe079aaf0a986ee6177f8217a78c68b813f7e149a4e56fd9562c07fed3d895942d7d101cb83f6",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAXGRX7AiNUy9IIJOWWuU8zQflVu1Z\n4q+UXNjHqVwcZE+KVqioo813OS3dhh6Kkk2smcaQaQk71SpS+mxWAEoHRQgAeHjW\n1C5LTdHpwGlss+GfYwM8PbTmDUcyWbPr4Hmq8KmG7mF3+CF6eMaLgT9+FJpOVv2V\nYsB/7T2JWULX0QHLg/Y=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004005c6457ec088d532f482093965ae53ccd07e556ed59e2af945cd8c7a95c1c644f8a56a8a8a3cd77392ddd861e8a924dac99c69069093bd52a52fa6c56004a074508007878d6d42e4b4dd1e9c0696cb3e19f63033c3db4e60d473259b3ebe079aaf0a986ee6177f8217a78c68b813f7e149a4e56fd9562c07fed3d895942d7d101cb83f6",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAXGRX7AiNUy9IIJOWWuU8zQflVu1Z\n4q+UXNjHqVwcZE+KVqioo813OS3dhh6Kkk2smcaQaQk71SpS+mxWAEoHRQgAeHjW\n1C5LTdHpwGlss+GfYwM8PbTmDUcyWbPr4Hmq8KmG7mF3+CF6eMaLgT9+FJpOVv2V\nYsB/7T2JWULX0QHLg/Y=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 1,
+          "tcId" : 5,
           "comment" : "signature malleability",
+          "flags" : [
+            "ValidSignature"
+          ],
           "msg" : "313233343030",
           "sig" : "30818702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024201d74a2f6d95be8d4cb64f02d16d6b785a1246b4ebd206dc596818bb953253245f5a27a24a1aae1e218fdccd8cd7d4990b666d4bf4902b84fdad123f941fe906d948",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 2,
-          "comment" : "valid",
-          "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 3,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "3082008602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : [
-            "BER"
-          ]
-        },
-        {
-          "tcId" : 4,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "308188028200414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : [
-            "BER"
-          ]
-        },
-        {
-          "tcId" : 5,
-          "comment" : "length contains leading 0",
-          "msg" : "313233343030",
-          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450282004128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : [
-            "BER"
-          ]
+          "result" : "valid"
         },
         {
           "tcId" : 6,
-          "comment" : "wrong length",
+          "comment" : "valid",
+          "flags" : [
+            "ValidSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "308702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "valid"
         },
         {
           "tcId" : 7,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] contains a leading 0",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "308502414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3082008602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 8,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] uses 135 instead of 134",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602424e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 9,
-          "comment" : "wrong length",
+          "comment" : "length of sequence [r, s] uses 133 instead of 134",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602404e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308502414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 10,
-          "comment" : "wrong length",
+          "comment" : "uint32 overflow in length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024228b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3085010000008602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 11,
-          "comment" : "wrong length",
+          "comment" : "uint64 overflow in length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024028b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308901000000000000008602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 12,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3085010000008602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30847fffffff02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 13,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818b028501000000414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30848000000002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 14,
-          "comment" : "uint32 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818b02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450285010000004128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3084ffffffff02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 15,
-          "comment" : "uint64 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**40 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308901000000000000008602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3085ffffffffff02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 16,
-          "comment" : "uint64 overflow in length",
+          "comment" : "length of sequence [r, s] = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818f02890100000000000000414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3088ffffffffffffffff02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 17,
-          "comment" : "uint64 overflow in length",
+          "comment" : "incorrect length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818f02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645028901000000000000004128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30ff02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 18,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "replaced sequence [r, s] by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30847fffffff02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 19,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "removing sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818a02847fffffff4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "",
+          "result" : "invalid"
         },
         {
           "tcId" : 20,
-          "comment" : "length = 2**31 - 1",
+          "comment" : "lonely sequence tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818a02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864502847fffffff28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30",
+          "result" : "invalid"
         },
         {
           "tcId" : 21,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "appending 0's to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3084ffffffff02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
+          "result" : "invalid"
         },
         {
           "tcId" : 22,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "prepending 0's to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818a0284ffffffff4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308188000002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 23,
-          "comment" : "length = 2**32 - 1",
+          "comment" : "appending unused 0's to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818a02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450284ffffffff28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
+          "result" : "invalid"
         },
         {
           "tcId" : 24,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "appending null value to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3085ffffffffff02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10500",
+          "result" : "invalid"
         },
         {
           "tcId" : 25,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "prepending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818b0285ffffffffff4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818c49817730818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 26,
-          "comment" : "length = 2**40 - 1",
+          "comment" : "prepending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818b02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450285ffffffffff28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818b250030818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 27,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "appending garbage to sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3088ffffffffffffffff02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818930818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10004deadbeef",
+          "result" : "invalid"
         },
         {
           "tcId" : 28,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818e0288ffffffffffffffff4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818faa00bb00cd0030818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 29,
-          "comment" : "length = 2**64 - 1",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818e02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450288ffffffffffffffff28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818e2249aa00bb00cd0002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 30,
-          "comment" : "incorrect length",
+          "comment" : "including undefined tags",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30ff02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818e02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86452249aa00bb00cd00024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 31,
-          "comment" : "incorrect length",
+          "comment" : "truncated length of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602ff4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3081",
+          "result" : "invalid"
         },
         {
           "tcId" : 32,
-          "comment" : "incorrect length",
+          "comment" : "including undefined tags to sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864502ff28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818daa02aabb30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 33,
-          "comment" : "indefinite length without termination",
+          "comment" : "using composition with indefinite length for sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308030818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
+          "result" : "invalid"
         },
         {
           "tcId" : 34,
-          "comment" : "indefinite length without termination",
+          "comment" : "using composition with wrong tag for sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602804e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308031818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
+          "result" : "invalid"
         },
         {
           "tcId" : 35,
-          "comment" : "indefinite length without termination",
+          "comment" : "Replacing sequence [r, s] with NULL",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645028028b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 36,
-          "comment" : "removing sequence",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "2e818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 37,
-          "comment" : "lonely sequence tag",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "2f818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 38,
-          "comment" : "appending 0's to sequence",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "31818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 39,
-          "comment" : "prepending 0's to sequence",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308188000002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "32818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 40,
-          "comment" : "appending unused 0's to sequence",
+          "comment" : "changing tag value of sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "ff818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 41,
-          "comment" : "appending null value to sequence",
+          "comment" : "dropping value of sequence [r, s]",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 42,
-          "comment" : "including garbage",
+          "comment" : "using composition for sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818c49817730818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818b300102308185414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 43,
-          "comment" : "including garbage",
+          "comment" : "truncated sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818b250030818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818502414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318a",
+          "result" : "invalid"
         },
         {
           "tcId" : 44,
-          "comment" : "including garbage",
+          "comment" : "truncated sequence [r, s]",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818930818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10004deadbeef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308185414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 45,
-          "comment" : "including garbage",
+          "comment" : "sequence [r, s] of size 4231 to check for overflows",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818b224649817702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3082108702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 46,
-          "comment" : "including garbage",
+          "comment" : "indefinite length",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818a2245250002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
+          "result" : "invalid"
         },
         {
           "tcId" : 47,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with truncated delimiter",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818e224302414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450004deadbeef024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac100",
+          "result" : "invalid"
         },
         {
           "tcId" : 48,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with additional element",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818b02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86452246498177024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac105000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 49,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with truncated element",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818a02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864522452500024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1060811220000",
+          "result" : "invalid"
         },
         {
           "tcId" : 50,
-          "comment" : "including garbage",
+          "comment" : "indefinite length with garbage",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818e02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86452243024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10004deadbeef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000fe02beef",
+          "result" : "invalid"
         },
         {
           "tcId" : 51,
-          "comment" : "including undefined tags",
+          "comment" : "indefinite length with nonempty EOC",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818faa00bb00cd0030818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10002beef",
+          "result" : "invalid"
         },
         {
           "tcId" : 52,
-          "comment" : "including undefined tags",
+          "comment" : "prepend empty sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818daa02aabb30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308188300002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 53,
-          "comment" : "including undefined tags",
+          "comment" : "append empty sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818e2249aa00bb00cd0002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac13000",
+          "result" : "invalid"
         },
         {
           "tcId" : 54,
-          "comment" : "including undefined tags",
+          "comment" : "append zero",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818c2247aa02aabb02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818902414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 55,
-          "comment" : "including undefined tags",
+          "comment" : "append garbage with high tag number",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818e02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86452249aa00bb00cd00024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818902414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1bf7f00",
+          "result" : "invalid"
         },
         {
           "tcId" : 56,
-          "comment" : "including undefined tags",
+          "comment" : "append null with explicit tag",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818c02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86452247aa02aabb024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818a02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1a0020500",
+          "result" : "invalid"
         },
         {
           "tcId" : 57,
-          "comment" : "truncated length of sequence",
+          "comment" : "append null with implicit tag",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3081",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1a000",
+          "result" : "invalid"
         },
         {
           "tcId" : 58,
-          "comment" : "using composition with indefinite length",
+          "comment" : "sequence of sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "308030818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818930818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 59,
-          "comment" : "using composition with indefinite length",
+          "comment" : "truncated sequence: removed last 1 elements",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818a228002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450000024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304302414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645",
+          "result" : "invalid"
         },
         {
           "tcId" : 60,
-          "comment" : "using composition with indefinite length",
+          "comment" : "repeating element in sequence",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818a02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86452280024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3081c902414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 61,
-          "comment" : "using composition with wrong tag",
+          "comment" : "flipped bit 0 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308031818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3081844e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8644024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 62,
-          "comment" : "using composition with wrong tag",
+          "comment" : "flipped bit 32 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818a228003414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450000024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3081844e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b63bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 63,
-          "comment" : "using composition with wrong tag",
+          "comment" : "flipped bit 48 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818a02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86452280034128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3081844e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd737f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 64,
-          "comment" : "Replacing sequence with NULL",
+          "comment" : "flipped bit 64 in r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "0500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3081844e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5dd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 65,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r uses long form encoding",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "2e818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3081870281414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 66,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r contains a leading 0",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "2f818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308188028200414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 67,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r uses 66 instead of 65",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "31818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602424e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 68,
-          "comment" : "changing tag value of sequence",
+          "comment" : "length of r uses 64 instead of 65",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "32818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602404e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 69,
-          "comment" : "changing tag value of sequence",
+          "comment" : "uint32 overflow in length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "ff818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818b028501000000414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 70,
-          "comment" : "dropping value of sequence",
+          "comment" : "uint64 overflow in length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818f02890100000000000000414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 71,
-          "comment" : "using composition for sequence",
+          "comment" : "length of r = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818b300102308185414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818a02847fffffff4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 72,
-          "comment" : "truncate sequence",
+          "comment" : "length of r = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818502414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318a",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818a0284800000004e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 73,
-          "comment" : "truncate sequence",
+          "comment" : "length of r = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308185414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818a0284ffffffff4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 74,
-          "comment" : "indefinite length",
-          "msg" : "313233343030",
-          "sig" : "308002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
-          "result" : "invalid",
+          "comment" : "length of r = 2**40 - 1",
           "flags" : [
-            "BER"
-          ]
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818b0285ffffffffff4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 75,
-          "comment" : "indefinite length with truncated delimiter",
+          "comment" : "length of r = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac100",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818e0288ffffffffffffffff4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 76,
-          "comment" : "indefinite length with additional element",
+          "comment" : "incorrect length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac105000000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602ff4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 77,
-          "comment" : "indefinite length with truncated element",
+          "comment" : "replaced r by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1060811220000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602804e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 78,
-          "comment" : "indefinite length with garbage",
+          "comment" : "removing r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000fe02beef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3043024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 79,
-          "comment" : "indefinite length with nonempty EOC",
+          "comment" : "lonely integer tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10002beef",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304402024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 80,
-          "comment" : "prepend empty sequence",
+          "comment" : "lonely integer tag",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308188300002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304402414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864502",
+          "result" : "invalid"
         },
         {
           "tcId" : 81,
-          "comment" : "append empty sequence",
+          "comment" : "appending 0's to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac13000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818802434e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450000024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 82,
-          "comment" : "sequence of sequence",
+          "comment" : "prepending 0's to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818930818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308188024300004e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 83,
-          "comment" : "truncated sequence",
+          "comment" : "appending unused 0's to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304302414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450000024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 84,
-          "comment" : "repeat element in sequence",
+          "comment" : "appending null value to r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3081c902414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818802434e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450500024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 85,
-          "comment" : "long form encoding of length",
-          "msg" : "313233343030",
-          "sig" : "3081870281414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
+          "comment" : "prepending garbage to r",
           "flags" : [
-            "BER"
-          ]
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818b224649817702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 86,
-          "comment" : "long form encoding of length",
-          "msg" : "313233343030",
-          "sig" : "30818702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864502814128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
+          "comment" : "prepending garbage to r",
           "flags" : [
-            "BER"
-          ]
+            "InvalidEncoding"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818a2245250002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 87,
-          "comment" : "removing integer",
+          "comment" : "appending garbage to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3043024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818e224302414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450004deadbeef024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 88,
-          "comment" : "lonely integer tag",
+          "comment" : "truncated length of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30450281024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 89,
-          "comment" : "lonely integer tag",
+          "comment" : "including undefined tags to r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304402414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864502",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818c2247aa02aabb02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 90,
-          "comment" : "appending 0's to integer",
+          "comment" : "using composition with indefinite length for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818802434e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450000024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818a228002414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450000024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 91,
-          "comment" : "appending 0's to integer",
+          "comment" : "using composition with wrong tag for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024328b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818a228003414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450000024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 92,
-          "comment" : "prepending 0's to integer",
-          "msg" : "313233343030",
-          "sig" : "308188024300004e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
+          "comment" : "Replacing r with NULL",
           "flags" : [
-            "BER"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30450500024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 93,
-          "comment" : "prepending 0's to integer",
-          "msg" : "313233343030",
-          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450243000028b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
+          "comment" : "changing tag value of r",
           "flags" : [
-            "BER"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818600414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 94,
-          "comment" : "appending unused 0's to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450000024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818601414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 95,
-          "comment" : "appending null value to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818802434e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450500024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818603414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 96,
-          "comment" : "appending null value to integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024328b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818604414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 97,
-          "comment" : "truncated length of integer",
+          "comment" : "changing tag value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30450281024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "308186ff414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 98,
-          "comment" : "truncated length of integer",
+          "comment" : "dropping value of r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450281",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30450200024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 99,
-          "comment" : "Replacing integer with NULL",
+          "comment" : "using composition for r",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30450500024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818a224502014e02404223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 100,
-          "comment" : "Replacing integer with NULL",
+          "comment" : "modifying first byte of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450500",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602414c4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 101,
-          "comment" : "changing tag value of integer",
+          "comment" : "modifying last byte of r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818600414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86c5024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 102,
-          "comment" : "changing tag value of integer",
+          "comment" : "truncated r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818601414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818502404e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 103,
-          "comment" : "changing tag value of integer",
+          "comment" : "truncated r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818603414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818502404223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 104,
-          "comment" : "changing tag value of integer",
+          "comment" : "r of size 4162 to check for overflows",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818604414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30821089028210424e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 105,
-          "comment" : "changing tag value of integer",
+          "comment" : "leading ff in r",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "308186ff414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3081870242ff4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 106,
-          "comment" : "changing tag value of integer",
+          "comment" : "replaced r by infinity",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645004128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3046090180024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 107,
-          "comment" : "changing tag value of integer",
+          "comment" : "replacing r with zero",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645014128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3046020100024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 108,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 0 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645034128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818402414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864528b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac0",
+          "result" : "invalid"
         },
         {
           "tcId" : 109,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 32 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645044128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818402414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864528b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022ffa8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 110,
-          "comment" : "changing tag value of integer",
+          "comment" : "flipped bit 48 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645ff4128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818402414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864528b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93122fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 111,
-          "comment" : "dropping value of integer",
+          "comment" : "flipped bit 64 in s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30450200024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818402414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864528b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a00a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 112,
-          "comment" : "dropping value of integer",
+          "comment" : "length of s uses long form encoding",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "304502414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450200",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864502814128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 113,
-          "comment" : "using composition for integer",
+          "comment" : "length of s contains a leading 0",
+          "flags" : [
+            "BerEncodedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818a224502014e02404223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450282004128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 114,
-          "comment" : "using composition for integer",
+          "comment" : "length of s uses 66 instead of 65",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818a02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864522450201280240b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024228b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 115,
-          "comment" : "modify first byte of integer",
+          "comment" : "length of s uses 64 instead of 65",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414c4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024028b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 116,
-          "comment" : "modify first byte of integer",
+          "comment" : "uint32 overflow in length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864502412ab5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818b02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450285010000004128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 117,
-          "comment" : "modify last byte of integer",
+          "comment" : "uint64 overflow in length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86c5024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818f02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645028901000000000000004128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 118,
-          "comment" : "modify last byte of integer",
+          "comment" : "length of s = 2**31 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318a41",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818a02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864502847fffffff28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 119,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**31",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818502404e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818a02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864502848000000028b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 120,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**32 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818502404223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818a02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450284ffffffff28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 121,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**40 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818502414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024028b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318a",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818b02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450285ffffffffff28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 122,
-          "comment" : "truncate integer",
+          "comment" : "length of s = 2**64 - 1",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818502414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450240b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818e02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450288ffffffffffffffff28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 123,
-          "comment" : "leading ff in integer",
+          "comment" : "incorrect length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3081870242ff4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864502ff28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 124,
-          "comment" : "leading ff in integer",
+          "comment" : "replaced s by an indefinite length tag without termination",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450242ff28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645028028b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 125,
-          "comment" : "infinity",
+          "comment" : "appending 0's to s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3046090180024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024328b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
+          "result" : "invalid"
         },
         {
           "tcId" : 126,
-          "comment" : "infinity",
+          "comment" : "prepending 0's to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645090180",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450243000028b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 127,
-          "comment" : "replacing integer with zero",
+          "comment" : "appending null value to s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3046020100024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818802414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024328b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10500",
+          "result" : "invalid"
         },
         {
           "tcId" : 128,
-          "comment" : "replacing integer with zero",
+          "comment" : "prepending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "304602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645020100",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818b02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86452246498177024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 129,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "prepending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3081870242024e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbe97b3367122fa4a20584c271233f3ec3b7f7b31b0faa4d340b92a6b0d5cd17ea4e024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818a02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864522452500024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 130,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "appending garbage to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3081870242fe4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbf4d826580ab145752e852a6e91512b78178047879e9714a4ae1bc74298aaa7223c024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818e02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86452243024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10004deadbeef",
+          "result" : "invalid"
         },
         {
           "tcId" : 131,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "truncated length of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3081860241b1bddc11bc17347621c4ecc6003d861a7d07d3854f08e4421bc241c8b538a00410d65320718f8af465fb099025b7cae2184402aea8df4f13a328c90648c42079bb024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450281",
+          "result" : "invalid"
         },
         {
           "tcId" : 132,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "including undefined tags to s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "308187024201b1bddc11bc17347621c4ecc6003d861a7d07d3854f08e4421bc241c8b538a0040b27d9a7f54eba8ad17ad5916eaed487e87fb8786168eb5b51e438bd675558ddc4024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818c02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86452247aa02aabb024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 133,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "using composition with indefinite length for s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3081870242fdb1bddc11bc17347621c4ecc6003d861a7d07d3854f08e4421bc241c8b538a0041684cc98edd05b5dfa7b3d8edcc0c13c48084ce4f055b2cbf46d594f2a32e815b2024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818a02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86452280024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
+          "result" : "invalid"
         },
         {
           "tcId" : 134,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "using composition with wrong tag for s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "3081870242024e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818a02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86452280034128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000",
+          "result" : "invalid"
         },
         {
           "tcId" : 135,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "Replacing s with NULL",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "3081870242fe4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450500",
+          "result" : "invalid"
         },
         {
           "tcId" : 136,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "308187024201b1bddc11bc17347621c4ecc6003d861a7d07d3854f08e4421bc241c8b538a00410d65320718f8af465fb099025b7cae2184402aea8df4f13a328c90648c42079bb024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645004128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 137,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864502420228b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba09a7b6ac4ecd0410b4722ca75ba197a403a0a1f9ee0e7b391b0649fda1d3969eeca",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645014128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 138,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450242fe28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a5d85db5e551e1de70233273282b66f49992b40b6fd47b0252edc06be016f926b8",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645034128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 139,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450241d74a2f6d95be8d4cb64f02d16d6b785a1246b4ebd206dc596818bb953253245f5fd61bc296eeee8b245d018b8edd8f659631962ad7a1e8b5fe56cfdd0157ce753f",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645044128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 140,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "changing tag value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450242fdd74a2f6d95be8d4cb64f02d16d6b785a1246b4ebd206dc596818bb953253245f6584953b132fbef4b8dd358a45e685bfc5f5e0611f184c6e4f9b6025e2c6961136",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645ff4128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 141,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "dropping value of s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864502420228b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "304502414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450200",
+          "result" : "invalid"
         },
         {
           "tcId" : 142,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "using composition for s",
+          "flags" : [
+            "InvalidEncoding"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450242fe28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818a02414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864522450201280240b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 143,
-          "comment" : "Modified r or s, e.g. by adding or subtracting the order of the group",
+          "comment" : "modifying first byte of s",
+          "flags" : [
+            "ModifiedSignature"
+          ],
           "msg" : "313233343030",
-          "sig" : "30818702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024201d74a2f6d95be8d4cb64f02d16d6b785a1246b4ebd206dc596818bb953253245f5fd61bc296eeee8b245d018b8edd8f659631962ad7a1e8b5fe56cfdd0157ce753f",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf864502412ab5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 144,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020100020100",
-          "result" : "invalid",
+          "comment" : "modifying last byte of s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318a41",
+          "result" : "invalid"
         },
         {
           "tcId" : 145,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020100020101",
-          "result" : "invalid",
+          "comment" : "truncated s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818502414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024028b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318a",
+          "result" : "invalid"
         },
         {
           "tcId" : 146,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201000201ff",
-          "result" : "invalid",
+          "comment" : "truncated s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818502414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450240b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 147,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047020100024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
-          "result" : "invalid",
+          "comment" : "s of size 4162 to check for overflows",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3082108902414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450282104228b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac10000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 148,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047020100024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
-          "result" : "invalid",
+          "comment" : "leading ff in s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818702414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf86450242ff28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 149,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047020100024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
-          "result" : "invalid",
+          "comment" : "replaced s by infinity",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645090180",
+          "result" : "invalid"
         },
         {
           "tcId" : 150,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047020100024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "replacing s with zero",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304602414e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 151,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30470201000242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "replaced r by r + n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081870242024e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbe97b3367122fa4a20584c271233f3ec3b7f7b31b0faa4d340b92a6b0d5cd17ea4e024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 152,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3008020100090380fe01",
-          "result" : "invalid",
+          "comment" : "replaced r by r - n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081870242fe4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbf4d826580ab145752e852a6e91512b78178047879e9714a4ae1bc74298aaa7223c024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 153,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020101020100",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 256 * n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024302004e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ff640b034634da00b7719d0f7b8d151daee2371c709e0bcf89b1846ee184874438f45024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 154,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020101020101",
-          "result" : "invalid",
+          "comment" : "replaced r by -r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081860241b1bddc11bc17347621c4ecc6003d861a7d07d3854f08e4421bc241c8b538a00410d65320718f8af465fb099025b7cae2184402aea8df4f13a328c90648c42079bb024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 155,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201010201ff",
-          "result" : "invalid",
+          "comment" : "replaced r by n - r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024201b1bddc11bc17347621c4ecc6003d861a7d07d3854f08e4421bc241c8b538a0040b27d9a7f54eba8ad17ad5916eaed487e87fb8786168eb5b51e438bd675558ddc4024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 156,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047020101024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
-          "result" : "invalid",
+          "comment" : "replaced r by -n - r",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081870242fdb1bddc11bc17347621c4ecc6003d861a7d07d3854f08e4421bc241c8b538a0041684cc98edd05b5dfa7b3d8edcc0c13c48084ce4f055b2cbf46d594f2a32e815b2024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 157,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047020101024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 2**521",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081870242024e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 158,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047020101024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
-          "result" : "invalid",
+          "comment" : "replaced r by r - 2**521",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081870242fe4e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 159,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047020101024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "replaced r by r + 2**585",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818f024a0200000000000000004e4223ee43e8cb89de3b1339ffc279e582f82c7ab0f71bbde43dbe374ac75ffbef29acdf8e70750b9a04f66fda48351de7bbfd515720b0ec5cd736f9b73bdf8645024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 160,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30470201010242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "replaced s by s + n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818702420228b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba09a7b6ac4ecd0410b4722ca75ba197a403a0a1f9ee0e7b391b0649fda1d3969eeca024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 161,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3008020101090380fe01",
-          "result" : "invalid",
+          "comment" : "replaced s by s - n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081870242fe28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a5d85db5e551e1de70233273282b66f49992b40b6fd47b0252edc06be016f926b8024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 162,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff020100",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 256 * n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "RangeCheck"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081880243020028b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdb9af1b06bc12840a7e05b6effbd682c166aa584338db1fa5ef8bd18e7418fe09593c1024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 163,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff020101",
-          "result" : "invalid",
+          "comment" : "replaced s by -s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081860241d74a2f6d95be8d4cb64f02d16d6b785a1246b4ebd206dc596818bb953253245f5fd61bc296eeee8b245d018b8edd8f659631962ad7a1e8b5fe56cfdd0157ce753f024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 164,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30060201ff0201ff",
-          "result" : "invalid",
+          "comment" : "replaced s by -n - s",
           "flags" : [
-            "EdgeCase"
-          ]
+            "ModifiedInteger"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081870242fdd74a2f6d95be8d4cb64f02d16d6b785a1246b4ebd206dc596818bb953253245f6584953b132fbef4b8dd358a45e685bfc5f5e0611f184c6e4f9b6025e2c6961136024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 165,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30470201ff024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 2**521",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818702420228b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 166,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30470201ff024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
-          "result" : "invalid",
+          "comment" : "replaced s by s - 2**521",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081870242fe28b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 167,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30470201ff024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
-          "result" : "invalid",
+          "comment" : "replaced s by s + 2**585",
           "flags" : [
-            "EdgeCase"
-          ]
+            "IntegerOverflow"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818f024a02000000000000000028b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1024128b5d0926a4172b349b0fd2e929487a5edb94b142df923a697e7446acdacdba0a029e43d69111174dba2fe747122709a69ce69d5285e174a01a93022fea8318ac1",
+          "result" : "invalid"
         },
         {
           "tcId" : 168,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30470201ff024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 169,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30470201ff0242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 170,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30080201ff090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201000201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 171,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047020100024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
+          "result" : "invalid"
         },
         {
           "tcId" : 172,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047020100024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
+          "result" : "invalid"
         },
         {
           "tcId" : 173,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e913864090201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047020100024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
+          "result" : "invalid"
         },
         {
           "tcId" : 174,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047020100024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 175,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=0 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30470201000242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 176,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 177,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 178,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e913864090242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201010201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 179,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3049024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047020101024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
+          "result" : "invalid"
         },
         {
           "tcId" : 180,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047020101024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
+          "result" : "invalid"
         },
         {
           "tcId" : 181,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047020101024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
+          "result" : "invalid"
         },
         {
           "tcId" : 182,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e913864080201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047020101024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 183,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30470201010242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 184,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 185,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 186,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff0201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 187,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e913864080242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30470201ff024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
+          "result" : "invalid"
         },
         {
           "tcId" : 188,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3049024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30470201ff024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
+          "result" : "invalid"
         },
         {
           "tcId" : 189,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30470201ff024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
+          "result" : "invalid"
         },
         {
           "tcId" : 190,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30470201ff024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 191,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a0201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=-1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30470201ff0242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 192,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 193,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 194,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e913864090201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 195,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
+          "result" : "invalid"
         },
         {
           "tcId" : 196,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a0242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
+          "result" : "invalid"
         },
         {
           "tcId" : 197,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3049024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
+          "result" : "invalid"
         },
         {
           "tcId" : 198,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 199,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e913864090242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 200,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3047024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 201,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 202,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e913864080201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 203,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
+          "result" : "invalid"
         },
         {
           "tcId" : 204,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
+          "result" : "invalid"
         },
         {
           "tcId" : 205,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "308188024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
+          "result" : "invalid"
         },
         {
           "tcId" : 206,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3049024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 207,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30470242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020100",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n - 1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e913864080242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 208,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30470242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020101",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=0",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 209,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "304702420200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000201ff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 210,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3081880242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=-1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a0201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 211,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3081880242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
+          "result" : "invalid"
         },
         {
           "tcId" : 212,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3081880242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n - 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
+          "result" : "invalid"
         },
         {
           "tcId" : 213,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "3081880242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=n + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
+          "result" : "invalid"
         },
         {
           "tcId" : 214,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30818802420200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=p",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 215,
-          "comment" : "Signature with special case values for r and s",
-          "msg" : "313233343030",
-          "sig" : "30490242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000090380fe01",
-          "result" : "invalid",
+          "comment" : "Signature with special case values r=n + 1 and s=p + 1",
           "flags" : [
-            "EdgeCase"
-          ]
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a0242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 216,
-          "comment" : "Edge case for Shamir multiplication",
-          "msg" : "39353032",
-          "sig" : "308187024200b4b10646a668c385e1c4da613eb6592c0976fc4df843fc446f20673be5ac18c7d8608a943f019d96216254b09de5f20f3159402ced88ef805a4154f780e093e044024165cd4e7f2d8b752c35a62fc11a4ab745a91ca80698a226b41f156fb764b79f4d76548140eb94d2c477c0a9be3e1d4d1acbf9cf449701c10bd47c2e3698b3287934",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=0",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 217,
-          "comment" : "special case hash",
-          "msg" : "33393439313934313732",
-          "sig" : "308188024201209e6f7b6f2f764261766d4106c3e4a43ac615f645f3ef5c7139651e86e4a177f9c2ab68027afbc6784ccb78d05c258a8b9b18fb1c0f28be4d024da90738fbd374024201ade5d2cb6bf79d80583aeb11ac3254fc151fa363305508a0f121457d00911f8f5ef6d4ec27460d26f3b56f4447f434ff9abe6a91e5055e7fe7707345e562983d64",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 218,
-          "comment" : "special case hash",
-          "msg" : "35333637363431383737",
-          "sig" : "308188024201c0832c973a455cac48a4439659aa21146036c52ec1514121c66714348a1c0e2c7099a2466d9acb49325a0cb509e5dff2efbcd90369d3027cbb7dca58a134278d05024200a426c063ab5cc6af20dd1ba8a519fac910183561598e67c0929e25f9c3aaeb245c5647fba21e30c103304dc6f49e6dec68a7833533e4e5448240bde023fe201eb9",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=-1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 219,
-          "comment" : "special case hash",
-          "msg" : "35363731343831303935",
-          "sig" : "30818702410d01cde64dda4dbcef1a9b924779598217b97eb688d9b4a4fd20d1b81ff0bb870abff1b0db6dfc3762f27c3954f230a7933d9ea397a972caac5ed2183ec72716c7024201c6530fb6b913005f81e156be89b3847701829fbb310d8a4c761212c6d2f8750174f2bf81c238fdde4370fa87de320f57dbed96691af45cb99f3daa865edcdda59e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
+          "result" : "invalid"
         },
         {
           "tcId" : 220,
-          "comment" : "special case hash",
-          "msg" : "3131323037313732393039",
-          "sig" : "308187024200c009c74ec707252325d78f4e7f14be28f56272be17c0c18c90ad4c07322cef4eea444c8feabf41a213e3e846f8ac8bb7750d49143069cd01877d530bb981f1a85b02411f1c27ef97f434a8c2ff315dd39d909709775bb3c7588243bdfd8f7c866c49b3369719d5b74a47924bbce57301675e2baadcec438e07e6d532aba664253ab09550",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n - 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
+          "result" : "invalid"
         },
         {
           "tcId" : 221,
-          "comment" : "special case hash",
-          "msg" : "3131323938303334323336",
-          "sig" : "308188024201d3b17a34b19d134773988c434a9fb7f22a57dfb4c4bcca031e213e1b9a56db0ecb2f3c54cf9b1b6e5981369652de37337a7a7d7ddb54d67b067bbce01fd7fd2808024200c90317dfa061122557eb3899939924a8ea3cdd886e0f2e5f2c384b65b1a40de5f00fd9fce889fc313a6a9d5f0a9cd3a7b89b7ba8e97807031f3d1e3f9c103f0a10",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=n + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
+          "result" : "invalid"
         },
         {
           "tcId" : 222,
-          "comment" : "special case hash",
-          "msg" : "39383736303239363833",
-          "sig" : "308188024200cdca5299e788600a3ca5938d4a4c5f42b5eea3cefc990e67af95a4449aac0ab50e8fc4778efa497223cdca07c0e5a5920110f3a87afaaf265beadbb91c00d13464024201a92b9a5570b42f91ebc3d8ba272db9241468154783548d3fcfb6ef46c9e037bb6217af0a31ef952c27604629ad5775e7695c63efa138cee8326a51c1b04d0c658f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=p",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 223,
-          "comment" : "special case hash",
-          "msg" : "3230323034323936353139",
-          "sig" : "308188024201660b0ed15d5f63044cb189e1a405bcb591c37217d0e000008614b152665d5bb9353a3826854a8bc6ebed423b15680e4340a00701b17bae24bd399bcff7e0438bfb024201c47f2f5c6143d2eef063757114aaeb27827b6a8f675d1825dac7f4548cbf78a37eb9621a29e9b14cf61fc6ae49e7e6e15350a4b90a4a897ff69b0c59b69508ebc7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p and s=p + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 224,
-          "comment" : "special case hash",
-          "msg" : "31343531363639313830",
-          "sig" : "3081870241364684856c7c02bfb2ad2de603d10883ca93c122d4cebef276467a9b7620fb530e4d05d07c15ab948b9ce7682561307913b64ea6896ece1095dc64369f1a9d5c0d0242009e6db2ff96d9d71150440fd44992656ca118fcaf6bd04499314e8ba61a55a8790aac023ddb68600fbd7ed4cd4decb176e8bd7822ea31d75adcbdaccafcf510c26c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=0",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30470242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 225,
-          "comment" : "special case hash",
-          "msg" : "31303933363835393531",
-          "sig" : "308188024201a317e49014f1bf3afc09cc048531010e2144b662cac657e51b32bb432d274a730b535fb2de66fa8ddd26faa3f46e004389d25517c56e7d8a1d39563b0e8c9c215b024201ad2e1212e1680b660a1c07f54addff575c8c8298e26a14c516f517fb5f966a2b383aa46a483fdbfa72711d60c0f67a2c03d63d2626ffe271e0ce353a4d4b09bd5e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30470242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000020101",
+          "result" : "invalid"
         },
         {
           "tcId" : 226,
-          "comment" : "special case hash",
-          "msg" : "36323139353630323031",
-          "sig" : "308188024201c09b29fc4da04e9b86097bd6d6806aa969ceb37ce52eeac5e9518d27541c3f30c00f113d9dd3b007dae6f381896d43fc6ddfb3fa256a36529b054e416ed638059902420113e5622cb1e4c4bb0842f3d396d7e660241116e94e8120a602e3d2952701b1a11415a3d8c503adced160450fd13157ad147d2d65d77449458659350e20a545602e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=-1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "304702420200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000201ff",
+          "result" : "invalid"
         },
         {
           "tcId" : 227,
-          "comment" : "special case hash",
-          "msg" : "35363832343734333033",
-          "sig" : "308187024178f4a2968460ea8f64a938b3a97c914eb0ccfa94eb08636efee9d5ad8668ce1c9099573abd146df9e7b2ccaaa1a25de903f85962849356a872e88e545babc28974024200f2729e9593c9fcdf5971b21e367ffdc87aa7520393527c6f68ab512b88b839003c1c9952b04f2dc74010a31071ee20a9fb1c7e1187d04de71b3f4327df128ccd43",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081880242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409",
+          "result" : "invalid"
         },
         {
           "tcId" : 228,
-          "comment" : "special case hash",
-          "msg" : "33373336353331373836",
-          "sig" : "3081870242019faed147a76b65779d0989e1300802844c9ba09f338c5e31a24d9ebf8f0b0b4c21f59d369ac10e315fa2b7605b0f17a9c07cf6ce4c83838e58333a3390142d79d002415f4de71fdaced1e8da86efd47ecbdac6a6ffc6d69df71da7ceb5596475cdfecea3d00f074d2de89e0fcc05e3231d531f0d38f2b7c6fe4ecf67a0cdddc21d0867b8",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n - 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081880242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386408",
+          "result" : "invalid"
         },
         {
           "tcId" : 229,
-          "comment" : "special case hash",
-          "msg" : "34373935393033373932",
-          "sig" : "308188024200d0b144350a2128f042bc1a27f6c021dad1ec031be8f1d8304797f9ddcb742974aae209f014980174b9d4e434e3f53247889d2da4b767593179cb4eda47e799643002420184d3416dee35ba8807703a91ac927096c10959a05cbffd8103a93a9f20a11537bed7a645f32295e4abce493579caa4e2242060cc4d58b2414870e98b9336795787",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=n + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081880242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a",
+          "result" : "invalid"
         },
         {
           "tcId" : 230,
-          "comment" : "special case hash",
-          "msg" : "39333939363131303037",
-          "sig" : "308187024105257a0f45ee2ae5cc30283d23c47c96f6deaa3ac1473e8e8a40eaf61bc4b0ef8bd18d11983f257ec4b1d8d04e76a122b5bbe1d31065159072c58fd9bc3e98376802420122dba50d0eb71bdbf092a94a7ea280412906e1f849e91dbd5d8158e3fc6cd12e20461b77653e3df2e45b86883f81071b33651ae1b84cc8e7c365ab8d6a36d1cfa6",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=p",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3081880242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+          "result" : "invalid"
         },
         {
           "tcId" : 231,
-          "comment" : "special case hash",
-          "msg" : "31303837343931313835",
-          "sig" : "3081880242014f624af9d8096fe7a290651d23ab260da64e44b886fef4f3881d0d984d3b387fddcf65b1fa1dbb239028fbab4a1de6ad150cc8a4e4db0a971bb8bcf01c4728ff9802420105e3b55db0141c06d9854096cc0f73415dd2b85a331da50cfea3bbf648bbf8651f61f2cd09386b62fbb8ce67248683c260894d9ed54d6667ae02978e38ab99320a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature with special case values r=p + 1 and s=p + 1",
+          "flags" : [
+            "InvalidSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818802420200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+          "result" : "invalid"
         },
         {
           "tcId" : 232,
-          "comment" : "special case hash",
-          "msg" : "33323336363738353030",
-          "sig" : "30818702412c952d7e61e1097cd7f709e62ec486879b380b63791c146b545c064e65b3060250d00af279cf15eade67384b28594db542845fcc6574ef5d8d5bb8a162e0350a0002420135ac6d1cc05b095fbae28b652fe5386b8689e21a14990236d3ada7ceeb0c12a4f774bff7b81c8d07572b0c7985364c5d31f33271f0ac3a2afb88b46bfeefbaeaa8",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008020100090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 233,
-          "comment" : "special case hash",
-          "msg" : "31343438393937373033",
-          "sig" : "3081880242017919eff78225e1937a921f98f5d153cbffa03929819f228ee013f8e59549b04b9867006a8df25a93a6a25dd1d3f540239a8ed14047ea00811da9305ec515ad000d0242011fb873bdae1757801e575c5df62cf82a1881af3cd6ed17dc50edbe6c5fd0f4d31766670b2aa572a9e6547b36142afa8464d0be4bf41930629dc04c85e01b2ee8e2",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 234,
-          "comment" : "special case hash",
-          "msg" : "35373134363332383037",
-          "sig" : "30818702416ac9b370067b13ac2b57f35d6d9b1faa93b9b068ef5ddf8bde3a54024810aa2226560065b0cb7501df96b4756ce1e1fa607f86a942367894a1f7728bd5f22cf1770242008b47a9e1370c9f5bf4677d554c00e9ac3ea7cdfc78836ac53ac710b7f3bff8c2297780c69a9fddb80e03a605e5e48a52e52fd35f41668cd9064886366fda206086",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 235,
-          "comment" : "special case hash",
-          "msg" : "323236343837343932",
-          "sig" : "308187024200c4bcfff265cd32442220976ffc7e4ec09181d694696eb89af0cb2d5a2dfc3876deb3c6adea168965200c355c3bff5e47ab17ecc44c8434333280796d3a183449ea024162debe91550f8a760eaea309f48483c65a52c7e88a83867c31730cbc6b0a64d4c564bde67e6539af787ecfd18016cde46ddf91740f58f6ea6ec80b173fd1c47ad0",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020100010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 236,
-          "comment" : "special case hash",
-          "msg" : "35333533343439343739",
-          "sig" : "30818802420174d744ddc631fcf8202fca0ab10f6d96d3f7552bb2a9ae5ac573634133f61c59a120fedbc39cfb521ab0cd572afbd5147981090d1dcbfe902e03f0c0579967b5810242012f59ca927c4ae331d2f667fcd9ec01b0b5514e2ab5da0561ea614431dc1fcb761c351cd1211092720ebb7074a5128f8019b7c18e048d5ed3573ed61686e9713f72",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201000500",
+          "result" : "invalid"
         },
         {
           "tcId" : 237,
-          "comment" : "special case hash",
-          "msg" : "34373837333033383830",
-          "sig" : "3081880242019a513cfaf871287340d8a51d2f4348ab4096c5fe244b22add38ce433e3178e8ff5b2df0fe74a1ba40fe8341f734c71f9a1177b41035777e2da6b082e0b566690de024200d0c43eb33a817c3aab30281c593c74517ee84e958b114395ce0b31fcf30bb8f5dfe60dbc7f6f14698977d8e0516a9274a5bd71847057e006fa315fae6922eaaa55",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201000c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 238,
-          "comment" : "special case hash",
-          "msg" : "32323332313935383233",
-          "sig" : "3081870242013204800efcb40ab09ae4137325a3e8c468edae91880a51616ba61f3ef1f72fd89feb956bfb39818d827468bb4475110a04779fd6bb3def25c61c4ba60889ed0ff70241704b7394687698c8841f4875d40e5b3c914f154ccb2b54466ae163ed3410f20d0a07ac5f90c0c31271ec8a524ca2dae4b8bc4f6e1ece173ea907890693c5f2190c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201000c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 239,
-          "comment" : "special case hash",
-          "msg" : "3130373339333931393137",
-          "sig" : "30818802420180241cd2e6163158a39599890dabee99c2c86b88accd2b04b5a72874fbdfbde0d18143c4d78e0da1abf3796b238738840d60e34775a8ff810d58a9bb3559a3997c024200bc396c2ef28b244fb8e004bf5361572ba1fef6fbe081ed1dedba4d9af78deee126599f75a0a9d0f1b1618ded7a0c5e672e40917fdd30582460da3aeb1e9c4477d7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201003000",
+          "result" : "invalid"
         },
         {
           "tcId" : 240,
-          "comment" : "special case hash",
-          "msg" : "31383831303237333135",
-          "sig" : "308188024201485fc03fcd629fd4c564775ab6969bbc696b5b0f38141b69f86e052e7fe8849a64af2dd37a2adf64672f20bd6f97cd32f0efea51aa22064c5f10a3911177e1979d02420180fab473ff9d726db6d266541a0bddff8610e4026d26b6c9abf972eaef477d50670bdd3067c9d711a8346e16869147751e89b4ea75bb00ece71300cc3b80cf8899",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201003003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 241,
-          "comment" : "special case hash",
-          "msg" : "36303631363933393037",
-          "sig" : "308188024201bea49b150a27026fdf848297b0491019f76abf90f3e6d782e3d3fa6caddb81b7ef58b27f1b2b3f7898889b4e2b6cdda7b5636177a27eb9a67b2055b6f21d262c26024200dffb13c2d5f746c8573aa444afc8baf8bf881cc4d0fca8169f6cb304f400eb3932666cd3758c437c9cad79abfd89c72a788505763aabdfabf8903ad4a70d9ec9f7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008020101090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 242,
-          "comment" : "special case hash",
-          "msg" : "38383935323237303934",
-          "sig" : "308187024201d56bf6f3758f627f470706d1d28c28fbfcad6dc30465cb285a274fc057f791de73ac30baccde044473fa9e3dce6d395eadf98d1f97259bd851a1eb6f3d31d2d756024133704b4ad37300a96682569f4f7fea3e14d6e1f65864663f39aa67f40b5c949f198d5de9f2ac2369bbb9111c89b393199537c6c08ed7c02709c733ef7660113d53",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 243,
-          "comment" : "special case hash",
-          "msg" : "31353830323334303934",
-          "sig" : "308188024201554035ba84b051d50901c622b98be4de0123a02928dffa7eb13b0403fd5e255f226505e15694956a66a878ff581173d123d1b24eaa85c5fe46d8973a55040ff405024201b016dd6b5176ad8347eb9802dd7727e06a29db33cc946f809a42f9193040692b0f82ebbd04eff9f099b7f75f8e45e74ac00a51a9cd4f2cbf5f03f4d2bee99c24eb",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 244,
-          "comment" : "special case hash",
-          "msg" : "33393635393931353132",
-          "sig" : "3081860241293e8d6775f3c14183aecc22f608e9013d7b15dad167bb38a1dfef6b373619f1ba2751d77b43f643f68643cfdb5c04a8ed858bfcf3858a681ae93bfc7cd7e3143802412c7d96db7dbbe347bab9f6f7b88f48cb32ab963248737d2c901b90d64591cbdb0f0ca7a14557f8a50fd80d402f929dad141141f1f0c85d9414b32d1fd4d796e6e7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 245,
-          "comment" : "special case hash",
-          "msg" : "32323838373332313938",
-          "sig" : "308188024200b16a9b3aceece85908125f96f6cb6b1afd0ef04171936b3766f8e43beb340d382084b33439f775a29a83945da8efc4190db1343e87d8c0ffb97aeb3be159d90f59024200e5c2bbd98e449bd0bb4f75a07f1a88dd63c0602a7660f4acd33937c4913a9c16ba44dc5808892ec88a4255109a7bc5b221c07e6a278888a9712fc2a25b374427e3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201010500",
+          "result" : "invalid"
         },
         {
           "tcId" : 246,
-          "comment" : "special case hash",
-          "msg" : "32323330383837333139",
-          "sig" : "30818702413b47a8ed52f5b0566365313520bc0b6e4e4efb3ea4176ed7a352c4b2f8bffbdb0148ff44f3f13d9e5e31b1cdeae097574aad8bf393c54a5c842e749ee87a74c6b0024201d3f484e9e224bda9c8f10fbb74bbb62d7a18245707f4eb52f17dde793892c16e4bdf504960fba55da487f542d412b1b833f6f46336118618fcff69469c83963777",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201010c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 247,
-          "comment" : "special case hash",
-          "msg" : "313239303536393337",
-          "sig" : "30818802420128b8988bfe9287f82ac97be507a544b823e85cc2813b6929e63699cff85a40283076028e7bf8d24330f89adb96bf24a4e183a898e679b36768909574e7d4733d61024200c18aae44e6801fc2e3d9c7a20ff9d42b46e4a31ca37772f8c46ce65219b195ca23717f816e1fed51e5b6f9a0ca12c3cf81ae7fc9cc6946a88330b2011ddd160930",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201010c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 248,
-          "comment" : "special case hash",
-          "msg" : "32373438363536343338",
-          "sig" : "3081870242015edf1fa95b17159f762d68c1736101309e80fe5b2c4415609a5ac0837fe5901f3c2d3d826a43b1f8cd1babf494ffd96cca1267950188a924d4e1bf7f68189f27d302412e8697efbbf53adb7cb1b904718fc71eb2561f331c209c50848b5bc50bef77c5c3487d285bfaa3caa14025cbb71bdbaea6911e3610335641d2799c3fd75019f716",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201013000",
+          "result" : "invalid"
         },
         {
           "tcId" : 249,
-          "comment" : "special case hash",
-          "msg" : "37353833353032363034",
-          "sig" : "30818802420161f64bbe93fdc0e61134cfd4c453ab740233b436179351aa68a3e38a83400d86ff464d7ceb7a51f541b86eb2f12e32a879b3a29bcb92e08cd50e74f86a0ed52ae90242008f6fef49ba12ced6696f4f6d24e6c68057a84496d42eede630199e9bd06d91363542a9776bfcd6d77fbae422e80fe466edd2c2c5e1f5cc79bedd1a7becc1a12660",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=1, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201013003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 250,
-          "comment" : "special case hash",
-          "msg" : "32333237373534323739",
-          "sig" : "3081870242013a6faccc1c06cb5dadb2cf083cb94a7181fd5cbf3954fdc430c2691248fcfcd13767e32491f00269b549cae93777ced0f7b069440726adde7605d4038d7b5ea4cc02417622c9065f4c49a6f8649073dfc6a827b897b6984176b1a09d151b9733a68f6da746c47427cdeb3be075da4a351ab78dd5e472cd98d1586edd6ff2a11c6c169fbb",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201ff090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 251,
-          "comment" : "special case hash",
-          "msg" : "373735353038353834",
-          "sig" : "308188024201899609e7f7cd2ef14bfbb1cb9ba9283ae11a9346a34bef23b1c249da2e76a7708e0f2f97f819e4e25b0d5227eeb85aa593c3fae9398a7020f61ae1606945d13841024201b8d5e9c4f030295447106d2b5c80cc2e7d4e36b458a90a08f505df62d2234e59d08187385ba5501049b34e12ec92f7839a18361a52a9a0b6f6a664b118680b53d7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 252,
-          "comment" : "special case hash",
-          "msg" : "3137393832363438333832",
-          "sig" : "308187024201ddc69d1508021eb560db39f3add8a28dd7fbce417e5fa1f4f626705caaad72b634868d01dfc474e926c97927c56ac51f9bdcfd0e7627be35cc300a0cdc083b00d402416e862caf9f2df11b0a46104e78865fbbabe30bfac0b1fe7f99badc11746a288c1ff27f6fa2aaba6441bab0372af906eef083ff03ba466b896c9344cd396dd46dbd",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 253,
-          "comment" : "special case hash",
-          "msg" : "32333936373737333635",
-          "sig" : "30818702420117fe2c21f282c7e4a8415e9c53c254514eeeb0adadc771adbc6d21a09add4f17ea0c597469488238be795f2e187fa016d590535b4ff10c62d2246aa17bb013f9ee02413c9f1590ce7a68fc84c617f478188e71aefe8c74c4b9979b8c9196bcc262205aecce5fd2bb80c360d3e20da20e36c5ab70d810d4ba97d13858199d3a1c9c140c63",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 254,
-          "comment" : "special case hash",
-          "msg" : "35393938313035383031",
-          "sig" : "308188024200be6b47254a3cf93e2e276adfb072256404744070d6dec83ef34e3e6c119206422bb275e61fc47053ef7b2af9e33aca8f8b2e4938057070eb6ebbcf82fabb44a5fe024201061ef80935ff6d0e9f87f3537b639945acf50c5d97d30b4b9c347e3f5f5ec02b15a376ae754d64b2efaa811b3d12a0fff0bc689022025dd2f69f2f4b40dda8687a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 255,
-          "comment" : "special case hash",
-          "msg" : "3136363737383237303537",
-          "sig" : "30818802420130b6fd7dec5cb6f90a8b54ce7b58c61b013d0aed7c4a26639de80aeac3d9e3388e9f87e1e6419d3f0339af324e1421b5d130317ffd9d8be36500a84bb41d026cea02420176b460a3eae01d8aa8ccffb0d6cf4d1595aa697c65510a1197b97343c1a6234552ce9d6d318c5f20f48bec0dc311dd62eb40058f3cb22fa958edaf9ddded191a08",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff0c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 256,
-          "comment" : "special case hash",
-          "msg" : "323036323134333632",
-          "sig" : "308188024200a87de42d827ae1f55d6fab3277c7a9fdfac3af22fe47e52bfee34fa1ee3e765095fff20175becbdc94b4a5ad3a149ea7c1bebf4d45370e6b4404a0437d8fae264f024201a3c1c5186d8aa491b4623f5765a388930f37bb8f3e1c0db508983585b9090b3aaf22bb846e0fb6d915b5811ac55e4d6cb08f605cb84deb55ab7fba2dde8736b1c4",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060201ff0c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 257,
-          "comment" : "special case hash",
-          "msg" : "36383432343936303435",
-          "sig" : "3081880242010e46055d9aa087f1c4b6056319cbf17a0694fe073266a3f30363030e345a4bd461acbd99d1261fc05ef3c9a1c37afba6e21c2d513ea3d4709de5586810d7d29ec6024200d0c95c7e97a94efb44aa717cd6ebe82de0644e32676d197351f128ee8d2b223ab476d3e66014ecc003081f7040c578b8984628d6ec80733f713e26b2c98cb4ede1",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050201ff3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 258,
-          "comment" : "special case hash",
-          "msg" : "33323639383937333231",
-          "sig" : "3081880242012c04d08a7a2d07403aba604ea85ec23a52b52786e7fce04170e867be6146eea75a7180f5d4f3b82a204a3c996811a1e61a3e76ed209c22428b35c51fe60f3bee1e0242016f2feabc25733b0a460463b9933e6e4ae9f4124cd0ad3785c77755dbf0848ec1cfd2ab08b960b556870fa00388d23d9a9fa3112ac3e62a0f342d58fb1f0aa81748",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=-1, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30080201ff3003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 259,
-          "comment" : "special case hash",
-          "msg" : "31333837333234363932",
-          "sig" : "308188024201ca9532c9daeb80d0dbc07a4138ba62a6bab8c88b9e1e2edf2675132eb97cfb26f4c395f3b9d1d1275694956b34c3ef72cd00bab86777465b9edba29a41b0114c6202420140eb6dddff253a7ff5b032d82fbd18e481a376fe242f6405b81b57165665c9bfe61e25cd3358245bdfb8de7632de72ed20cdacf384764096c8fe3a376563a348af",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3049024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 260,
-          "comment" : "special case hash",
-          "msg" : "34313138383837353336",
-          "sig" : "308188024200d609e1f1cc1adf5889dc6deda441682e760be08932b31592fef3ada143fb4940e4ea75ae519e4fb0769c4fbd33a52b183a21d0bba1ffa3fe50fd11f75c6ac58ff60242012400cc4ddc24ddcd47a6d639a2abdef29a65d4fe9175f51b316f4bf918bc918879495c572f8e98364e2e1aa0d4d53ad29e803a4470d94dd06a982a1d041bf2b5dd",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 261,
-          "comment" : "special case hash",
-          "msg" : "393838363036353435",
-          "sig" : "30818702413775a7e61bdda9a3a990ba9fde98f9d81d4b03195547bbd0658e1059daa00da9270671b2fada1bbbf13982f87c9f3f26dda5cd4f24de63bceb5fd9390163c58d260242010a03e4ba08f9e2b6915a6c0b83156b00f59efc5417394c51ca7616b58cf91ab7166d8459eb4eeb0d57146ed6560e173faf354b4390817e0aafb38294df25992cbd",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 262,
-          "comment" : "special case hash",
-          "msg" : "32343739313135383435",
-          "sig" : "3081880242017ab00a30c88faeced3e4a10f9c63785bc29e9af4499466bd8880827cfa580b6171f4a20f36487f7b94592946bca4162faf65872af6bfb1919e6b026c14e51e2740024201927515f6489e9b7d9cbf61e103295857c8131320217e7a86d3f2fdcb350da5b42c2dbe173fcb025d14da239d7d610de8475914748573429c9590d3594f4fa3aab3",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386409010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 263,
-          "comment" : "special case hash",
-          "msg" : "35303736383837333637",
-          "sig" : "30818602413b2ba1509aea9d42d400400033952a022fe7e00c7ad65c39a2f76d41130aada99c3cdfb9cf44575a2163de29f097beb9bd3aef9334e6fd0813dde2a087f938c5f602411afb56087dfd5cb4fff6679a114c340f3a59f6b3e1813373bf3ebe30cb5e8b285a5875d1b5a9120db80f70310201559f89bb1df147961d1ca4fcdb5e8e84cae082",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e913864090500",
+          "result" : "invalid"
         },
         {
           "tcId" : 264,
-          "comment" : "special case hash",
-          "msg" : "393838353036393637",
-          "sig" : "3081880242010efb321a347625343f5126ed8545017d799eb103c75558922eabe44211e8fd834655dc2ec5bee9bb3e44350eb6885e0ab974730222e55f13ad27c066722fecaa25024200d62e3d7ff9215369aa7da818db302e49033875010b2f9b73d25ca5b9bf2c62ed756686230cd5f4a37c1fa881c97e623919fab827de5995ab456a1fd7ac7b85b1f8",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e913864090c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 265,
-          "comment" : "special case hash",
-          "msg" : "32373231333036313331",
-          "sig" : "30818702412f778cd552f54da5f567f47e6979872ba130dc0890172bf3b3bb952f03c64bc8783abe9f056d60e1667780f5ea88f59ef33c735d540561a197d31fe34853a60a52024200bd2816f06372f2e3f2582d53e583e133a551aaec04ddc2fdb7b8131787e73e4295ac28a9604a2402ed5b272cc03be57dd4a7df84d9ee24cb0c2bf124ed927defee",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e913864090c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 266,
-          "comment" : "special case hash",
-          "msg" : "33323034313031363535",
-          "sig" : "3081880242012a459fffea70d3bfc13e9ea0abb10aae3910df604997cb5e4bb0548abd852abac6b9a32418c3b5ed4e7951ae88eecc0a2f1065caf24c6a814674e95682d9b493f2024200e2abd05c585e0c213a219a7e7d38b810d252ffea67650d4d1994a41c2ca325bb964920c6c2545381c45ca3e1eca05e00514b366cb0e1e49b8c236d383b260b9cbd",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e913864093000",
+          "result" : "invalid"
         },
         {
           "tcId" : 267,
-          "comment" : "special case hash",
-          "msg" : "33313530363830393530",
-          "sig" : "3081870242010f2653d94aa28bcbd667a5013f9b283d8487c44d093ee47660329398caa550ca9c9388c7aadeceacac1507e76590afb736adb3583f54f31ae25c9c717ec9f89b5e0241494448a7ffe4a4eed84b4602781ecef77a23fed116b1b791b8d2e4231b7ca2a7b6f06d132705932d446e61d344714ee24014fa5bb144a96572b3d48d038a55ad68",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=n, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3049024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e913864093003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 268,
-          "comment" : "special case hash",
-          "msg" : "31373237343630313033",
-          "sig" : "308188024200c2da48552c39d94f5a45427ae9dcd891b65cca33e624ad2532ffa333666b241d873336fab7bbd7b4c193db4d865cd50f0c1d8cb5c14cf3f089ad42dd43cfff634e0242014f2070dcf860b96a45f2a6061e4ec2a6ad64d7d0e9fbdb25aa93b99941be280f5c70c0e32b6234df545bace7341af94c140c865d44fa8ea7ebe0fe53bda44645df",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3049024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 269,
-          "comment" : "special case hash",
-          "msg" : "3134353731343631323235",
-          "sig" : "3081880242009bc6e74549b48a1e7c181b179687fb27d6e9acac47ec34b1b8bd044d329320544e4e568e67d17f4cda2f0a3fe303d561a11fc0c981ed9be2fcc6d397a43ad49e10024200ff295e43fec5b68b00ce8044434bcd17af1ba04a74556353e258d017ba26bed67f458fad5dd8e7d2734d56f59928c2419441a9e8c0573db3586ca056951ca935e0",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 270,
-          "comment" : "special case hash",
-          "msg" : "34313739353136303930",
-          "sig" : "308187024120963638d0b058494254efce57778ac65e5f23491f7adfa72e4713b7c03946b543c014d9660d855246f308085eeee495cd831b7dbece47aea48e90433bd0fe818402420161a4f4977fecae92d4f67e56f3338c7a9b820b5e05db1f28d05d71f7e5f36bc63f6edda4d3c1b2d73bb8a30c4d745b73e634ef574cf47656a372e3eb42cc038850",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 271,
-          "comment" : "special case hash",
-          "msg" : "35383932373133303534",
-          "sig" : "308187024201bcc5858597ce8d4dc5ffa6be33f7d804f2f8ef59c5db9301785e0cceb7ed57462f455a465710c7414570c9a35a3100bd15fa40e3ec350d1f75406c2a25885e9d76024143757d282fd1d44c253f9a05d8142c29a6d63c0a1f5508431bc9fb9b60a38b7f414e730e0d59b7b709706a67022e1922fe88b182a57443c58bd06a69ee7814bcab",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 272,
-          "comment" : "special case hash",
-          "msg" : "33383936313832323937",
-          "sig" : "308188024201240120b97ea67bcbd0e412d87137a13e347a870a2249375fccf8c004da35e592620774160e7b82aed1f57997fb015a764d014d4be1f389e5499777054576e7bf000242019f157ec3a2410853274bc4d8e7565e9eaa5dc47d5e515abc86c22fa6dc215482df5c0e2b885f37baef3a6ae83daac930617a5fb37bb03ce40f06fa4ece26cbb11c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0500",
+          "result" : "invalid"
         },
         {
           "tcId" : 273,
-          "comment" : "special case hash",
-          "msg" : "38323833333436373332",
-          "sig" : "308188024201a7536d55876f8392a6eba18f075118c273015844eb3536c727c004c1bf23067d57e8fe31872f8bf839640e80e06aba3c0a365a268cabc2da96d84550a569f17f9c024200e840b6a7cba718d91103faa134c2f63763f3b6b91db7ecbd3b10f10171a875712cb9384325411beca9a3aa87aaae3902c282d2dedaa1cbddd40ccf0d29975df22a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 274,
-          "comment" : "special case hash",
-          "msg" : "33333636393734383931",
-          "sig" : "3081880242013f72be1c331214f45007ff72ce54afce1c910a90e4ff3d176620ff3ca976c2b62d0cdf5d1134290ee97440715531455dc29818828094d366f959e1adc7d7e98ea4024201e80ac38ba69f3e53116e5432fbdb3b1e7ea1b43e5f86d1c0e3d1c469442dbb406ffe524f0685f71e811d94a9efa9ed38ccd9213f983983035f2add0b8f2fa4ae23",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 275,
-          "comment" : "special case hash",
-          "msg" : "32313939313533323239",
-          "sig" : "308188024201aceaa6d567ddb39ba52d297e60e4a814c9b476cab568c09d8ace878d846218dd2b5d2a2461f0d5a56c12f0bd803e3253dc5b387b94e86589cb1d0cb809c7071125024201b1fb021b10b593cf9e793cf22a88bde9a4b92f9e218094f270b093e8c6c95aced43d097bfa3354e6b98d195c599c2e6f13351c63c28967e08b7e497e120665c663",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3046024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3000",
+          "result" : "invalid"
         },
         {
           "tcId" : 276,
-          "comment" : "special case hash",
-          "msg" : "35363030333136383232",
-          "sig" : "308188024200f6ffb5dd786326041e74564b719d38924a28329868177c13463cff90c4b09d3d2dbc011281cc78aa0e5e8656123bc50605601a547bb4b1761f852a120ea46df9df024201a407fdd445614a16a5ebd4ba075c6c1d7564f3cfd477d6b2620abf18a5bf78311282ea45b9bff813f24c3c7854e6091c8055144f9592fbf2e456421a41c555d7a9",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=p, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3049024201ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff3003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 277,
-          "comment" : "special case hash",
-          "msg" : "383639363531363935",
-          "sig" : "308187024201a15af4d5ca3deadecd75ec1baec31c8d43fbc889466475e6c23106db4e63ab69003f56d819ddfc5a673c8289f9e6df806b07af57a2541af694e6489734c8eec837024169c35433a3217fcd738a65b7da9e81cd81f04f0ef060050b9c843e9e808d8b8175f3adaefa105d215ea9a46bf415fe2ac180958fcdd878d54f8d19d23e11b76d1a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0.25, s=0.25",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300a090380fe01090380fe01",
+          "result" : "invalid"
         },
         {
           "tcId" : 278,
-          "comment" : "special case hash",
-          "msg" : "36353833393236333732",
-          "sig" : "308188024200ba899f94841db6c33b850867c8906b436be3853640dbfc863197fa1e5a55ce25240f2be498b9bdcfc0a89dbdca192d8f84ca3c44e5e0ee6f83e7900e085e1bd48102420086e6d558de8d8f014a85cb4a5f6908627e7a1acd70581d9d9c7d14df44d437aa09e5a10a0b760e98d46731f2512ca1b0240c602b5f0a2030485e34de9c6cd08e7e",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=nan, s=nan",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006090142090142",
+          "result" : "invalid"
         },
         {
           "tcId" : 279,
-          "comment" : "special case hash",
-          "msg" : "3133323035303135373235",
-          "sig" : "3081880242008eb5c92dbf5e00888b85e6bf6617017e97c04ae950dd731856b9dfb20e0c0e5c54284f411231fed1d071b321f78618d2a75c139663fb9db3435214cbac5a0dcb4f024201da0dd29d4728fe6331c8e2ade5045b1237664aed157db2a6cbdeaf5abea81324e28920a1c49c334b1226441f88e1a7f2c7e01d63e950d4378f08973db16b2e6161",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=True, s=True",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010101010101",
+          "result" : "invalid"
         },
         {
           "tcId" : 280,
-          "comment" : "special case hash",
-          "msg" : "35303835333330373931",
-          "sig" : "30818802420130779f943df098ddb5315cdca4b731c83472d589f4ba4d32c172faf6b3a9e4154c0517fcc5c432eb269b0152297f6df490ece59496bea8047e2f32d0b5f91e85ef024200c9eb0b56273114ce2e553341247da86b813bfd65f143a5562bb1c874ff970523836bcdf390dc196e67dd75cd28112ef74afd51b1fb35333be0505a012efebd4e22",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=False, s=False",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010100010100",
+          "result" : "invalid"
         },
         {
           "tcId" : 281,
-          "comment" : "special case hash",
-          "msg" : "37383636383133313139",
-          "sig" : "3081870241593f0132f7b5c282355978a2cba73fd3bd5ce3272066d4ad9bd8bd8b3e2be0990071b3509ea445dd155cf97e294e2b8d1355809d880e10700eeab0eb8ebbaa4f0902420107eb3d5ed75cbb9bcb9278f2266c14c57cf703cbd8f7c7de45c51f0f3baf1dff6bb92f1cbf89ba649677bcdca776fc57f587ce714e2e43e6cc523f0d0a286d38fb",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=Null, s=Null",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300405000500",
+          "result" : "invalid"
         },
         {
           "tcId" : 282,
-          "comment" : "special case hash",
-          "msg" : "32303832353339343239",
-          "sig" : "3081880242016ded17fad10f945e3d953b4fd3b72898c370f15164bb7712673385c10bf3929bea293e08bfc30029a465138ad47abe604df807b31707fef55adf3e104920038e3b024200b76b212d74e4b6eb994d926e9e796975235fad90e339a21a329e6eed3fe96b6d3c0d5426e8464c4a9ed5cbe08eeb5e490f72e9e0406c0d76ad076b476d07c0144a",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=empyt UTF-8 string",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30040c000c00",
+          "result" : "invalid"
         },
         {
           "tcId" : 283,
-          "comment" : "special case hash",
-          "msg" : "3130303635393536363937",
-          "sig" : "308187024201f8624ffa5a6aa8d9d04ed1c2272ea55f5271ca2cfc9aa6a3778a0b8a230f611e5d65af18d8251a0cc4ace663878c33205239ee7e8388cc0a040ea51515072e3f6102412c1e61197229f40e840ea37325f3bd87a6cd32d080bd61bbde4b072cf7a0c8a89d402cd9235c26f19a084ddceb1cc0bae4006251ccbe10de3954e85a8c5efaf6cc",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=\"0\", s=\"0\"",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060c01300c0130",
+          "result" : "invalid"
         },
         {
           "tcId" : 284,
-          "comment" : "special case hash",
-          "msg" : "33303234313831363034",
-          "sig" : "3081880242012b01c6601ceca9e58e8abb85d1f6663df70cee761a756b77e45294f09ae609a6b76cfcd67f60e47a3494cb85511e33d92a8d297a1b89e9a9038c0c5b78c3a3d4ca0242010ef5d2fab59bd42e2e92a2fca7a975b959dfb372519330defc8fa8954bfcfb397ba939edb6a944a2ce9f6fafbfcda6092cddf628801f6dd8cd40cad4d809d5c1bf",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empty list, s=empty list",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300430003000",
+          "result" : "invalid"
         },
         {
           "tcId" : 285,
-          "comment" : "special case hash",
-          "msg" : "37373637383532383734",
-          "sig" : "308188024201c54a330b9dc47eb88dbf60c9ee49f2c7518c0a78baf642c74105fe283fa4c357ff22931ef42f92d16d6a0b806ef718539d21cad71955a530e21cab49a56f561673024201c2cc32c5a4d335c48d0cbb0407fb7e4729c57251afbf9534c5309b94e6aae13614a1f2514252f48cc7f143ee761782f8dcebf2fb490e08fdeaf570a7ed9d287da2",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=list containing 0, s=list containing 0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "300a30030201003003020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 286,
-          "comment" : "special case hash",
-          "msg" : "353434313939393734",
-          "sig" : "308188024201467b4511b9d6601da3557b8ed432c14a80e5999847be136c756a88dd5134689b5ab70d0a2e8fd8d6141e2b143282f98afb93b7e17609522dd9e64c9e4a31c7c34f024200f50ee66a1dfbf86167ba5968d4ee3506a7cffe0f521c1bf830d0867241e345d319e77eeca45858bb3062acbf8d100bc6bfd3127d57a7e91a8199e05052b8ccf304",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=0.25, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3008090380fe01020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 287,
-          "comment" : "special case hash",
-          "msg" : "35383433343830333931",
-          "sig" : "30818602417af90f6227750f917d65b1c60200c755158bb783a479be6877c59ed89ff595fea3f3a4137591aab23826ed385bd6156277364b5d603ca272259083e6e9ab5db3f9024170842eb62c894935b82da15ca611d9d754ef57859e0c912c0358d0820f4940cdf5360f116a7547a81bf65617f182e597eb1007e26c62838487ca021c3829a590db",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=nan, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006090142020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 288,
-          "comment" : "special case hash",
-          "msg" : "373138383932363239",
-          "sig" : "308188024200b0169e68062caa79f99ec0c72d83c4d0fc2a1c818665cfed1aba3e684392b9a95afb82ddd1de49e3fc3cb3889b4f5a86a7bdf944361db2cfa57021a7643fcfce9502420115ec784e042436892c6cc1bede0f4b7b6eb24b300b1f0c674999a6da816dbefb2d53f90b0dedb962a085e5209fcea50311130800d2a9249d279c7bde2f88622512",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=True, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010101020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 289,
-          "comment" : "special case hash",
-          "msg" : "31373433323233343433",
-          "sig" : "308188024201de4ed1ee81d5cffcf8256a06858cba5eb925ee68e3ed848ac98071b6e30c3b44b102a2de8117cce5b4f9e42603225e0dbcb3fcc171d1492e7ed8bcb6ec286c7de0024200fd1e93bbc8b8adeb7864a2bf8e29d6f9c0966fe3d543525bf268b57cd6fa8852bfe0d2750726d5445560f2fc211aa7859dd3ee10078ef907e49cd64326b397e01c",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=False, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006010100020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 290,
-          "comment" : "special case hash",
-          "msg" : "32343036303035393336",
-          "sig" : "308188024201fcafa62ee6275443d7277fc46e4c30b4db845ba45b5d6b54faf47bbf921f825f6fd0f23a38c0c7f4debc33add282afad1154c8707b6e18cd65adcb07d32915b46202420087a27b2bf3c35d18fd397e0cd7159516cf563b98441e030bfde93ceacd2c4e41228b7b33443ef0a351ce553d6d1d71c12092df796276175cd779b8090c4958b391",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=Null, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050500020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 291,
-          "comment" : "special case hash",
-          "msg" : "31363134303336393838",
-          "sig" : "308187024178989628acfba86d4bf28beeb9f44001fb8f2d8e245320a19efdede31eae3ec8b496faec30c85e8f63f8ae06046fe1d1575321fa04953e460f6b1386dd5df94edb0242012aba3349732e21a5bb27d7d6facd8c7688b9d0d0271d6a077f9d6d82db45b5456b767f4b9f1a80f487031f9c0b3ea833c63fdf9c6a25e6b424c19c2e55305d7a0f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empyt UTF-8 string, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30050c00020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 292,
-          "comment" : "special case hash",
-          "msg" : "32303935343235363835",
-          "sig" : "308187024114a5a46a3ba415f6e8c566ca1b15fa2055649687b1a9fc84cc0fa8631296898fe014e0d45927e4271396baa4cfb3675669b16e76c339db3c0edaf61337e8bebe91024201fb313129757f76754b60fdb1e4077f9fe3dd62c8bce52190cfeb9c03021cc92f6d7d1302b8a84733486bf769ae94d3db4b60b6df28fed481d3d7c510299f0c319f",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=\"0\", s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30060c0130020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 293,
-          "comment" : "special case hash",
-          "msg" : "31303038303938393833",
-          "sig" : "3081870242008a3250eb5f28b598c4a42890d25f6af84082d4376f84f1717e5112a76623e6fe0d207c39463d20bb86341bc26c9f68bcdf794671a01f90465025f87a8c52137edf02411ddd317f6622d9b032223f76765ba6c9116ae4b43a1bd357bc9db6fa62f0867dc5d8f781f08c1cbd49b4424fe8c22cfd1dcd07cfde7b3598342442589825aa67f7",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=empty list, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30053000020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 294,
-          "comment" : "special case hash",
-          "msg" : "31353734313437393237",
-          "sig" : "308187024160ee161741d5cb2dd0ff2cf9924aca0376b1544681627a31688e4d8b3b63a01adbb417ee113b9ba8d4d13b7b4e1b14b51a24dbc3f099b068d916aa94862ee081b40242015caff8d30141e1c163e3ec62b7e14874da624a6d8e0252d8e829860e5a49d3732321b625262e5c9b1ef348c3e7cbb1de8227513f320637866785e97e1931d35ccb",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Signature encoding contains incorrect types: r=list containing 0, s=0",
+          "flags" : [
+            "InvalidTypesInSignature"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30083003020100020100",
+          "result" : "invalid"
         },
         {
           "tcId" : 295,
-          "comment" : "special case hash",
-          "msg" : "32383636373731353232",
-          "sig" : "308188024200a1ef8229db9f45da38ae3b6d601110611e209878bbd03ac2a6de65e8402957c669a115e3f02d085fe2d031c61324b77052ab346b4b1a437b58062fb36f9d56cf45024200cc5c0a3b68970279ae16880f6ca579d0171a827e99a46aa82b9242dcc09cb0b22a44ebcfca84293e6d21aeea492f00ba3157c5b6e2e4caea6a1c09c824720552f2",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "Edge case for Shamir multiplication",
+          "flags" : [
+            "EdgeCaseShamirMultiplication"
+          ],
+          "msg" : "39353032",
+          "sig" : "308187024200b4b10646a668c385e1c4da613eb6592c0976fc4df843fc446f20673be5ac18c7d8608a943f019d96216254b09de5f20f3159402ced88ef805a4154f780e093e044024165cd4e7f2d8b752c35a62fc11a4ab745a91ca80698a226b41f156fb764b79f4d76548140eb94d2c477c0a9be3e1d4d1acbf9cf449701c10bd47c2e3698b3287934",
+          "result" : "valid"
         },
         {
           "tcId" : 296,
           "comment" : "special case hash",
-          "msg" : "31363934323830373837",
-          "sig" : "30818702415aa0c8a378c4e02bcc2f56c2c365ccee424e2973c28f0daae8f4c3f0d90b421fefd456e749087e0c667c2a7147bc67b90c696244f216b4d9d7418eadc7d06ef1d2024201e28914bd341f526b041128f2d251131d8b2c65847e541d65adca3442962cddb2a71c64fae39fdd56e41686ad632f99c6038d8de0b3aac4045e0a961efdbf4c6a22",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33393439313934313732",
+          "sig" : "308188024201209e6f7b6f2f764261766d4106c3e4a43ac615f645f3ef5c7139651e86e4a177f9c2ab68027afbc6784ccb78d05c258a8b9b18fb1c0f28be4d024da90738fbd374024201ade5d2cb6bf79d80583aeb11ac3254fc151fa363305508a0f121457d00911f8f5ef6d4ec27460d26f3b56f4447f434ff9abe6a91e5055e7fe7707345e562983d64",
+          "result" : "valid"
         },
         {
           "tcId" : 297,
           "comment" : "special case hash",
-          "msg" : "39393231363932353638",
-          "sig" : "30818702415a05f5366c8b8be28654bc39a6671d1b1593495e445c07c995c3be3e168ffdec92e44288802fd455007f8746570d93b5683e4d40e9d9e59de539f0e62bc40d92bc02420187a47d8f70adcc5e10267b8fec89d7011d9985427645aed19a8efa2d1189b469cb7aab1998e0c1d2fcac5a5054d79d2ec1c9a00b183dc9af20f555a1140be2dcef",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35333637363431383737",
+          "sig" : "308188024201c0832c973a455cac48a4439659aa21146036c52ec1514121c66714348a1c0e2c7099a2466d9acb49325a0cb509e5dff2efbcd90369d3027cbb7dca58a134278d05024200a426c063ab5cc6af20dd1ba8a519fac910183561598e67c0929e25f9c3aaeb245c5647fba21e30c103304dc6f49e6dec68a7833533e4e5448240bde023fe201eb9",
+          "result" : "valid"
         },
         {
           "tcId" : 298,
           "comment" : "special case hash",
-          "msg" : "3131363039343339373938",
-          "sig" : "308187024201e213bcb8b960b1296ae176993b2449bae556b6d90df2f07fb08ad8fd60e3b7fe6c73f9c8a7364417611d60119c550261c54bbca8d61e264130ab90187e27d22dbd024134f519382cfacfd07b0a6f3aca117c13d2be725d2f9ee4e5f88739c99121e63ed7358046bfb1575fc73e1ede8339e46c5139843e52e9184bb8c579061a154a0b8f",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35363731343831303935",
+          "sig" : "30818702410d01cde64dda4dbcef1a9b924779598217b97eb688d9b4a4fd20d1b81ff0bb870abff1b0db6dfc3762f27c3954f230a7933d9ea397a972caac5ed2183ec72716c7024201c6530fb6b913005f81e156be89b3847701829fbb310d8a4c761212c6d2f8750174f2bf81c238fdde4370fa87de320f57dbed96691af45cb99f3daa865edcdda59e",
+          "result" : "valid"
         },
         {
           "tcId" : 299,
           "comment" : "special case hash",
-          "msg" : "37313836313632313030",
-          "sig" : "308188024200ed11ac7efb1f29ee64108a5e2606fa9af3bbc12d1a952e47240d5236df64f5b2b77a0f7a0a73d30d0708b5b23ac6d584bf6997d8851623793655dee8774549b829024201e1602a2cae7d3212df47eebd12e2fe404851201101bbde702be9d74d040ed998e79a09ebf6d055f94473b1f8d87c99aa165bdaf0a5f270d46caabb8e88bfa54103",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131323037313732393039",
+          "sig" : "308187024200c009c74ec707252325d78f4e7f14be28f56272be17c0c18c90ad4c07322cef4eea444c8feabf41a213e3e846f8ac8bb7750d49143069cd01877d530bb981f1a85b02411f1c27ef97f434a8c2ff315dd39d909709775bb3c7588243bdfd8f7c866c49b3369719d5b74a47924bbce57301675e2baadcec438e07e6d532aba664253ab09550",
+          "result" : "valid"
         },
         {
           "tcId" : 300,
           "comment" : "special case hash",
-          "msg" : "33323934333437313737",
-          "sig" : "308187024107123c45e6e9338bc9fe225cdd96c5ab36cad5c06163f44f6bd903c7594e8068ba9bc89f652ec31b6e1298766b246c1f10877f1e3ec9829b0937b8d36e3c1ab2b5024201688bbaeb188b5047be6e8023b14fb121eb1451dcb19f814f5f4dca55ff95128011e3bae505a4d22166d00cb7cf14130590335ee923dc5db3e736832a128a067aa4",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131323938303334323336",
+          "sig" : "308188024201d3b17a34b19d134773988c434a9fb7f22a57dfb4c4bcca031e213e1b9a56db0ecb2f3c54cf9b1b6e5981369652de37337a7a7d7ddb54d67b067bbce01fd7fd2808024200c90317dfa061122557eb3899939924a8ea3cdd886e0f2e5f2c384b65b1a40de5f00fd9fce889fc313a6a9d5f0a9cd3a7b89b7ba8e97807031f3d1e3f9c103f0a10",
+          "result" : "valid"
         },
         {
           "tcId" : 301,
           "comment" : "special case hash",
-          "msg" : "3138353134343535313230",
-          "sig" : "308187024201264e3cc4fb802aa221d0787cd0cdf44eb6568982a00a6639f15238af36e894b14f45f06f8c2180fdeaaac77f674e056d1928cbbdfc4b2ceca0b35345ca07bfff7f02415c2dedee6b3aa096fc47ba0991a077ef4d5df20d8eff1bf8354412b171f08a98cea1704c8189a7951b0e7a8270ccb285b8db8e35285ed926b19c1eef07fdc05ee5",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "39383736303239363833",
+          "sig" : "308188024200cdca5299e788600a3ca5938d4a4c5f42b5eea3cefc990e67af95a4449aac0ab50e8fc4778efa497223cdca07c0e5a5920110f3a87afaaf265beadbb91c00d13464024201a92b9a5570b42f91ebc3d8ba272db9241468154783548d3fcfb6ef46c9e037bb6217af0a31ef952c27604629ad5775e7695c63efa138cee8326a51c1b04d0c658f",
+          "result" : "valid"
         },
         {
           "tcId" : 302,
           "comment" : "special case hash",
-          "msg" : "343736303433393330",
-          "sig" : "308188024200ca3814747888751794b0488955e2aee07e5fab4b9872074aa7432698e7c83b8079773734df1bc752548a218fa59a362e0657b77ae7798ef4a7a3873256ea59ec670242015df8f1f16611c960d56647424b97936c8a06f62dc3a95d66bf4aa378d7a9e17d2afb53565780025927e6928f5313428f1d6708339787c8f460ba18457d4c0f521f",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3230323034323936353139",
+          "sig" : "308188024201660b0ed15d5f63044cb189e1a405bcb591c37217d0e000008614b152665d5bb9353a3826854a8bc6ebed423b15680e4340a00701b17bae24bd399bcff7e0438bfb024201c47f2f5c6143d2eef063757114aaeb27827b6a8f675d1825dac7f4548cbf78a37eb9621a29e9b14cf61fc6ae49e7e6e15350a4b90a4a897ff69b0c59b69508ebc7",
+          "result" : "valid"
         },
         {
           "tcId" : 303,
           "comment" : "special case hash",
-          "msg" : "32353637333738373431",
-          "sig" : "3081870242017ba871aee34a893c4ded7a2a546da0d6867d428497b80fca7eea6e51b73d6411aff7609743e6242b6d4d3736ddcc9ee1aa12c8b62de5382e5c33d1fc4853e3e47d02415feb9d9f8fdd44622e4f9effe73fd9b467d355fd6b8de205527f722ee2f5a15eebd59ccdd7b57da26cf953f78886db5a6e5bdd0d56c9bd47ba2271f77687a64b63",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31343531363639313830",
+          "sig" : "3081870241364684856c7c02bfb2ad2de603d10883ca93c122d4cebef276467a9b7620fb530e4d05d07c15ab948b9ce7682561307913b64ea6896ece1095dc64369f1a9d5c0d0242009e6db2ff96d9d71150440fd44992656ca118fcaf6bd04499314e8ba61a55a8790aac023ddb68600fbd7ed4cd4decb176e8bd7822ea31d75adcbdaccafcf510c26c",
+          "result" : "valid"
         },
         {
           "tcId" : 304,
           "comment" : "special case hash",
-          "msg" : "35373339393334393935",
-          "sig" : "308188024201840793684765410baf26b66cbcf7c36658d6c18a2f750c1225520e9f3a7c1b890583f321d4e48752c3b3116dfef733ee386c52a53402acea77cfad1db9380110e6024201b51985a306fcdbe3692181106d7d6308873912d003946992098bc98b4261fd78869ed8218849459780b6079f6899a47fcb9ea4874d1c08fab82c6f1e9c9aaae245",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31303933363835393531",
+          "sig" : "308188024201a317e49014f1bf3afc09cc048531010e2144b662cac657e51b32bb432d274a730b535fb2de66fa8ddd26faa3f46e004389d25517c56e7d8a1d39563b0e8c9c215b024201ad2e1212e1680b660a1c07f54addff575c8c8298e26a14c516f517fb5f966a2b383aa46a483fdbfa72711d60c0f67a2c03d63d2626ffe271e0ce353a4d4b09bd5e",
+          "result" : "valid"
         },
         {
           "tcId" : 305,
           "comment" : "special case hash",
-          "msg" : "33343738333636313339",
-          "sig" : "3081870242012276720b2725ba556d06be39cd16ca0a0351d8f530913c4f0cfb71fdda74b83f02febddc8da0a1f0f910d37d3f5332c027d7bd4c38fd08ebc770bf1252078649540241637e70b06045a86e2f329f907e079a785d7f8649541860322fb8b64b9736363f90156b9a5532d808cf2af33b87ff970c02e648dc4f1c90ff0704028ec2c2d9a82d",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36323139353630323031",
+          "sig" : "308188024201c09b29fc4da04e9b86097bd6d6806aa969ceb37ce52eeac5e9518d27541c3f30c00f113d9dd3b007dae6f381896d43fc6ddfb3fa256a36529b054e416ed638059902420113e5622cb1e4c4bb0842f3d396d7e660241116e94e8120a602e3d2952701b1a11415a3d8c503adced160450fd13157ad147d2d65d77449458659350e20a545602e",
+          "result" : "valid"
         },
         {
           "tcId" : 306,
           "comment" : "special case hash",
-          "msg" : "363439303532363032",
-          "sig" : "30818702417aade608b22c77245734fc5c4be8737ba24dc2ed4321b58124ae46a77ea7befaa5bcf166cb966aad007911623af10925a324bc3c6d06f24d0e2e7b2c7b8468b8ee024201e9913a412300b3980719148de0bb03826184aabd58f19659aa8ca18045f36c73c97df3d12b921de510ffa96ceac5454b801c86c55a06b2d771fa77bca784332c39",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35363832343734333033",
+          "sig" : "308187024178f4a2968460ea8f64a938b3a97c914eb0ccfa94eb08636efee9d5ad8668ce1c9099573abd146df9e7b2ccaaa1a25de903f85962849356a872e88e545babc28974024200f2729e9593c9fcdf5971b21e367ffdc87aa7520393527c6f68ab512b88b839003c1c9952b04f2dc74010a31071ee20a9fb1c7e1187d04de71b3f4327df128ccd43",
+          "result" : "valid"
         },
         {
           "tcId" : 307,
           "comment" : "special case hash",
-          "msg" : "34373633383837343936",
-          "sig" : "308187024201eefc7b6c1468ffa7d60b8408bd44c64a3ffaff298168c5016c6f504031867ea14ae48c661b8124418b4ed6ccc32df6bac6d0a485b1990236e15676268b7868d2760241515d48436afffdb65caed737116a861974b734bd1903e37dbbc231a9db37464ed762e364cac8b32f1546d6de37979fa05f8b80159a0f747d9470291af6569d6d94",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33373336353331373836",
+          "sig" : "3081870242019faed147a76b65779d0989e1300802844c9ba09f338c5e31a24d9ebf8f0b0b4c21f59d369ac10e315fa2b7605b0f17a9c07cf6ce4c83838e58333a3390142d79d002415f4de71fdaced1e8da86efd47ecbdac6a6ffc6d69df71da7ceb5596475cdfecea3d00f074d2de89e0fcc05e3231d531f0d38f2b7c6fe4ecf67a0cdddc21d0867b8",
+          "result" : "valid"
         },
         {
           "tcId" : 308,
           "comment" : "special case hash",
-          "msg" : "353739303230303830",
-          "sig" : "308188024201271b912ca055040c227955df729757654aa9bbdb73c61ba14155220e4e7132319f6fb0ee94f2fbe160738f1dce2ad690845c38d962db4fda1598e93270da84a2bb024200b8907f041c3b19b9234ab555d0b48325b0cd330889a53276a1e913bab892b9c05cfa889005b14ee2730220746aecf12af911c5baea4be377ee76c0eeaf47b7a712",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34373935393033373932",
+          "sig" : "308188024200d0b144350a2128f042bc1a27f6c021dad1ec031be8f1d8304797f9ddcb742974aae209f014980174b9d4e434e3f53247889d2da4b767593179cb4eda47e799643002420184d3416dee35ba8807703a91ac927096c10959a05cbffd8103a93a9f20a11537bed7a645f32295e4abce493579caa4e2242060cc4d58b2414870e98b9336795787",
+          "result" : "valid"
         },
         {
           "tcId" : 309,
           "comment" : "special case hash",
-          "msg" : "35333434373837383438",
-          "sig" : "3081880242016a813db0f75f9047fb11f3e19fc1688c29328a54f56ae30c1c9d9378537bfc40c5719d084e49a3b4aea255f5b7f6cc775492b5371e6b67b2d6abd5743e10fac709024201c258ffd830151bfd41ccdabb86b24af846612788b361c196d24e997ccf3f17d4452f63d32851a483072e6908095e5c49bbc241a0417749b097bc1ca0e4d127779b",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "39333939363131303037",
+          "sig" : "308187024105257a0f45ee2ae5cc30283d23c47c96f6deaa3ac1473e8e8a40eaf61bc4b0ef8bd18d11983f257ec4b1d8d04e76a122b5bbe1d31065159072c58fd9bc3e98376802420122dba50d0eb71bdbf092a94a7ea280412906e1f849e91dbd5d8158e3fc6cd12e20461b77653e3df2e45b86883f81071b33651ae1b84cc8e7c365ab8d6a36d1cfa6",
+          "result" : "valid"
         },
         {
           "tcId" : 310,
           "comment" : "special case hash",
-          "msg" : "3139323636343130393230",
-          "sig" : "3081870241156a04c22ea5bdb7871124f1117301d781113ac4c9d4da05fea536e983d9261d25dc97006f8c78de23c788718557cf6f98863994af2086f0be3e8aa8812dc3a11d024200ffca96b04c56a4a6ce5d22b36e44d3b974d520e7f7c0f9d69034f9e59e0bbdc43236b3e4bfb0f6bde8802cc5cd6022cff166f4c488d64f38d44e3c563da31cf6fe",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31303837343931313835",
+          "sig" : "3081880242014f624af9d8096fe7a290651d23ab260da64e44b886fef4f3881d0d984d3b387fddcf65b1fa1dbb239028fbab4a1de6ad150cc8a4e4db0a971bb8bcf01c4728ff9802420105e3b55db0141c06d9854096cc0f73415dd2b85a331da50cfea3bbf648bbf8651f61f2cd09386b62fbb8ce67248683c260894d9ed54d6667ae02978e38ab99320a",
+          "result" : "valid"
         },
         {
           "tcId" : 311,
           "comment" : "special case hash",
-          "msg" : "33373033393135373035",
-          "sig" : "3081880242010913540ad73ceef7314d1758264e1d1525a371a7b9b3086971599a6b749be4d6ba69269b089508f6500dd925aa89a7c7cb7185e0cca7d2ee5664f22845d961e31702420135256c79ea5e5768fb3a55e2899b12219b8f68953ccd98c710b6a13de0f59786f4331845e65c7dd6340023a5e280206ca31416058f395fff4bb5de411ff66fc018",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323336363738353030",
+          "sig" : "30818702412c952d7e61e1097cd7f709e62ec486879b380b63791c146b545c064e65b3060250d00af279cf15eade67384b28594db542845fcc6574ef5d8d5bb8a162e0350a0002420135ac6d1cc05b095fbae28b652fe5386b8689e21a14990236d3ada7ceeb0c12a4f774bff7b81c8d07572b0c7985364c5d31f33271f0ac3a2afb88b46bfeefbaeaa8",
+          "result" : "valid"
         },
         {
           "tcId" : 312,
           "comment" : "special case hash",
-          "msg" : "3831353435373730",
-          "sig" : "308188024201b5051ca0dd3b20df7d8c5b92cb42b8a204f92fb4e58c612f43d3800de8c0683c427e832ce622156747052b81bfbf6ed5fa177b6d47858ec8478f6c9ca7948fd511024201fe5710fac0e9d3e2b3b83081b28b194b822d0c13397bf1516140cbe3faa52e908848f69789a741b9cd54d703a94577fa813e2f2c75834807401ca010fde5328317",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31343438393937373033",
+          "sig" : "3081880242017919eff78225e1937a921f98f5d153cbffa03929819f228ee013f8e59549b04b9867006a8df25a93a6a25dd1d3f540239a8ed14047ea00811da9305ec515ad000d0242011fb873bdae1757801e575c5df62cf82a1881af3cd6ed17dc50edbe6c5fd0f4d31766670b2aa572a9e6547b36142afa8464d0be4bf41930629dc04c85e01b2ee8e2",
+          "result" : "valid"
         },
         {
           "tcId" : 313,
           "comment" : "special case hash",
-          "msg" : "313935353330333737",
-          "sig" : "3081870242008d3c8f8e7ab74d49e16a4c7db3a393fa9567777e373313667f9ce32b1b5e648debffedfd2ff5345ca1b8154c18c8b883957d911e41336285f86261c3ee225fdedd02413c51b84c2c9a3feb76a6518634b6f09c0dde8a9d08dec0b3d66135cc1bdb0a80fd69636104af69de8f4062646b29fa3af685ec82704cef706a18c59ca7eca0fb56",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35373134363332383037",
+          "sig" : "30818702416ac9b370067b13ac2b57f35d6d9b1faa93b9b068ef5ddf8bde3a54024810aa2226560065b0cb7501df96b4756ce1e1fa607f86a942367894a1f7728bd5f22cf1770242008b47a9e1370c9f5bf4677d554c00e9ac3ea7cdfc78836ac53ac710b7f3bff8c2297780c69a9fddb80e03a605e5e48a52e52fd35f41668cd9064886366fda206086",
+          "result" : "valid"
         },
         {
           "tcId" : 314,
           "comment" : "special case hash",
-          "msg" : "31323637383130393033",
-          "sig" : "308187024201195625a64ac11c4fc1fc479ef80430eb85c1af77f8a197a17e009569ef6c41ac6f35850755379f478d8928b154e3baaa29e92b481ac04dc72f3728b4f088ff37dc02410d55c7067877dd1302fdc6bb69b7b7c024e4cf3a0e924102d744ac52366d9d76d5855d3da228c4b67bc7bc4b2a14e7999962cc9bbdc517fc24a823abf584b8f56e",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "323236343837343932",
+          "sig" : "308187024200c4bcfff265cd32442220976ffc7e4ec09181d694696eb89af0cb2d5a2dfc3876deb3c6adea168965200c355c3bff5e47ab17ecc44c8434333280796d3a183449ea024162debe91550f8a760eaea309f48483c65a52c7e88a83867c31730cbc6b0a64d4c564bde67e6539af787ecfd18016cde46ddf91740f58f6ea6ec80b173fd1c47ad0",
+          "result" : "valid"
         },
         {
           "tcId" : 315,
           "comment" : "special case hash",
-          "msg" : "3131313830373230383135",
-          "sig" : "308187024126eb68bc0fb7664c35bf5762cd532dce33b0e396e97d6f4143dc6e1e766c836e27c069da9ea1e74e0b03d030cf8a81490508c1c728f86e59282df94de8d8a0dcaf024200a9fb584b712986f19ab7568693df278cafa43272dba400ff333cf48b5556e6e78353a665605c70b6fd0f18f30b850e1a47cda42c4c924bca80102e6793be9a8698",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35333533343439343739",
+          "sig" : "30818802420174d744ddc631fcf8202fca0ab10f6d96d3f7552bb2a9ae5ac573634133f61c59a120fedbc39cfb521ab0cd572afbd5147981090d1dcbfe902e03f0c0579967b5810242012f59ca927c4ae331d2f667fcd9ec01b0b5514e2ab5da0561ea614431dc1fcb761c351cd1211092720ebb7074a5128f8019b7c18e048d5ed3573ed61686e9713f72",
+          "result" : "valid"
         },
         {
           "tcId" : 316,
           "comment" : "special case hash",
-          "msg" : "38333831383639323930",
-          "sig" : "308188024200f3d34e36f9754dfa8eafab160ca96d91c7f4f388ec82ac33784026bb6c6a035719eaeec3ee511fffb22dd5d6ab819e6c6387192d6c3a6e9249ead565157e323f62024201b5786b1d662d26fe9f69c370d2bc18882abef693c8f17100a02725de7c9f03602fd53a9208b573b3b7b0b66db971767bde835f9e8f42ada201e7b7391b86fe0294",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34373837333033383830",
+          "sig" : "3081880242019a513cfaf871287340d8a51d2f4348ab4096c5fe244b22add38ce433e3178e8ff5b2df0fe74a1ba40fe8341f734c71f9a1177b41035777e2da6b082e0b566690de024200d0c43eb33a817c3aab30281c593c74517ee84e958b114395ce0b31fcf30bb8f5dfe60dbc7f6f14698977d8e0516a9274a5bd71847057e006fa315fae6922eaaa55",
+          "result" : "valid"
         },
         {
           "tcId" : 317,
           "comment" : "special case hash",
-          "msg" : "33313331323837323737",
-          "sig" : "308188024200e69c833b604075e9b28a2ff73a56a32e1a247ef9ae01e7a0e471f6015c2b86eb864c281c8c93d2acf5653ad05bafab2f58027f37513eb8569f50bd475e770e9a81024200b9c9d6ce09b53025bfcaa7d172ae41a9b636aa4b80a930931fc99e5e2aa23306f19dc57399b0431e72440a1f4ec7d5ca902f0f7b81c91de85e469f992fdfd4c52e",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32323332313935383233",
+          "sig" : "3081870242013204800efcb40ab09ae4137325a3e8c468edae91880a51616ba61f3ef1f72fd89feb956bfb39818d827468bb4475110a04779fd6bb3def25c61c4ba60889ed0ff70241704b7394687698c8841f4875d40e5b3c914f154ccb2b54466ae163ed3410f20d0a07ac5f90c0c31271ec8a524ca2dae4b8bc4f6e1ece173ea907890693c5f2190c",
+          "result" : "valid"
         },
         {
           "tcId" : 318,
           "comment" : "special case hash",
-          "msg" : "3134333331393236353338",
-          "sig" : "308188024201c6b8b5cf3c4dd3d62391f18e97eef3aa6ace0ae2c6fc97a561cb8e49c087dbcf8135fa433b566b3385cb57202f1b12164fe62765ef73b72a94e7a57870989a498102420185944434b83a0d0fb4bcdce8ddaadb30a1e440815e7674562df9c8bf711222208cc346b9665d90abedb437912391505dd5d26f0178e7c063790f5518f47d1b05c7",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130373339333931393137",
+          "sig" : "30818802420180241cd2e6163158a39599890dabee99c2c86b88accd2b04b5a72874fbdfbde0d18143c4d78e0da1abf3796b238738840d60e34775a8ff810d58a9bb3559a3997c024200bc396c2ef28b244fb8e004bf5361572ba1fef6fbe081ed1dedba4d9af78deee126599f75a0a9d0f1b1618ded7a0c5e672e40917fdd30582460da3aeb1e9c4477d7",
+          "result" : "valid"
         },
         {
           "tcId" : 319,
           "comment" : "special case hash",
-          "msg" : "333434393038323336",
-          "sig" : "3081880242009f351a41d5375b8993e90b8d8a65bf01d52d14aba1dbe49cbb4ea823804f2b533e0c167903c8bbc593297c18f309798a544787d598074cbf56ef0e5022520912ad024201b892740a57204186bd5f434f72d1534b4289f8f7114cb7b1c9cf4541d754f314448cc32deaf35608263488fdc7596f7481ec098b36f8e440829194becc746c77f5",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31383831303237333135",
+          "sig" : "308188024201485fc03fcd629fd4c564775ab6969bbc696b5b0f38141b69f86e052e7fe8849a64af2dd37a2adf64672f20bd6f97cd32f0efea51aa22064c5f10a3911177e1979d02420180fab473ff9d726db6d266541a0bddff8610e4026d26b6c9abf972eaef477d50670bdd3067c9d711a8346e16869147751e89b4ea75bb00ece71300cc3b80cf8899",
+          "result" : "valid"
         },
         {
           "tcId" : 320,
           "comment" : "special case hash",
-          "msg" : "36383239383335393239",
-          "sig" : "308187024201fe24ea831199e31cc68ef23980c4babd3773040870af8823a19708bd0229adc1ce99d02e4d95224101e3e974236f54df86051fa1e9fd21380432633b2495ab782a02410efd1f2a281f967e7b09d721581356a714c499f9b14f781992eb9ae7a19f6825045fdc6d9d763f44e1e7c91480a678a1d8ecf6d66e76cea3505f65ff78cff15cbd",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36303631363933393037",
+          "sig" : "308188024201bea49b150a27026fdf848297b0491019f76abf90f3e6d782e3d3fa6caddb81b7ef58b27f1b2b3f7898889b4e2b6cdda7b5636177a27eb9a67b2055b6f21d262c26024200dffb13c2d5f746c8573aa444afc8baf8bf881cc4d0fca8169f6cb304f400eb3932666cd3758c437c9cad79abfd89c72a788505763aabdfabf8903ad4a70d9ec9f7",
+          "result" : "valid"
         },
         {
           "tcId" : 321,
           "comment" : "special case hash",
-          "msg" : "33343435313538303233",
-          "sig" : "3081870242014c6ee9de0a2a0b60c981831e0acd6636b46ae134fedce61b0488112663b24e1d7e74e227fea883d26b68f21e4135ba0e2069bbe0d9c6433c3908fd5b00182894b002416a180a493182c6bc2a09d7e17ff5d62015293f1e8ae205a16fa09042b0a9af6794cb377f4b8b1175fcee5137c234900f735c484feb7da4cbb405cf9e5370fe4f49",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "38383935323237303934",
+          "sig" : "308187024201d56bf6f3758f627f470706d1d28c28fbfcad6dc30465cb285a274fc057f791de73ac30baccde044473fa9e3dce6d395eadf98d1f97259bd851a1eb6f3d31d2d756024133704b4ad37300a96682569f4f7fea3e14d6e1f65864663f39aa67f40b5c949f198d5de9f2ac2369bbb9111c89b393199537c6c08ed7c02709c733ef7660113d53",
+          "result" : "valid"
         },
         {
           "tcId" : 322,
           "comment" : "special case hash",
-          "msg" : "3132363937393837363434",
-          "sig" : "308188024201044a45853ada17ca761acc7df6d1d380252cb0fa66124d9278a5ed8a4a60453bc71de1dbe32b0261165948823c461c7c1eb1714ec1dbf66fd602c7a47446d1dae1024200f8b27f7c71e37e4b440d2c86f1c1d50bf7c53d3878ed27e7bcfbeb902f769f86d6c3e8820b99f890050f0dbebd2132e84626c5b16a8c7ffffc3a30ace69dd15a11",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31353830323334303934",
+          "sig" : "308188024201554035ba84b051d50901c622b98be4de0123a02928dffa7eb13b0403fd5e255f226505e15694956a66a878ff581173d123d1b24eaa85c5fe46d8973a55040ff405024201b016dd6b5176ad8347eb9802dd7727e06a29db33cc946f809a42f9193040692b0f82ebbd04eff9f099b7f75f8e45e74ac00a51a9cd4f2cbf5f03f4d2bee99c24eb",
+          "result" : "valid"
         },
         {
           "tcId" : 323,
           "comment" : "special case hash",
-          "msg" : "333939323432353533",
-          "sig" : "3081870241676a381b18d05207cddd73b44e4dd71449985c0fa7de1fff43ca5155139a1a09e5e3fd754d86ebbe32f6609f6e906d48d24790e494343c61faa90bfdaa4f49fdc7024200fbc1c891bf6e368fccad51cc9b2c29e8e92b658e88c0d23285af269aff6702a55a0ab16807e5523b6637bbb004727f6f55c51ad4cec8c924f9c1feb24601aeddef",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33393635393931353132",
+          "sig" : "3081860241293e8d6775f3c14183aecc22f608e9013d7b15dad167bb38a1dfef6b373619f1ba2751d77b43f643f68643cfdb5c04a8ed858bfcf3858a681ae93bfc7cd7e3143802412c7d96db7dbbe347bab9f6f7b88f48cb32ab963248737d2c901b90d64591cbdb0f0ca7a14557f8a50fd80d402f929dad141141f1f0c85d9414b32d1fd4d796e6e7",
+          "result" : "valid"
         },
         {
           "tcId" : 324,
           "comment" : "special case hash",
-          "msg" : "31363031393737393737",
-          "sig" : "3081880242013c9a575382ff6881c908fb5184be7baf38edb0b06008592558efd57dd8fb9993c893800a6ac8c6d2e34ebfbeff43e63263f133868d0ac7a838f69aff26d60a38490242009d22ae7bca8a75a53214c3eece437fb28e05b076ec704d751a28a7ed7e529d5c5338be8c724afa547574a17f70510b2462748a53678e39752a688dc8cf39e886c2",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32323838373332313938",
+          "sig" : "308188024200b16a9b3aceece85908125f96f6cb6b1afd0ef04171936b3766f8e43beb340d382084b33439f775a29a83945da8efc4190db1343e87d8c0ffb97aeb3be159d90f59024200e5c2bbd98e449bd0bb4f75a07f1a88dd63c0602a7660f4acd33937c4913a9c16ba44dc5808892ec88a4255109a7bc5b221c07e6a278888a9712fc2a25b374427e3",
+          "result" : "valid"
         },
         {
           "tcId" : 325,
           "comment" : "special case hash",
-          "msg" : "3130383738373535313435",
-          "sig" : "308188024201071ce5a19a09aacd43c7cacd58a439dcca4e85f94ea1d48a60f298ee01bb3eeb11d5daf545e7086486f8e4b518a15be69620ab920cf95c5c15ff178c903124fac3024201ad6eaeedece9a7592bd21508b2720f1b8c4bf55637b1e8a5ce5359775b980b21eb1d33e8ebf5c0b3d7829152a295b8a9a1343c25350e35f709936accc8ce08b0b1",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32323330383837333139",
+          "sig" : "30818702413b47a8ed52f5b0566365313520bc0b6e4e4efb3ea4176ed7a352c4b2f8bffbdb0148ff44f3f13d9e5e31b1cdeae097574aad8bf393c54a5c842e749ee87a74c6b0024201d3f484e9e224bda9c8f10fbb74bbb62d7a18245707f4eb52f17dde793892c16e4bdf504960fba55da487f542d412b1b833f6f46336118618fcff69469c83963777",
+          "result" : "valid"
         },
         {
           "tcId" : 326,
           "comment" : "special case hash",
-          "msg" : "37303034323532393939",
-          "sig" : "308188024201bdae499160f4cc6cd163cf110bb1f9b421e8786a8ef9297e4b98fd508a1d14c50617c8d1a3de94fc8bd6c38055e4906b20fdcab6ef7bf9e7e5c98ef3e83e38ec3b024201ba867b8ee72bb7304ff83fc2d734749447420791d5609e0515de4e05fa70a83385a853cac6c47a075c8c61e4b65b9774574101cf4e081770f83ae1b7e727010ba3",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "313239303536393337",
+          "sig" : "30818802420128b8988bfe9287f82ac97be507a544b823e85cc2813b6929e63699cff85a40283076028e7bf8d24330f89adb96bf24a4e183a898e679b36768909574e7d4733d61024200c18aae44e6801fc2e3d9c7a20ff9d42b46e4a31ca37772f8c46ce65219b195ca23717f816e1fed51e5b6f9a0ca12c3cf81ae7fc9cc6946a88330b2011ddd160930",
+          "result" : "valid"
         },
         {
           "tcId" : 327,
           "comment" : "special case hash",
-          "msg" : "31353635333235323833",
-          "sig" : "3081860240269fc7ed89e554aa52b3875dc00bc140c1937d4f1b32e29da41ff241cdb9bd3058fc148f905982b8717b035e0db00ded7ebcb08572ec76bf0128411145d73091024201b4bd6bc4ba7befd5c305e018448a771b71fa1a11b3a2c6185dd6b8477c35eaeb4733fecd90f38ecba628f27c02f809191e993e1e7ff590383e2ec2afd08020b267",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32373438363536343338",
+          "sig" : "3081870242015edf1fa95b17159f762d68c1736101309e80fe5b2c4415609a5ac0837fe5901f3c2d3d826a43b1f8cd1babf494ffd96cca1267950188a924d4e1bf7f68189f27d302412e8697efbbf53adb7cb1b904718fc71eb2561f331c209c50848b5bc50bef77c5c3487d285bfaa3caa14025cbb71bdbaea6911e3610335641d2799c3fd75019f716",
+          "result" : "valid"
         },
         {
           "tcId" : 328,
           "comment" : "special case hash",
-          "msg" : "3233383236333432333530",
-          "sig" : "308188024201a5cecc0e572f5ee4eed6755d3230ec5a933c1fb0e35ae771a1fcf0dc880e1c159dd5b6d192dc377505048b7188de3feb815a81a4f30d9226cdc85f751dec1a0410024201ef4a743e1e16f0a60201cc1060625ede6f0936e7af90b42736281e89fe7f2de6aa3f25c68576da705d8b3f6d5d8a34d3073307ea198d1cc8d72a18ef25e90f31af",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37353833353032363034",
+          "sig" : "30818802420161f64bbe93fdc0e61134cfd4c453ab740233b436179351aa68a3e38a83400d86ff464d7ceb7a51f541b86eb2f12e32a879b3a29bcb92e08cd50e74f86a0ed52ae90242008f6fef49ba12ced6696f4f6d24e6c68057a84496d42eede630199e9bd06d91363542a9776bfcd6d77fbae422e80fe466edd2c2c5e1f5cc79bedd1a7becc1a12660",
+          "result" : "valid"
         },
         {
           "tcId" : 329,
           "comment" : "special case hash",
-          "msg" : "31343437383437303635",
-          "sig" : "308188024201a92b43f57421e54d2528d305e7d5aac9a708e75a7d6fedb47908a4e3edcabdd836a2c4e8436f3b7b64895254536174d88c6dca143699522bc2dfdeebcbf38eb90502420093b0b99a89de72aca0c03e12724c2be323577a4629cb47fdda5b12b61ace0b9fdb97549d3d2a1dac15da66ba6389ee54cbc82c995b9f3aa3ae8474f4bb4b52da8a",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32333237373534323739",
+          "sig" : "3081870242013a6faccc1c06cb5dadb2cf083cb94a7181fd5cbf3954fdc430c2691248fcfcd13767e32491f00269b549cae93777ced0f7b069440726adde7605d4038d7b5ea4cc02417622c9065f4c49a6f8649073dfc6a827b897b6984176b1a09d151b9733a68f6da746c47427cdeb3be075da4a351ab78dd5e472cd98d1586edd6ff2a11c6c169fbb",
+          "result" : "valid"
         },
         {
           "tcId" : 330,
           "comment" : "special case hash",
-          "msg" : "3134323630323035353434",
-          "sig" : "308188024200a0400f255174ffb8548c29f5faa70e806bb6f6ca08a08753c85c5d145a555cc8e2df285af9985f2e729d4a99a734b7e7fc95560d546a067fda03529f56b2fe66bc024200d7fb60271d22ecb5d8ec904a9df1a416be706ce539e34650b8fc514d1dd7afebc1344c0c68c533c5b20ee249a77c075293b2d7efc8731c2e3619be59da871bb083",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "373735353038353834",
+          "sig" : "308188024201899609e7f7cd2ef14bfbb1cb9ba9283ae11a9346a34bef23b1c249da2e76a7708e0f2f97f819e4e25b0d5227eeb85aa593c3fae9398a7020f61ae1606945d13841024201b8d5e9c4f030295447106d2b5c80cc2e7d4e36b458a90a08f505df62d2234e59d08187385ba5501049b34e12ec92f7839a18361a52a9a0b6f6a664b118680b53d7",
+          "result" : "valid"
         },
         {
           "tcId" : 331,
           "comment" : "special case hash",
-          "msg" : "31393933383335323835",
-          "sig" : "3081880242019207c7b645aa45c2722331f46e094f2eb0052075b8ac9414ad77baafd01d4d1fdc68344136fbce01edfa5627bfb8f3c128abb61072c74802192e89137c68d0cc31024200ff15b0218f81f0a848742f683cb4d1b7c517efdb8fcf8ac6a35e4971b35536851ed68de40a6e1a4a23bddb5b42efca23b91e91959a4f7e2afa196779c96c6c654c",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3137393832363438333832",
+          "sig" : "308187024201ddc69d1508021eb560db39f3add8a28dd7fbce417e5fa1f4f626705caaad72b634868d01dfc474e926c97927c56ac51f9bdcfd0e7627be35cc300a0cdc083b00d402416e862caf9f2df11b0a46104e78865fbbabe30bfac0b1fe7f99badc11746a288c1ff27f6fa2aaba6441bab0372af906eef083ff03ba466b896c9344cd396dd46dbd",
+          "result" : "valid"
         },
         {
           "tcId" : 332,
           "comment" : "special case hash",
-          "msg" : "34323932313533353233",
-          "sig" : "308188024200aaf119702b9985354bbe3f6b6cda8c46151af4202546dfbe04d5f0ffd18ebe7b29d616f1c40376a412a52f4204b5a13e7f3e4304ead566fc41bf4b5fc0b84c8a2d024200d599deafd4fa2368cd072b854a3d53425d06adf3573e886b81248a7328a546ddc41caed38c6b1ffeaec9a98c940905cbffa87b936da980d4a9003da41e0c59c92f",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32333936373737333635",
+          "sig" : "30818702420117fe2c21f282c7e4a8415e9c53c254514eeeb0adadc771adbc6d21a09add4f17ea0c597469488238be795f2e187fa016d590535b4ff10c62d2246aa17bb013f9ee02413c9f1590ce7a68fc84c617f478188e71aefe8c74c4b9979b8c9196bcc262205aecce5fd2bb80c360d3e20da20e36c5ab70d810d4ba97d13858199d3a1c9c140c63",
+          "result" : "valid"
         },
         {
           "tcId" : 333,
           "comment" : "special case hash",
-          "msg" : "34343539393031343936",
-          "sig" : "30818702416c09a59e71cf34f983f75dbb4724c4828a93021cee8fd7d92af6941ca8efc9c5ddda7c49a0e1777225782e09313e3091f056122e585c4eaa689fb2fdb1cb7848d80242019f0c5ff6b4638f4c33916db76f9d078bfa8f9e25ae00348e46bb32d777aa26155b82ea73a9e4e2f21f6a65c73ed6c6ab2101cef3524d45b9fc6ea1292f1986acad",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35393938313035383031",
+          "sig" : "308188024200be6b47254a3cf93e2e276adfb072256404744070d6dec83ef34e3e6c119206422bb275e61fc47053ef7b2af9e33aca8f8b2e4938057070eb6ebbcf82fabb44a5fe024201061ef80935ff6d0e9f87f3537b639945acf50c5d97d30b4b9c347e3f5f5ec02b15a376ae754d64b2efaa811b3d12a0fff0bc689022025dd2f69f2f4b40dda8687a",
+          "result" : "valid"
         },
         {
           "tcId" : 334,
           "comment" : "special case hash",
-          "msg" : "31333933393731313731",
-          "sig" : "3081880242014e791c42f3998458c5e17f895d25c85cb419195d65e5a0b9a42cf13ddd36959c73460f54aa840d2254355c6ac626f440cb3a84fba632262c9dc5cab31be7da106b024200abb97b682f01f45168403613a7e2ff82bb4a9fc20952a35d935428f71ddcc799c6d9085fe3230d72261d73cd082e8108523da7ba0b1691ad6ea63f5f4e8e8909f4",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3136363737383237303537",
+          "sig" : "30818802420130b6fd7dec5cb6f90a8b54ce7b58c61b013d0aed7c4a26639de80aeac3d9e3388e9f87e1e6419d3f0339af324e1421b5d130317ffd9d8be36500a84bb41d026cea02420176b460a3eae01d8aa8ccffb0d6cf4d1595aa697c65510a1197b97343c1a6234552ce9d6d318c5f20f48bec0dc311dd62eb40058f3cb22fa958edaf9ddded191a08",
+          "result" : "valid"
         },
         {
           "tcId" : 335,
           "comment" : "special case hash",
-          "msg" : "32333930363936343935",
-          "sig" : "3081880242013ded35ddff2f97780bbc60b8cec89855a35183a48f8fa6bbdc183994bf89021118cc019629df72112b2c529c023e7a5cfce253f7fdb49105d238680b64275a213c0242009c92e7a0f71608e8d8cfab3f850f7fda1a1a1d056e72254469afe5ceec3c718e6a462e1346941eb08c105501647502c1a810a29df8b208da6a5b296b2bd1e98137",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "323036323134333632",
+          "sig" : "308188024200a87de42d827ae1f55d6fab3277c7a9fdfac3af22fe47e52bfee34fa1ee3e765095fff20175becbdc94b4a5ad3a149ea7c1bebf4d45370e6b4404a0437d8fae264f024201a3c1c5186d8aa491b4623f5765a388930f37bb8f3e1c0db508983585b9090b3aaf22bb846e0fb6d915b5811ac55e4d6cb08f605cb84deb55ab7fba2dde8736b1c4",
+          "result" : "valid"
         },
         {
           "tcId" : 336,
           "comment" : "special case hash",
-          "msg" : "3131343436303536323634",
-          "sig" : "308188024201d0d29756ebff02b71674fa4eae37557ccd51a036fb1eb0b7121b405e7fabd60592927d805b75815af1bca6e9d6c5484225bdd0ec7a40735da972fd5ff645d86f1d0242008b9fe55357dc118070cf898973a64e7554b734e900c675541e20332a260ca51a23248d9b8f47ded811cfce556a06a71ba5dc5b873075f264a6843e675caf06a534",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36383432343936303435",
+          "sig" : "3081880242010e46055d9aa087f1c4b6056319cbf17a0694fe073266a3f30363030e345a4bd461acbd99d1261fc05ef3c9a1c37afba6e21c2d513ea3d4709de5586810d7d29ec6024200d0c95c7e97a94efb44aa717cd6ebe82de0644e32676d197351f128ee8d2b223ab476d3e66014ecc003081f7040c578b8984628d6ec80733f713e26b2c98cb4ede1",
+          "result" : "valid"
         },
         {
           "tcId" : 337,
           "comment" : "special case hash",
-          "msg" : "363835303034373530",
-          "sig" : "30818802420165fb993f39d350ed60c8483dd6e4e6736591dea974ecd8ab027d3839b752322ee220d40bb6fc0b0d5a8c42928bde50f659b18f51f42fb2b1aa4583892a9114a0c3024200a8816c09d47138bf662da4ba25caf44e24185696d4914a7de2b2535f73b9afbd3ffa9cb0a86a115e4d9ac5be48cf7e8fe276466abdf17127bcc7aaf4d096008ca4",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323639383937333231",
+          "sig" : "3081880242012c04d08a7a2d07403aba604ea85ec23a52b52786e7fce04170e867be6146eea75a7180f5d4f3b82a204a3c996811a1e61a3e76ed209c22428b35c51fe60f3bee1e0242016f2feabc25733b0a460463b9933e6e4ae9f4124cd0ad3785c77755dbf0848ec1cfd2ab08b960b556870fa00388d23d9a9fa3112ac3e62a0f342d58fb1f0aa81748",
+          "result" : "valid"
         },
         {
           "tcId" : 338,
           "comment" : "special case hash",
-          "msg" : "3232323035333630363139",
-          "sig" : "30818702410b901c88ea699e715f6db864e23a676e7f7f2415ac1f850f2dde1ad0d3f9c92e8c5de66d45174d619955fae4b0dfebe49c583506481d28d30cbf58e2ac49f370c202420144c97b688b9ecc07b84c68095267e17e48232922756609e9859d18d2eb7844ec925150c39f2b3a255c882be705e0a8e30e68e49fe7914dbcc3ccfbc1d467050f80",
-          "result" : "valid",
-          "flags" : []
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31333837333234363932",
+          "sig" : "308188024201ca9532c9daeb80d0dbc07a4138ba62a6bab8c88b9e1e2edf2675132eb97cfb26f4c395f3b9d1d1275694956b34c3ef72cd00bab86777465b9edba29a41b0114c6202420140eb6dddff253a7ff5b032d82fbd18e481a376fe242f6405b81b57165665c9bfe61e25cd3358245bdfb8de7632de72ed20cdacf384764096c8fe3a376563a348af",
+          "result" : "valid"
         },
         {
           "tcId" : 339,
           "comment" : "special case hash",
-          "msg" : "36323135363635313234",
-          "sig" : "308188024200abbd9e77ef1e2a36c6b06f063d93effb8e852387a94bfdf8359b5c18708f90d9f4e9749fd45347f637546b08733789c988fda4f0309551bde813a0bb1a232adee102420191165d58d153fec68f5cc83bcf5891e2e0ca9681204876e872453e9ebd45870b6878ee437e4d833c6ec54337b779acbf9f8202df510d269a710d0c43e4e07b040d",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp521r1",
-        "keySize" : 521,
-        "type" : "ECPublicKey",
-        "uncompressed" : "0400491cd6c5f93b7414d6d45cfe3d264bd077fc4427a4b0afede76cac537a7ca5ee2c44564258260f7691b81fdfecebfd03ba672277875c5b311ea920e74fb3978af50144a353a251b4297894161bae12d16a89c33b719f904cfccc277df78cea5379198642fd549df919904dc0cf3662eeab01ef11b8e3cb49b51b853d98f042600c0997",
-        "wx" : "491cd6c5f93b7414d6d45cfe3d264bd077fc4427a4b0afede76cac537a7ca5ee2c44564258260f7691b81fdfecebfd03ba672277875c5b311ea920e74fb3978af5",
-        "wy" : "144a353a251b4297894161bae12d16a89c33b719f904cfccc277df78cea5379198642fd549df919904dc0cf3662eeab01ef11b8e3cb49b51b853d98f042600c0997"
-      },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400491cd6c5f93b7414d6d45cfe3d264bd077fc4427a4b0afede76cac537a7ca5ee2c44564258260f7691b81fdfecebfd03ba672277875c5b311ea920e74fb3978af50144a353a251b4297894161bae12d16a89c33b719f904cfccc277df78cea5379198642fd549df919904dc0cf3662eeab01ef11b8e3cb49b51b853d98f042600c0997",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQASRzWxfk7dBTW1Fz+PSZL0Hf8RCek\nsK/t52ysU3p8pe4sRFZCWCYPdpG4H9/s6/0Dumcid4dcWzEeqSDnT7OXivUBRKNT\nolG0KXiUFhuuEtFqicM7cZ+QTPzMJ333jOpTeRmGQv1UnfkZkE3AzzZi7qsB7xG4\n48tJtRuFPZjwQmAMCZc=\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-512",
-      "type" : "ECDSAVer",
-      "tests" : [
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34313138383837353336",
+          "sig" : "308188024200d609e1f1cc1adf5889dc6deda441682e760be08932b31592fef3ada143fb4940e4ea75ae519e4fb0769c4fbd33a52b183a21d0bba1ffa3fe50fd11f75c6ac58ff60242012400cc4ddc24ddcd47a6d639a2abdef29a65d4fe9175f51b316f4bf918bc918879495c572f8e98364e2e1aa0d4d53ad29e803a4470d94dd06a982a1d041bf2b5dd",
+          "result" : "valid"
+        },
         {
           "tcId" : 340,
-          "comment" : "k*G has a large x-coordinate",
-          "msg" : "313233343030",
-          "sig" : "3067022105ae79787c40d069948033feb708f65a2fc44a36477663b851449048e16ec79bf5024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "393838363036353435",
+          "sig" : "30818702413775a7e61bdda9a3a990ba9fde98f9d81d4b03195547bbd0658e1059daa00da9270671b2fada1bbbf13982f87c9f3f26dda5cd4f24de63bceb5fd9390163c58d260242010a03e4ba08f9e2b6915a6c0b83156b00f59efc5417394c51ca7616b58cf91ab7166d8459eb4eeb0d57146ed6560e173faf354b4390817e0aafb38294df25992cbd",
+          "result" : "valid"
         },
         {
           "tcId" : 341,
-          "comment" : "r too large",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
-          "result" : "invalid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp521r1",
-        "keySize" : 521,
-        "type" : "ECPublicKey",
-        "uncompressed" : "04015f281dcdc976641ce024dca1eac8ddd7f949e3290d3b2de11c4873f3676a06ff9f704c24813bd8d63528b2e813f78b869ff38112527e79b383a3bd527badb929ff01502e4cc7032d3ec35b0f8d05409438a86966d623f7a2f432bf712f76dc6345405dfcfcdc36d477831d38eec64ede7f4d39aa91bffcc56ec4241cb06735b2809fbe",
-        "wx" : "15f281dcdc976641ce024dca1eac8ddd7f949e3290d3b2de11c4873f3676a06ff9f704c24813bd8d63528b2e813f78b869ff38112527e79b383a3bd527badb929ff",
-        "wy" : "1502e4cc7032d3ec35b0f8d05409438a86966d623f7a2f432bf712f76dc6345405dfcfcdc36d477831d38eec64ede7f4d39aa91bffcc56ec4241cb06735b2809fbe"
-      },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004015f281dcdc976641ce024dca1eac8ddd7f949e3290d3b2de11c4873f3676a06ff9f704c24813bd8d63528b2e813f78b869ff38112527e79b383a3bd527badb929ff01502e4cc7032d3ec35b0f8d05409438a86966d623f7a2f432bf712f76dc6345405dfcfcdc36d477831d38eec64ede7f4d39aa91bffcc56ec4241cb06735b2809fbe",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBXygdzcl2ZBzgJNyh6sjd1/lJ4ykN\nOy3hHEhz82dqBv+fcEwkgTvY1jUosugT94uGn/OBElJ+ebODo71Se625Kf8BUC5M\nxwMtPsNbD40FQJQ4qGlm1iP3ovQyv3EvdtxjRUBd/PzcNtR3gx047sZO3n9NOaqR\nv/zFbsQkHLBnNbKAn74=\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-512",
-      "type" : "ECDSAVer",
-      "tests" : [
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32343739313135383435",
+          "sig" : "3081880242017ab00a30c88faeced3e4a10f9c63785bc29e9af4499466bd8880827cfa580b6171f4a20f36487f7b94592946bca4162faf65872af6bfb1919e6b026c14e51e2740024201927515f6489e9b7d9cbf61e103295857c8131320217e7a86d3f2fdcb350da5b42c2dbe173fcb025d14da239d7d610de8475914748573429c9590d3594f4fa3aab3",
+          "result" : "valid"
+        },
         {
           "tcId" : 342,
-          "comment" : "r,s are large",
-          "msg" : "313233343030",
-          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386407024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp521r1",
-        "keySize" : 521,
-        "type" : "ECPublicKey",
-        "uncompressed" : "0400336d5d08fe75c50946e6dddd36c550bb054d9925c8f254cfe1c3388f720b1d6500a90412b020b3db592b92ab9f68f1c693b8d1365371635e21bc43eaadf89e4e7401d48d60319dfd06f935fc46488c229b611eecd038804ae9f681a078dde8ed8f8e20ad9504bcf3c24a0b566b1e85b2d3ed0a1273292ff5f87bae5b3c87857e67ed81",
-        "wx" : "336d5d08fe75c50946e6dddd36c550bb054d9925c8f254cfe1c3388f720b1d6500a90412b020b3db592b92ab9f68f1c693b8d1365371635e21bc43eaadf89e4e74",
-        "wy" : "1d48d60319dfd06f935fc46488c229b611eecd038804ae9f681a078dde8ed8f8e20ad9504bcf3c24a0b566b1e85b2d3ed0a1273292ff5f87bae5b3c87857e67ed81"
-      },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400336d5d08fe75c50946e6dddd36c550bb054d9925c8f254cfe1c3388f720b1d6500a90412b020b3db592b92ab9f68f1c693b8d1365371635e21bc43eaadf89e4e7401d48d60319dfd06f935fc46488c229b611eecd038804ae9f681a078dde8ed8f8e20ad9504bcf3c24a0b566b1e85b2d3ed0a1273292ff5f87bae5b3c87857e67ed81",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAM21dCP51xQlG5t3dNsVQuwVNmSXI\n8lTP4cM4j3ILHWUAqQQSsCCz21krkqufaPHGk7jRNlNxY14hvEPqrfieTnQB1I1g\nMZ39Bvk1/EZIjCKbYR7s0DiASun2gaB43ejtj44grZUEvPPCSgtWax6FstPtChJz\nKS/1+HuuWzyHhX5n7YE=\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-512",
-      "type" : "ECDSAVer",
-      "tests" : [
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35303736383837333637",
+          "sig" : "30818602413b2ba1509aea9d42d400400033952a022fe7e00c7ad65c39a2f76d41130aada99c3cdfb9cf44575a2163de29f097beb9bd3aef9334e6fd0813dde2a087f938c5f602411afb56087dfd5cb4fff6679a114c340f3a59f6b3e1813373bf3ebe30cb5e8b285a5875d1b5a9120db80f70310201559f89bb1df147961d1ca4fcdb5e8e84cae082",
+          "result" : "valid"
+        },
         {
           "tcId" : 343,
-          "comment" : "r and s^-1 have a large Hamming weight",
-          "msg" : "313233343030",
-          "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe02420095e19fd2b755d603bf994562d9a11f63cf4eadecbdc0ecb5a394e54529e8da58a527bc6d85725043786362ab4de6cbc7d80e625ae0a98861aea1c7bf7109c91f66",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp521r1",
-        "keySize" : 521,
-        "type" : "ECPublicKey",
-        "uncompressed" : "04006f8fadedbae63701072c287c633f9c0052ea1e6cd00a84342cc0f626210071576abfd0875664b0746cdaf2745effc18d94905b0fc9d2cad4ba375c0ea2298c8d1c0150d128cb62a527ae6df3e92f1f280ea33248711ffe4b35c1b162a9508576860165e0ddc361d96fafcd2ff82776c743b9cd6845db61eb56739f5c4ef561e6c20d8c",
-        "wx" : "6f8fadedbae63701072c287c633f9c0052ea1e6cd00a84342cc0f626210071576abfd0875664b0746cdaf2745effc18d94905b0fc9d2cad4ba375c0ea2298c8d1c",
-        "wy" : "150d128cb62a527ae6df3e92f1f280ea33248711ffe4b35c1b162a9508576860165e0ddc361d96fafcd2ff82776c743b9cd6845db61eb56739f5c4ef561e6c20d8c"
-      },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004006f8fadedbae63701072c287c633f9c0052ea1e6cd00a84342cc0f626210071576abfd0875664b0746cdaf2745effc18d94905b0fc9d2cad4ba375c0ea2298c8d1c0150d128cb62a527ae6df3e92f1f280ea33248711ffe4b35c1b162a9508576860165e0ddc361d96fafcd2ff82776c743b9cd6845db61eb56739f5c4ef561e6c20d8c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAb4+t7brmNwEHLCh8Yz+cAFLqHmzQ\nCoQ0LMD2JiEAcVdqv9CHVmSwdGza8nRe/8GNlJBbD8nSytS6N1wOoimMjRwBUNEo\ny2KlJ65t8+kvHygOozJIcR/+SzXBsWKpUIV2hgFl4N3DYdlvr80v+Cd2x0O5zWhF\n22HrVnOfXE71YebCDYw=\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-512",
-      "type" : "ECDSAVer",
-      "tests" : [
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "393838353036393637",
+          "sig" : "3081880242010efb321a347625343f5126ed8545017d799eb103c75558922eabe44211e8fd834655dc2ec5bee9bb3e44350eb6885e0ab974730222e55f13ad27c066722fecaa25024200d62e3d7ff9215369aa7da818db302e49033875010b2f9b73d25ca5b9bf2c62ed756686230cd5f4a37c1fa881c97e623919fab827de5995ab456a1fd7ac7b85b1f8",
+          "result" : "valid"
+        },
         {
           "tcId" : 344,
-          "comment" : "r and s^-1 have a large Hamming weight",
-          "msg" : "313233343030",
-          "sig" : "308187024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe024115837645583a37a7a665f983c5e347f65dca47647aa80fd2498a791d44d9b2850a151a6e86fce7d7bb814e724ff11b9ef726bf36c6e7548c37f82a24902876ee19",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp521r1",
-        "keySize" : 521,
-        "type" : "ECPublicKey",
-        "uncompressed" : "04005e7eb6c4f481830abaad8a60ddb09891164ee418ea4cd2995062e227d33c229fb737bf330703097d6b3b69a3f09e79c9de0b402bf846dd26b5bb1191cff801355d01789c9afda567e61de414437b0e93a17611e6e76853762bc0aff1e2bc9e46ce1285b931651d7129b85aef2c1fab1728e7eb4449b2956dec33e6cd7c9ba125c5cd9d",
-        "wx" : "5e7eb6c4f481830abaad8a60ddb09891164ee418ea4cd2995062e227d33c229fb737bf330703097d6b3b69a3f09e79c9de0b402bf846dd26b5bb1191cff801355d",
-        "wy" : "1789c9afda567e61de414437b0e93a17611e6e76853762bc0aff1e2bc9e46ce1285b931651d7129b85aef2c1fab1728e7eb4449b2956dec33e6cd7c9ba125c5cd9d"
-      },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004005e7eb6c4f481830abaad8a60ddb09891164ee418ea4cd2995062e227d33c229fb737bf330703097d6b3b69a3f09e79c9de0b402bf846dd26b5bb1191cff801355d01789c9afda567e61de414437b0e93a17611e6e76853762bc0aff1e2bc9e46ce1285b931651d7129b85aef2c1fab1728e7eb4449b2956dec33e6cd7c9ba125c5cd9d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAXn62xPSBgwq6rYpg3bCYkRZO5Bjq\nTNKZUGLiJ9M8Ip+3N78zBwMJfWs7aaPwnnnJ3gtAK/hG3Sa1uxGRz/gBNV0BeJya\n/aVn5h3kFEN7DpOhdhHm52hTdivAr/HivJ5GzhKFuTFlHXEpuFrvLB+rFyjn60RJ\nspVt7DPmzXyboSXFzZ0=\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-512",
-      "type" : "ECDSAVer",
-      "tests" : [
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32373231333036313331",
+          "sig" : "30818702412f778cd552f54da5f567f47e6979872ba130dc0890172bf3b3bb952f03c64bc8783abe9f056d60e1667780f5ea88f59ef33c735d540561a197d31fe34853a60a52024200bd2816f06372f2e3f2582d53e583e133a551aaec04ddc2fdb7b8131787e73e4295ac28a9604a2402ed5b272cc03be57dd4a7df84d9ee24cb0c2bf124ed927defee",
+          "result" : "valid"
+        },
         {
           "tcId" : 345,
-          "comment" : "small r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020101020101",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp521r1",
-        "keySize" : 521,
-        "type" : "ECPublicKey",
-        "uncompressed" : "0400b420fb1fecdd9cc5ea7d7c7617e70538db32e6d7a0ad722c63580f1f6a1f5537eb50930b90fd6fdd9abd40015f746d2fd8adf945a75621407edb6863588e41979e00295108a7e9d2191a287fd160bd24f498055dc9badbd61c6a89fede27b4f9d479d86a20b6dc07c90f008ebe68a0e0cc15a4a03b8cf990e4ff7ed6e3892b21c52153",
-        "wx" : "0b420fb1fecdd9cc5ea7d7c7617e70538db32e6d7a0ad722c63580f1f6a1f5537eb50930b90fd6fdd9abd40015f746d2fd8adf945a75621407edb6863588e41979e",
-        "wy" : "295108a7e9d2191a287fd160bd24f498055dc9badbd61c6a89fede27b4f9d479d86a20b6dc07c90f008ebe68a0e0cc15a4a03b8cf990e4ff7ed6e3892b21c52153"
-      },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400b420fb1fecdd9cc5ea7d7c7617e70538db32e6d7a0ad722c63580f1f6a1f5537eb50930b90fd6fdd9abd40015f746d2fd8adf945a75621407edb6863588e41979e00295108a7e9d2191a287fd160bd24f498055dc9badbd61c6a89fede27b4f9d479d86a20b6dc07c90f008ebe68a0e0cc15a4a03b8cf990e4ff7ed6e3892b21c52153",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAtCD7H+zdnMXqfXx2F+cFONsy5teg\nrXIsY1gPH2ofVTfrUJMLkP1v3Zq9QAFfdG0v2K35RadWIUB+22hjWI5Bl54AKVEI\np+nSGRoof9FgvST0mAVdybrb1hxqif7eJ7T51HnYaiC23AfJDwCOvmig4MwVpKA7\njPmQ5P9+1uOJKyHFIVM=\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-512",
-      "type" : "ECDSAVer",
-      "tests" : [
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323034313031363535",
+          "sig" : "3081880242012a459fffea70d3bfc13e9ea0abb10aae3910df604997cb5e4bb0548abd852abac6b9a32418c3b5ed4e7951ae88eecc0a2f1065caf24c6a814674e95682d9b493f2024200e2abd05c585e0c213a219a7e7d38b810d252ffea67650d4d1994a41c2ca325bb964920c6c2545381c45ca3e1eca05e00514b366cb0e1e49b8c236d383b260b9cbd",
+          "result" : "valid"
+        },
         {
           "tcId" : 346,
-          "comment" : "small r and s",
-          "msg" : "313233343030",
-          "sig" : "3006020101020102",
-          "result" : "valid",
-          "flags" : []
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33313530363830393530",
+          "sig" : "3081870242010f2653d94aa28bcbd667a5013f9b283d8487c44d093ee47660329398caa550ca9c9388c7aadeceacac1507e76590afb736adb3583f54f31ae25c9c717ec9f89b5e0241494448a7ffe4a4eed84b4602781ecef77a23fed116b1b791b8d2e4231b7ca2a7b6f06d132705932d446e61d344714ee24014fa5bb144a96572b3d48d038a55ad68",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 347,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31373237343630313033",
+          "sig" : "308188024200c2da48552c39d94f5a45427ae9dcd891b65cca33e624ad2532ffa333666b241d873336fab7bbd7b4c193db4d865cd50f0c1d8cb5c14cf3f089ad42dd43cfff634e0242014f2070dcf860b96a45f2a6061e4ec2a6ad64d7d0e9fbdb25aa93b99941be280f5c70c0e32b6234df545bace7341af94c140c865d44fa8ea7ebe0fe53bda44645df",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 348,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3134353731343631323235",
+          "sig" : "3081880242009bc6e74549b48a1e7c181b179687fb27d6e9acac47ec34b1b8bd044d329320544e4e568e67d17f4cda2f0a3fe303d561a11fc0c981ed9be2fcc6d397a43ad49e10024200ff295e43fec5b68b00ce8044434bcd17af1ba04a74556353e258d017ba26bed67f458fad5dd8e7d2734d56f59928c2419441a9e8c0573db3586ca056951ca935e0",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 349,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34313739353136303930",
+          "sig" : "308187024120963638d0b058494254efce57778ac65e5f23491f7adfa72e4713b7c03946b543c014d9660d855246f308085eeee495cd831b7dbece47aea48e90433bd0fe818402420161a4f4977fecae92d4f67e56f3338c7a9b820b5e05db1f28d05d71f7e5f36bc63f6edda4d3c1b2d73bb8a30c4d745b73e634ef574cf47656a372e3eb42cc038850",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 350,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35383932373133303534",
+          "sig" : "308187024201bcc5858597ce8d4dc5ffa6be33f7d804f2f8ef59c5db9301785e0cceb7ed57462f455a465710c7414570c9a35a3100bd15fa40e3ec350d1f75406c2a25885e9d76024143757d282fd1d44c253f9a05d8142c29a6d63c0a1f5508431bc9fb9b60a38b7f414e730e0d59b7b709706a67022e1922fe88b182a57443c58bd06a69ee7814bcab",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 351,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33383936313832323937",
+          "sig" : "308188024201240120b97ea67bcbd0e412d87137a13e347a870a2249375fccf8c004da35e592620774160e7b82aed1f57997fb015a764d014d4be1f389e5499777054576e7bf000242019f157ec3a2410853274bc4d8e7565e9eaa5dc47d5e515abc86c22fa6dc215482df5c0e2b885f37baef3a6ae83daac930617a5fb37bb03ce40f06fa4ece26cbb11c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 352,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "38323833333436373332",
+          "sig" : "308188024201a7536d55876f8392a6eba18f075118c273015844eb3536c727c004c1bf23067d57e8fe31872f8bf839640e80e06aba3c0a365a268cabc2da96d84550a569f17f9c024200e840b6a7cba718d91103faa134c2f63763f3b6b91db7ecbd3b10f10171a875712cb9384325411beca9a3aa87aaae3902c282d2dedaa1cbddd40ccf0d29975df22a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 353,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33333636393734383931",
+          "sig" : "3081880242013f72be1c331214f45007ff72ce54afce1c910a90e4ff3d176620ff3ca976c2b62d0cdf5d1134290ee97440715531455dc29818828094d366f959e1adc7d7e98ea4024201e80ac38ba69f3e53116e5432fbdb3b1e7ea1b43e5f86d1c0e3d1c469442dbb406ffe524f0685f71e811d94a9efa9ed38ccd9213f983983035f2add0b8f2fa4ae23",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 354,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32313939313533323239",
+          "sig" : "308188024201aceaa6d567ddb39ba52d297e60e4a814c9b476cab568c09d8ace878d846218dd2b5d2a2461f0d5a56c12f0bd803e3253dc5b387b94e86589cb1d0cb809c7071125024201b1fb021b10b593cf9e793cf22a88bde9a4b92f9e218094f270b093e8c6c95aced43d097bfa3354e6b98d195c599c2e6f13351c63c28967e08b7e497e120665c663",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 355,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35363030333136383232",
+          "sig" : "308188024200f6ffb5dd786326041e74564b719d38924a28329868177c13463cff90c4b09d3d2dbc011281cc78aa0e5e8656123bc50605601a547bb4b1761f852a120ea46df9df024201a407fdd445614a16a5ebd4ba075c6c1d7564f3cfd477d6b2620abf18a5bf78311282ea45b9bff813f24c3c7854e6091c8055144f9592fbf2e456421a41c555d7a9",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 356,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "383639363531363935",
+          "sig" : "308187024201a15af4d5ca3deadecd75ec1baec31c8d43fbc889466475e6c23106db4e63ab69003f56d819ddfc5a673c8289f9e6df806b07af57a2541af694e6489734c8eec837024169c35433a3217fcd738a65b7da9e81cd81f04f0ef060050b9c843e9e808d8b8175f3adaefa105d215ea9a46bf415fe2ac180958fcdd878d54f8d19d23e11b76d1a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 357,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36353833393236333732",
+          "sig" : "308188024200ba899f94841db6c33b850867c8906b436be3853640dbfc863197fa1e5a55ce25240f2be498b9bdcfc0a89dbdca192d8f84ca3c44e5e0ee6f83e7900e085e1bd48102420086e6d558de8d8f014a85cb4a5f6908627e7a1acd70581d9d9c7d14df44d437aa09e5a10a0b760e98d46731f2512ca1b0240c602b5f0a2030485e34de9c6cd08e7e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 358,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3133323035303135373235",
+          "sig" : "3081880242008eb5c92dbf5e00888b85e6bf6617017e97c04ae950dd731856b9dfb20e0c0e5c54284f411231fed1d071b321f78618d2a75c139663fb9db3435214cbac5a0dcb4f024201da0dd29d4728fe6331c8e2ade5045b1237664aed157db2a6cbdeaf5abea81324e28920a1c49c334b1226441f88e1a7f2c7e01d63e950d4378f08973db16b2e6161",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 359,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35303835333330373931",
+          "sig" : "30818802420130779f943df098ddb5315cdca4b731c83472d589f4ba4d32c172faf6b3a9e4154c0517fcc5c432eb269b0152297f6df490ece59496bea8047e2f32d0b5f91e85ef024200c9eb0b56273114ce2e553341247da86b813bfd65f143a5562bb1c874ff970523836bcdf390dc196e67dd75cd28112ef74afd51b1fb35333be0505a012efebd4e22",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 360,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37383636383133313139",
+          "sig" : "3081870241593f0132f7b5c282355978a2cba73fd3bd5ce3272066d4ad9bd8bd8b3e2be0990071b3509ea445dd155cf97e294e2b8d1355809d880e10700eeab0eb8ebbaa4f0902420107eb3d5ed75cbb9bcb9278f2266c14c57cf703cbd8f7c7de45c51f0f3baf1dff6bb92f1cbf89ba649677bcdca776fc57f587ce714e2e43e6cc523f0d0a286d38fb",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 361,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32303832353339343239",
+          "sig" : "3081880242016ded17fad10f945e3d953b4fd3b72898c370f15164bb7712673385c10bf3929bea293e08bfc30029a465138ad47abe604df807b31707fef55adf3e104920038e3b024200b76b212d74e4b6eb994d926e9e796975235fad90e339a21a329e6eed3fe96b6d3c0d5426e8464c4a9ed5cbe08eeb5e490f72e9e0406c0d76ad076b476d07c0144a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 362,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130303635393536363937",
+          "sig" : "308187024201f8624ffa5a6aa8d9d04ed1c2272ea55f5271ca2cfc9aa6a3778a0b8a230f611e5d65af18d8251a0cc4ace663878c33205239ee7e8388cc0a040ea51515072e3f6102412c1e61197229f40e840ea37325f3bd87a6cd32d080bd61bbde4b072cf7a0c8a89d402cd9235c26f19a084ddceb1cc0bae4006251ccbe10de3954e85a8c5efaf6cc",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 363,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33303234313831363034",
+          "sig" : "3081880242012b01c6601ceca9e58e8abb85d1f6663df70cee761a756b77e45294f09ae609a6b76cfcd67f60e47a3494cb85511e33d92a8d297a1b89e9a9038c0c5b78c3a3d4ca0242010ef5d2fab59bd42e2e92a2fca7a975b959dfb372519330defc8fa8954bfcfb397ba939edb6a944a2ce9f6fafbfcda6092cddf628801f6dd8cd40cad4d809d5c1bf",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 364,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37373637383532383734",
+          "sig" : "308188024201c54a330b9dc47eb88dbf60c9ee49f2c7518c0a78baf642c74105fe283fa4c357ff22931ef42f92d16d6a0b806ef718539d21cad71955a530e21cab49a56f561673024201c2cc32c5a4d335c48d0cbb0407fb7e4729c57251afbf9534c5309b94e6aae13614a1f2514252f48cc7f143ee761782f8dcebf2fb490e08fdeaf570a7ed9d287da2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 365,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "353434313939393734",
+          "sig" : "308188024201467b4511b9d6601da3557b8ed432c14a80e5999847be136c756a88dd5134689b5ab70d0a2e8fd8d6141e2b143282f98afb93b7e17609522dd9e64c9e4a31c7c34f024200f50ee66a1dfbf86167ba5968d4ee3506a7cffe0f521c1bf830d0867241e345d319e77eeca45858bb3062acbf8d100bc6bfd3127d57a7e91a8199e05052b8ccf304",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 366,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35383433343830333931",
+          "sig" : "30818602417af90f6227750f917d65b1c60200c755158bb783a479be6877c59ed89ff595fea3f3a4137591aab23826ed385bd6156277364b5d603ca272259083e6e9ab5db3f9024170842eb62c894935b82da15ca611d9d754ef57859e0c912c0358d0820f4940cdf5360f116a7547a81bf65617f182e597eb1007e26c62838487ca021c3829a590db",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 367,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "373138383932363239",
+          "sig" : "308188024200b0169e68062caa79f99ec0c72d83c4d0fc2a1c818665cfed1aba3e684392b9a95afb82ddd1de49e3fc3cb3889b4f5a86a7bdf944361db2cfa57021a7643fcfce9502420115ec784e042436892c6cc1bede0f4b7b6eb24b300b1f0c674999a6da816dbefb2d53f90b0dedb962a085e5209fcea50311130800d2a9249d279c7bde2f88622512",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 368,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31373433323233343433",
+          "sig" : "308188024201de4ed1ee81d5cffcf8256a06858cba5eb925ee68e3ed848ac98071b6e30c3b44b102a2de8117cce5b4f9e42603225e0dbcb3fcc171d1492e7ed8bcb6ec286c7de0024200fd1e93bbc8b8adeb7864a2bf8e29d6f9c0966fe3d543525bf268b57cd6fa8852bfe0d2750726d5445560f2fc211aa7859dd3ee10078ef907e49cd64326b397e01c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 369,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32343036303035393336",
+          "sig" : "308188024201fcafa62ee6275443d7277fc46e4c30b4db845ba45b5d6b54faf47bbf921f825f6fd0f23a38c0c7f4debc33add282afad1154c8707b6e18cd65adcb07d32915b46202420087a27b2bf3c35d18fd397e0cd7159516cf563b98441e030bfde93ceacd2c4e41228b7b33443ef0a351ce553d6d1d71c12092df796276175cd779b8090c4958b391",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 370,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31363134303336393838",
+          "sig" : "308187024178989628acfba86d4bf28beeb9f44001fb8f2d8e245320a19efdede31eae3ec8b496faec30c85e8f63f8ae06046fe1d1575321fa04953e460f6b1386dd5df94edb0242012aba3349732e21a5bb27d7d6facd8c7688b9d0d0271d6a077f9d6d82db45b5456b767f4b9f1a80f487031f9c0b3ea833c63fdf9c6a25e6b424c19c2e55305d7a0f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 371,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32303935343235363835",
+          "sig" : "308187024114a5a46a3ba415f6e8c566ca1b15fa2055649687b1a9fc84cc0fa8631296898fe014e0d45927e4271396baa4cfb3675669b16e76c339db3c0edaf61337e8bebe91024201fb313129757f76754b60fdb1e4077f9fe3dd62c8bce52190cfeb9c03021cc92f6d7d1302b8a84733486bf769ae94d3db4b60b6df28fed481d3d7c510299f0c319f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 372,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31303038303938393833",
+          "sig" : "3081870242008a3250eb5f28b598c4a42890d25f6af84082d4376f84f1717e5112a76623e6fe0d207c39463d20bb86341bc26c9f68bcdf794671a01f90465025f87a8c52137edf02411ddd317f6622d9b032223f76765ba6c9116ae4b43a1bd357bc9db6fa62f0867dc5d8f781f08c1cbd49b4424fe8c22cfd1dcd07cfde7b3598342442589825aa67f7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 373,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31353734313437393237",
+          "sig" : "308187024160ee161741d5cb2dd0ff2cf9924aca0376b1544681627a31688e4d8b3b63a01adbb417ee113b9ba8d4d13b7b4e1b14b51a24dbc3f099b068d916aa94862ee081b40242015caff8d30141e1c163e3ec62b7e14874da624a6d8e0252d8e829860e5a49d3732321b625262e5c9b1ef348c3e7cbb1de8227513f320637866785e97e1931d35ccb",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 374,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32383636373731353232",
+          "sig" : "308188024200a1ef8229db9f45da38ae3b6d601110611e209878bbd03ac2a6de65e8402957c669a115e3f02d085fe2d031c61324b77052ab346b4b1a437b58062fb36f9d56cf45024200cc5c0a3b68970279ae16880f6ca579d0171a827e99a46aa82b9242dcc09cb0b22a44ebcfca84293e6d21aeea492f00ba3157c5b6e2e4caea6a1c09c824720552f2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 375,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31363934323830373837",
+          "sig" : "30818702415aa0c8a378c4e02bcc2f56c2c365ccee424e2973c28f0daae8f4c3f0d90b421fefd456e749087e0c667c2a7147bc67b90c696244f216b4d9d7418eadc7d06ef1d2024201e28914bd341f526b041128f2d251131d8b2c65847e541d65adca3442962cddb2a71c64fae39fdd56e41686ad632f99c6038d8de0b3aac4045e0a961efdbf4c6a22",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 376,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "39393231363932353638",
+          "sig" : "30818702415a05f5366c8b8be28654bc39a6671d1b1593495e445c07c995c3be3e168ffdec92e44288802fd455007f8746570d93b5683e4d40e9d9e59de539f0e62bc40d92bc02420187a47d8f70adcc5e10267b8fec89d7011d9985427645aed19a8efa2d1189b469cb7aab1998e0c1d2fcac5a5054d79d2ec1c9a00b183dc9af20f555a1140be2dcef",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 377,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131363039343339373938",
+          "sig" : "308187024201e213bcb8b960b1296ae176993b2449bae556b6d90df2f07fb08ad8fd60e3b7fe6c73f9c8a7364417611d60119c550261c54bbca8d61e264130ab90187e27d22dbd024134f519382cfacfd07b0a6f3aca117c13d2be725d2f9ee4e5f88739c99121e63ed7358046bfb1575fc73e1ede8339e46c5139843e52e9184bb8c579061a154a0b8f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 378,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37313836313632313030",
+          "sig" : "308188024200ed11ac7efb1f29ee64108a5e2606fa9af3bbc12d1a952e47240d5236df64f5b2b77a0f7a0a73d30d0708b5b23ac6d584bf6997d8851623793655dee8774549b829024201e1602a2cae7d3212df47eebd12e2fe404851201101bbde702be9d74d040ed998e79a09ebf6d055f94473b1f8d87c99aa165bdaf0a5f270d46caabb8e88bfa54103",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 379,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33323934333437313737",
+          "sig" : "308187024107123c45e6e9338bc9fe225cdd96c5ab36cad5c06163f44f6bd903c7594e8068ba9bc89f652ec31b6e1298766b246c1f10877f1e3ec9829b0937b8d36e3c1ab2b5024201688bbaeb188b5047be6e8023b14fb121eb1451dcb19f814f5f4dca55ff95128011e3bae505a4d22166d00cb7cf14130590335ee923dc5db3e736832a128a067aa4",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 380,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3138353134343535313230",
+          "sig" : "308187024201264e3cc4fb802aa221d0787cd0cdf44eb6568982a00a6639f15238af36e894b14f45f06f8c2180fdeaaac77f674e056d1928cbbdfc4b2ceca0b35345ca07bfff7f02415c2dedee6b3aa096fc47ba0991a077ef4d5df20d8eff1bf8354412b171f08a98cea1704c8189a7951b0e7a8270ccb285b8db8e35285ed926b19c1eef07fdc05ee5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 381,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "343736303433393330",
+          "sig" : "308188024200ca3814747888751794b0488955e2aee07e5fab4b9872074aa7432698e7c83b8079773734df1bc752548a218fa59a362e0657b77ae7798ef4a7a3873256ea59ec670242015df8f1f16611c960d56647424b97936c8a06f62dc3a95d66bf4aa378d7a9e17d2afb53565780025927e6928f5313428f1d6708339787c8f460ba18457d4c0f521f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 382,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32353637333738373431",
+          "sig" : "3081870242017ba871aee34a893c4ded7a2a546da0d6867d428497b80fca7eea6e51b73d6411aff7609743e6242b6d4d3736ddcc9ee1aa12c8b62de5382e5c33d1fc4853e3e47d02415feb9d9f8fdd44622e4f9effe73fd9b467d355fd6b8de205527f722ee2f5a15eebd59ccdd7b57da26cf953f78886db5a6e5bdd0d56c9bd47ba2271f77687a64b63",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 383,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35373339393334393935",
+          "sig" : "308188024201840793684765410baf26b66cbcf7c36658d6c18a2f750c1225520e9f3a7c1b890583f321d4e48752c3b3116dfef733ee386c52a53402acea77cfad1db9380110e6024201b51985a306fcdbe3692181106d7d6308873912d003946992098bc98b4261fd78869ed8218849459780b6079f6899a47fcb9ea4874d1c08fab82c6f1e9c9aaae245",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 384,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33343738333636313339",
+          "sig" : "3081870242012276720b2725ba556d06be39cd16ca0a0351d8f530913c4f0cfb71fdda74b83f02febddc8da0a1f0f910d37d3f5332c027d7bd4c38fd08ebc770bf1252078649540241637e70b06045a86e2f329f907e079a785d7f8649541860322fb8b64b9736363f90156b9a5532d808cf2af33b87ff970c02e648dc4f1c90ff0704028ec2c2d9a82d",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 385,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "363439303532363032",
+          "sig" : "30818702417aade608b22c77245734fc5c4be8737ba24dc2ed4321b58124ae46a77ea7befaa5bcf166cb966aad007911623af10925a324bc3c6d06f24d0e2e7b2c7b8468b8ee024201e9913a412300b3980719148de0bb03826184aabd58f19659aa8ca18045f36c73c97df3d12b921de510ffa96ceac5454b801c86c55a06b2d771fa77bca784332c39",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 386,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34373633383837343936",
+          "sig" : "308187024201eefc7b6c1468ffa7d60b8408bd44c64a3ffaff298168c5016c6f504031867ea14ae48c661b8124418b4ed6ccc32df6bac6d0a485b1990236e15676268b7868d2760241515d48436afffdb65caed737116a861974b734bd1903e37dbbc231a9db37464ed762e364cac8b32f1546d6de37979fa05f8b80159a0f747d9470291af6569d6d94",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 387,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "353739303230303830",
+          "sig" : "308188024201271b912ca055040c227955df729757654aa9bbdb73c61ba14155220e4e7132319f6fb0ee94f2fbe160738f1dce2ad690845c38d962db4fda1598e93270da84a2bb024200b8907f041c3b19b9234ab555d0b48325b0cd330889a53276a1e913bab892b9c05cfa889005b14ee2730220746aecf12af911c5baea4be377ee76c0eeaf47b7a712",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 388,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "35333434373837383438",
+          "sig" : "3081880242016a813db0f75f9047fb11f3e19fc1688c29328a54f56ae30c1c9d9378537bfc40c5719d084e49a3b4aea255f5b7f6cc775492b5371e6b67b2d6abd5743e10fac709024201c258ffd830151bfd41ccdabb86b24af846612788b361c196d24e997ccf3f17d4452f63d32851a483072e6908095e5c49bbc241a0417749b097bc1ca0e4d127779b",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 389,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3139323636343130393230",
+          "sig" : "3081870241156a04c22ea5bdb7871124f1117301d781113ac4c9d4da05fea536e983d9261d25dc97006f8c78de23c788718557cf6f98863994af2086f0be3e8aa8812dc3a11d024200ffca96b04c56a4a6ce5d22b36e44d3b974d520e7f7c0f9d69034f9e59e0bbdc43236b3e4bfb0f6bde8802cc5cd6022cff166f4c488d64f38d44e3c563da31cf6fe",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 390,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33373033393135373035",
+          "sig" : "3081880242010913540ad73ceef7314d1758264e1d1525a371a7b9b3086971599a6b749be4d6ba69269b089508f6500dd925aa89a7c7cb7185e0cca7d2ee5664f22845d961e31702420135256c79ea5e5768fb3a55e2899b12219b8f68953ccd98c710b6a13de0f59786f4331845e65c7dd6340023a5e280206ca31416058f395fff4bb5de411ff66fc018",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 391,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3831353435373730",
+          "sig" : "308188024201b5051ca0dd3b20df7d8c5b92cb42b8a204f92fb4e58c612f43d3800de8c0683c427e832ce622156747052b81bfbf6ed5fa177b6d47858ec8478f6c9ca7948fd511024201fe5710fac0e9d3e2b3b83081b28b194b822d0c13397bf1516140cbe3faa52e908848f69789a741b9cd54d703a94577fa813e2f2c75834807401ca010fde5328317",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 392,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "313935353330333737",
+          "sig" : "3081870242008d3c8f8e7ab74d49e16a4c7db3a393fa9567777e373313667f9ce32b1b5e648debffedfd2ff5345ca1b8154c18c8b883957d911e41336285f86261c3ee225fdedd02413c51b84c2c9a3feb76a6518634b6f09c0dde8a9d08dec0b3d66135cc1bdb0a80fd69636104af69de8f4062646b29fa3af685ec82704cef706a18c59ca7eca0fb56",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 393,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31323637383130393033",
+          "sig" : "308187024201195625a64ac11c4fc1fc479ef80430eb85c1af77f8a197a17e009569ef6c41ac6f35850755379f478d8928b154e3baaa29e92b481ac04dc72f3728b4f088ff37dc02410d55c7067877dd1302fdc6bb69b7b7c024e4cf3a0e924102d744ac52366d9d76d5855d3da228c4b67bc7bc4b2a14e7999962cc9bbdc517fc24a823abf584b8f56e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 394,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131313830373230383135",
+          "sig" : "308187024126eb68bc0fb7664c35bf5762cd532dce33b0e396e97d6f4143dc6e1e766c836e27c069da9ea1e74e0b03d030cf8a81490508c1c728f86e59282df94de8d8a0dcaf024200a9fb584b712986f19ab7568693df278cafa43272dba400ff333cf48b5556e6e78353a665605c70b6fd0f18f30b850e1a47cda42c4c924bca80102e6793be9a8698",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 395,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "38333831383639323930",
+          "sig" : "308188024200f3d34e36f9754dfa8eafab160ca96d91c7f4f388ec82ac33784026bb6c6a035719eaeec3ee511fffb22dd5d6ab819e6c6387192d6c3a6e9249ead565157e323f62024201b5786b1d662d26fe9f69c370d2bc18882abef693c8f17100a02725de7c9f03602fd53a9208b573b3b7b0b66db971767bde835f9e8f42ada201e7b7391b86fe0294",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 396,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33313331323837323737",
+          "sig" : "308188024200e69c833b604075e9b28a2ff73a56a32e1a247ef9ae01e7a0e471f6015c2b86eb864c281c8c93d2acf5653ad05bafab2f58027f37513eb8569f50bd475e770e9a81024200b9c9d6ce09b53025bfcaa7d172ae41a9b636aa4b80a930931fc99e5e2aa23306f19dc57399b0431e72440a1f4ec7d5ca902f0f7b81c91de85e469f992fdfd4c52e",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 397,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3134333331393236353338",
+          "sig" : "308188024201c6b8b5cf3c4dd3d62391f18e97eef3aa6ace0ae2c6fc97a561cb8e49c087dbcf8135fa433b566b3385cb57202f1b12164fe62765ef73b72a94e7a57870989a498102420185944434b83a0d0fb4bcdce8ddaadb30a1e440815e7674562df9c8bf711222208cc346b9665d90abedb437912391505dd5d26f0178e7c063790f5518f47d1b05c7",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 398,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "333434393038323336",
+          "sig" : "3081880242009f351a41d5375b8993e90b8d8a65bf01d52d14aba1dbe49cbb4ea823804f2b533e0c167903c8bbc593297c18f309798a544787d598074cbf56ef0e5022520912ad024201b892740a57204186bd5f434f72d1534b4289f8f7114cb7b1c9cf4541d754f314448cc32deaf35608263488fdc7596f7481ec098b36f8e440829194becc746c77f5",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 399,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36383239383335393239",
+          "sig" : "308187024201fe24ea831199e31cc68ef23980c4babd3773040870af8823a19708bd0229adc1ce99d02e4d95224101e3e974236f54df86051fa1e9fd21380432633b2495ab782a02410efd1f2a281f967e7b09d721581356a714c499f9b14f781992eb9ae7a19f6825045fdc6d9d763f44e1e7c91480a678a1d8ecf6d66e76cea3505f65ff78cff15cbd",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 400,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "33343435313538303233",
+          "sig" : "3081870242014c6ee9de0a2a0b60c981831e0acd6636b46ae134fedce61b0488112663b24e1d7e74e227fea883d26b68f21e4135ba0e2069bbe0d9c6433c3908fd5b00182894b002416a180a493182c6bc2a09d7e17ff5d62015293f1e8ae205a16fa09042b0a9af6794cb377f4b8b1175fcee5137c234900f735c484feb7da4cbb405cf9e5370fe4f49",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 401,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3132363937393837363434",
+          "sig" : "308188024201044a45853ada17ca761acc7df6d1d380252cb0fa66124d9278a5ed8a4a60453bc71de1dbe32b0261165948823c461c7c1eb1714ec1dbf66fd602c7a47446d1dae1024200f8b27f7c71e37e4b440d2c86f1c1d50bf7c53d3878ed27e7bcfbeb902f769f86d6c3e8820b99f890050f0dbebd2132e84626c5b16a8c7ffffc3a30ace69dd15a11",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 402,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "333939323432353533",
+          "sig" : "3081870241676a381b18d05207cddd73b44e4dd71449985c0fa7de1fff43ca5155139a1a09e5e3fd754d86ebbe32f6609f6e906d48d24790e494343c61faa90bfdaa4f49fdc7024200fbc1c891bf6e368fccad51cc9b2c29e8e92b658e88c0d23285af269aff6702a55a0ab16807e5523b6637bbb004727f6f55c51ad4cec8c924f9c1feb24601aeddef",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 403,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31363031393737393737",
+          "sig" : "3081880242013c9a575382ff6881c908fb5184be7baf38edb0b06008592558efd57dd8fb9993c893800a6ac8c6d2e34ebfbeff43e63263f133868d0ac7a838f69aff26d60a38490242009d22ae7bca8a75a53214c3eece437fb28e05b076ec704d751a28a7ed7e529d5c5338be8c724afa547574a17f70510b2462748a53678e39752a688dc8cf39e886c2",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 404,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3130383738373535313435",
+          "sig" : "308188024201071ce5a19a09aacd43c7cacd58a439dcca4e85f94ea1d48a60f298ee01bb3eeb11d5daf545e7086486f8e4b518a15be69620ab920cf95c5c15ff178c903124fac3024201ad6eaeedece9a7592bd21508b2720f1b8c4bf55637b1e8a5ce5359775b980b21eb1d33e8ebf5c0b3d7829152a295b8a9a1343c25350e35f709936accc8ce08b0b1",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 405,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "37303034323532393939",
+          "sig" : "308188024201bdae499160f4cc6cd163cf110bb1f9b421e8786a8ef9297e4b98fd508a1d14c50617c8d1a3de94fc8bd6c38055e4906b20fdcab6ef7bf9e7e5c98ef3e83e38ec3b024201ba867b8ee72bb7304ff83fc2d734749447420791d5609e0515de4e05fa70a83385a853cac6c47a075c8c61e4b65b9774574101cf4e081770f83ae1b7e727010ba3",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 406,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31353635333235323833",
+          "sig" : "3081860240269fc7ed89e554aa52b3875dc00bc140c1937d4f1b32e29da41ff241cdb9bd3058fc148f905982b8717b035e0db00ded7ebcb08572ec76bf0128411145d73091024201b4bd6bc4ba7befd5c305e018448a771b71fa1a11b3a2c6185dd6b8477c35eaeb4733fecd90f38ecba628f27c02f809191e993e1e7ff590383e2ec2afd08020b267",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 407,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3233383236333432333530",
+          "sig" : "308188024201a5cecc0e572f5ee4eed6755d3230ec5a933c1fb0e35ae771a1fcf0dc880e1c159dd5b6d192dc377505048b7188de3feb815a81a4f30d9226cdc85f751dec1a0410024201ef4a743e1e16f0a60201cc1060625ede6f0936e7af90b42736281e89fe7f2de6aa3f25c68576da705d8b3f6d5d8a34d3073307ea198d1cc8d72a18ef25e90f31af",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 408,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31343437383437303635",
+          "sig" : "308188024201a92b43f57421e54d2528d305e7d5aac9a708e75a7d6fedb47908a4e3edcabdd836a2c4e8436f3b7b64895254536174d88c6dca143699522bc2dfdeebcbf38eb90502420093b0b99a89de72aca0c03e12724c2be323577a4629cb47fdda5b12b61ace0b9fdb97549d3d2a1dac15da66ba6389ee54cbc82c995b9f3aa3ae8474f4bb4b52da8a",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 409,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3134323630323035353434",
+          "sig" : "308188024200a0400f255174ffb8548c29f5faa70e806bb6f6ca08a08753c85c5d145a555cc8e2df285af9985f2e729d4a99a734b7e7fc95560d546a067fda03529f56b2fe66bc024200d7fb60271d22ecb5d8ec904a9df1a416be706ce539e34650b8fc514d1dd7afebc1344c0c68c533c5b20ee249a77c075293b2d7efc8731c2e3619be59da871bb083",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 410,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31393933383335323835",
+          "sig" : "3081880242019207c7b645aa45c2722331f46e094f2eb0052075b8ac9414ad77baafd01d4d1fdc68344136fbce01edfa5627bfb8f3c128abb61072c74802192e89137c68d0cc31024200ff15b0218f81f0a848742f683cb4d1b7c517efdb8fcf8ac6a35e4971b35536851ed68de40a6e1a4a23bddb5b42efca23b91e91959a4f7e2afa196779c96c6c654c",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 411,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34323932313533353233",
+          "sig" : "308188024200aaf119702b9985354bbe3f6b6cda8c46151af4202546dfbe04d5f0ffd18ebe7b29d616f1c40376a412a52f4204b5a13e7f3e4304ead566fc41bf4b5fc0b84c8a2d024200d599deafd4fa2368cd072b854a3d53425d06adf3573e886b81248a7328a546ddc41caed38c6b1ffeaec9a98c940905cbffa87b936da980d4a9003da41e0c59c92f",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 412,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "34343539393031343936",
+          "sig" : "30818702416c09a59e71cf34f983f75dbb4724c4828a93021cee8fd7d92af6941ca8efc9c5ddda7c49a0e1777225782e09313e3091f056122e585c4eaa689fb2fdb1cb7848d80242019f0c5ff6b4638f4c33916db76f9d078bfa8f9e25ae00348e46bb32d777aa26155b82ea73a9e4e2f21f6a65c73ed6c6ab2101cef3524d45b9fc6ea1292f1986acad",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 413,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "31333933393731313731",
+          "sig" : "3081880242014e791c42f3998458c5e17f895d25c85cb419195d65e5a0b9a42cf13ddd36959c73460f54aa840d2254355c6ac626f440cb3a84fba632262c9dc5cab31be7da106b024200abb97b682f01f45168403613a7e2ff82bb4a9fc20952a35d935428f71ddcc799c6d9085fe3230d72261d73cd082e8108523da7ba0b1691ad6ea63f5f4e8e8909f4",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 414,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "32333930363936343935",
+          "sig" : "3081880242013ded35ddff2f97780bbc60b8cec89855a35183a48f8fa6bbdc183994bf89021118cc019629df72112b2c529c023e7a5cfce253f7fdb49105d238680b64275a213c0242009c92e7a0f71608e8d8cfab3f850f7fda1a1a1d056e72254469afe5ceec3c718e6a462e1346941eb08c105501647502c1a810a29df8b208da6a5b296b2bd1e98137",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 415,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3131343436303536323634",
+          "sig" : "308188024201d0d29756ebff02b71674fa4eae37557ccd51a036fb1eb0b7121b405e7fabd60592927d805b75815af1bca6e9d6c5484225bdd0ec7a40735da972fd5ff645d86f1d0242008b9fe55357dc118070cf898973a64e7554b734e900c675541e20332a260ca51a23248d9b8f47ded811cfce556a06a71ba5dc5b873075f264a6843e675caf06a534",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 416,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "363835303034373530",
+          "sig" : "30818802420165fb993f39d350ed60c8483dd6e4e6736591dea974ecd8ab027d3839b752322ee220d40bb6fc0b0d5a8c42928bde50f659b18f51f42fb2b1aa4583892a9114a0c3024200a8816c09d47138bf662da4ba25caf44e24185696d4914a7de2b2535f73b9afbd3ffa9cb0a86a115e4d9ac5be48cf7e8fe276466abdf17127bcc7aaf4d096008ca4",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 417,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "3232323035333630363139",
+          "sig" : "30818702410b901c88ea699e715f6db864e23a676e7f7f2415ac1f850f2dde1ad0d3f9c92e8c5de66d45174d619955fae4b0dfebe49c583506481d28d30cbf58e2ac49f370c202420144c97b688b9ecc07b84c68095267e17e48232922756609e9859d18d2eb7844ec925150c39f2b3a255c882be705e0a8e30e68e49fe7914dbcc3ccfbc1d467050f80",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 418,
+          "comment" : "special case hash",
+          "flags" : [
+            "SpecialCaseHash"
+          ],
+          "msg" : "36323135363635313234",
+          "sig" : "308188024200abbd9e77ef1e2a36c6b06f063d93effb8e852387a94bfdf8359b5c18708f90d9f4e9749fd45347f637546b08733789c988fda4f0309551bde813a0bb1a232adee102420191165d58d153fec68f5cc83bcf5891e2e0ca9681204876e872453e9ebd45870b6878ee437e4d833c6ec54337b779acbf9f8202df510d269a710d0c43e4e07b040d",
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
+        "uncompressed" : "0400491cd6c5f93b7414d6d45cfe3d264bd077fc4427a4b0afede76cac537a7ca5ee2c44564258260f7691b81fdfecebfd03ba672277875c5b311ea920e74fb3978af50144a353a251b4297894161bae12d16a89c33b719f904cfccc277df78cea5379198642fd549df919904dc0cf3662eeab01ef11b8e3cb49b51b853d98f042600c0997",
+        "wx" : "491cd6c5f93b7414d6d45cfe3d264bd077fc4427a4b0afede76cac537a7ca5ee2c44564258260f7691b81fdfecebfd03ba672277875c5b311ea920e74fb3978af5",
+        "wy" : "0144a353a251b4297894161bae12d16a89c33b719f904cfccc277df78cea5379198642fd549df919904dc0cf3662eeab01ef11b8e3cb49b51b853d98f042600c0997"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400491cd6c5f93b7414d6d45cfe3d264bd077fc4427a4b0afede76cac537a7ca5ee2c44564258260f7691b81fdfecebfd03ba672277875c5b311ea920e74fb3978af50144a353a251b4297894161bae12d16a89c33b719f904cfccc277df78cea5379198642fd549df919904dc0cf3662eeab01ef11b8e3cb49b51b853d98f042600c0997",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQASRzWxfk7dBTW1Fz+PSZL0Hf8RCek\nsK/t52ysU3p8pe4sRFZCWCYPdpG4H9/s6/0Dumcid4dcWzEeqSDnT7OXivUBRKNT\nolG0KXiUFhuuEtFqicM7cZ+QTPzMJ333jOpTeRmGQv1UnfkZkE3AzzZi7qsB7xG4\n48tJtRuFPZjwQmAMCZc=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 419,
+          "comment" : "k*G has a large x-coordinate",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3067022105ae79787c40d069948033feb708f65a2fc44a36477663b851449048e16ec79bf5024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 420,
+          "comment" : "r too large",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04015f281dcdc976641ce024dca1eac8ddd7f949e3290d3b2de11c4873f3676a06ff9f704c24813bd8d63528b2e813f78b869ff38112527e79b383a3bd527badb929ff01502e4cc7032d3ec35b0f8d05409438a86966d623f7a2f432bf712f76dc6345405dfcfcdc36d477831d38eec64ede7f4d39aa91bffcc56ec4241cb06735b2809fbe",
+        "wx" : "015f281dcdc976641ce024dca1eac8ddd7f949e3290d3b2de11c4873f3676a06ff9f704c24813bd8d63528b2e813f78b869ff38112527e79b383a3bd527badb929ff",
+        "wy" : "01502e4cc7032d3ec35b0f8d05409438a86966d623f7a2f432bf712f76dc6345405dfcfcdc36d477831d38eec64ede7f4d39aa91bffcc56ec4241cb06735b2809fbe"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004015f281dcdc976641ce024dca1eac8ddd7f949e3290d3b2de11c4873f3676a06ff9f704c24813bd8d63528b2e813f78b869ff38112527e79b383a3bd527badb929ff01502e4cc7032d3ec35b0f8d05409438a86966d623f7a2f432bf712f76dc6345405dfcfcdc36d477831d38eec64ede7f4d39aa91bffcc56ec4241cb06735b2809fbe",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBXygdzcl2ZBzgJNyh6sjd1/lJ4ykN\nOy3hHEhz82dqBv+fcEwkgTvY1jUosugT94uGn/OBElJ+ebODo71Se625Kf8BUC5M\nxwMtPsNbD40FQJQ4qGlm1iP3ovQyv3EvdtxjRUBd/PzcNtR3gx047sZO3n9NOaqR\nv/zFbsQkHLBnNbKAn74=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 421,
+          "comment" : "r,s are large",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386407024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e91386406",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "0400336d5d08fe75c50946e6dddd36c550bb054d9925c8f254cfe1c3388f720b1d6500a90412b020b3db592b92ab9f68f1c693b8d1365371635e21bc43eaadf89e4e7401d48d60319dfd06f935fc46488c229b611eecd038804ae9f681a078dde8ed8f8e20ad9504bcf3c24a0b566b1e85b2d3ed0a1273292ff5f87bae5b3c87857e67ed81",
+        "wx" : "336d5d08fe75c50946e6dddd36c550bb054d9925c8f254cfe1c3388f720b1d6500a90412b020b3db592b92ab9f68f1c693b8d1365371635e21bc43eaadf89e4e74",
+        "wy" : "01d48d60319dfd06f935fc46488c229b611eecd038804ae9f681a078dde8ed8f8e20ad9504bcf3c24a0b566b1e85b2d3ed0a1273292ff5f87bae5b3c87857e67ed81"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400336d5d08fe75c50946e6dddd36c550bb054d9925c8f254cfe1c3388f720b1d6500a90412b020b3db592b92ab9f68f1c693b8d1365371635e21bc43eaadf89e4e7401d48d60319dfd06f935fc46488c229b611eecd038804ae9f681a078dde8ed8f8e20ad9504bcf3c24a0b566b1e85b2d3ed0a1273292ff5f87bae5b3c87857e67ed81",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAM21dCP51xQlG5t3dNsVQuwVNmSXI\n8lTP4cM4j3ILHWUAqQQSsCCz21krkqufaPHGk7jRNlNxY14hvEPqrfieTnQB1I1g\nMZ39Bvk1/EZIjCKbYR7s0DiASun2gaB43ejtj44grZUEvPPCSgtWax6FstPtChJz\nKS/1+HuuWzyHhX5n7YE=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 422,
+          "comment" : "r and s^-1 have a large Hamming weight",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe02420095e19fd2b755d603bf994562d9a11f63cf4eadecbdc0ecb5a394e54529e8da58a527bc6d85725043786362ab4de6cbc7d80e625ae0a98861aea1c7bf7109c91f66",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04006f8fadedbae63701072c287c633f9c0052ea1e6cd00a84342cc0f626210071576abfd0875664b0746cdaf2745effc18d94905b0fc9d2cad4ba375c0ea2298c8d1c0150d128cb62a527ae6df3e92f1f280ea33248711ffe4b35c1b162a9508576860165e0ddc361d96fafcd2ff82776c743b9cd6845db61eb56739f5c4ef561e6c20d8c",
+        "wx" : "6f8fadedbae63701072c287c633f9c0052ea1e6cd00a84342cc0f626210071576abfd0875664b0746cdaf2745effc18d94905b0fc9d2cad4ba375c0ea2298c8d1c",
+        "wy" : "0150d128cb62a527ae6df3e92f1f280ea33248711ffe4b35c1b162a9508576860165e0ddc361d96fafcd2ff82776c743b9cd6845db61eb56739f5c4ef561e6c20d8c"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004006f8fadedbae63701072c287c633f9c0052ea1e6cd00a84342cc0f626210071576abfd0875664b0746cdaf2745effc18d94905b0fc9d2cad4ba375c0ea2298c8d1c0150d128cb62a527ae6df3e92f1f280ea33248711ffe4b35c1b162a9508576860165e0ddc361d96fafcd2ff82776c743b9cd6845db61eb56739f5c4ef561e6c20d8c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAb4+t7brmNwEHLCh8Yz+cAFLqHmzQ\nCoQ0LMD2JiEAcVdqv9CHVmSwdGza8nRe/8GNlJBbD8nSytS6N1wOoimMjRwBUNEo\ny2KlJ65t8+kvHygOozJIcR/+SzXBsWKpUIV2hgFl4N3DYdlvr80v+Cd2x0O5zWhF\n22HrVnOfXE71YebCDYw=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 423,
+          "comment" : "r and s^-1 have a large Hamming weight",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe024115837645583a37a7a665f983c5e347f65dca47647aa80fd2498a791d44d9b2850a151a6e86fce7d7bb814e724ff11b9ef726bf36c6e7548c37f82a24902876ee19",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04005e7eb6c4f481830abaad8a60ddb09891164ee418ea4cd2995062e227d33c229fb737bf330703097d6b3b69a3f09e79c9de0b402bf846dd26b5bb1191cff801355d01789c9afda567e61de414437b0e93a17611e6e76853762bc0aff1e2bc9e46ce1285b931651d7129b85aef2c1fab1728e7eb4449b2956dec33e6cd7c9ba125c5cd9d",
+        "wx" : "5e7eb6c4f481830abaad8a60ddb09891164ee418ea4cd2995062e227d33c229fb737bf330703097d6b3b69a3f09e79c9de0b402bf846dd26b5bb1191cff801355d",
+        "wy" : "01789c9afda567e61de414437b0e93a17611e6e76853762bc0aff1e2bc9e46ce1285b931651d7129b85aef2c1fab1728e7eb4449b2956dec33e6cd7c9ba125c5cd9d"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004005e7eb6c4f481830abaad8a60ddb09891164ee418ea4cd2995062e227d33c229fb737bf330703097d6b3b69a3f09e79c9de0b402bf846dd26b5bb1191cff801355d01789c9afda567e61de414437b0e93a17611e6e76853762bc0aff1e2bc9e46ce1285b931651d7129b85aef2c1fab1728e7eb4449b2956dec33e6cd7c9ba125c5cd9d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAXn62xPSBgwq6rYpg3bCYkRZO5Bjq\nTNKZUGLiJ9M8Ip+3N78zBwMJfWs7aaPwnnnJ3gtAK/hG3Sa1uxGRz/gBNV0BeJya\n/aVn5h3kFEN7DpOhdhHm52hTdivAr/HivJ5GzhKFuTFlHXEpuFrvLB+rFyjn60RJ\nspVt7DPmzXyboSXFzZ0=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 424,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101020101",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "0400b420fb1fecdd9cc5ea7d7c7617e70538db32e6d7a0ad722c63580f1f6a1f5537eb50930b90fd6fdd9abd40015f746d2fd8adf945a75621407edb6863588e41979e00295108a7e9d2191a287fd160bd24f498055dc9badbd61c6a89fede27b4f9d479d86a20b6dc07c90f008ebe68a0e0cc15a4a03b8cf990e4ff7ed6e3892b21c52153",
+        "wx" : "00b420fb1fecdd9cc5ea7d7c7617e70538db32e6d7a0ad722c63580f1f6a1f5537eb50930b90fd6fdd9abd40015f746d2fd8adf945a75621407edb6863588e41979e",
+        "wy" : "295108a7e9d2191a287fd160bd24f498055dc9badbd61c6a89fede27b4f9d479d86a20b6dc07c90f008ebe68a0e0cc15a4a03b8cf990e4ff7ed6e3892b21c52153"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400b420fb1fecdd9cc5ea7d7c7617e70538db32e6d7a0ad722c63580f1f6a1f5537eb50930b90fd6fdd9abd40015f746d2fd8adf945a75621407edb6863588e41979e00295108a7e9d2191a287fd160bd24f498055dc9badbd61c6a89fede27b4f9d479d86a20b6dc07c90f008ebe68a0e0cc15a4a03b8cf990e4ff7ed6e3892b21c52153",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAtCD7H+zdnMXqfXx2F+cFONsy5teg\nrXIsY1gPH2ofVTfrUJMLkP1v3Zq9QAFfdG0v2K35RadWIUB+22hjWI5Bl54AKVEI\np+nSGRoof9FgvST0mAVdybrb1hxqif7eJ7T51HnYaiC23AfJDwCOvmig4MwVpKA7\njPmQ5P9+1uOJKyHFIVM=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 425,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020101020102",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
         "uncompressed" : "040032b9a17c201aec34d29b8c2764e7c7f6aeef10fb61bf9837117fad879f8c6a22a300006d2018cf42b25898ffc9a1bf507352e59e6a52e627cda160e17ea2f4600500317a89899b7cb3a0d33eafa02b0137a0fb1b05102b22b676f35b9ff6c050ddee9f185609ffb7f5165a769e440792b75044a43e838690d13f884aaae888bf5f86f0",
         "wx" : "32b9a17c201aec34d29b8c2764e7c7f6aeef10fb61bf9837117fad879f8c6a22a300006d2018cf42b25898ffc9a1bf507352e59e6a52e627cda160e17ea2f46005",
         "wy" : "317a89899b7cb3a0d33eafa02b0137a0fb1b05102b22b676f35b9ff6c050ddee9f185609ffb7f5165a769e440792b75044a43e838690d13f884aaae888bf5f86f0"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040032b9a17c201aec34d29b8c2764e7c7f6aeef10fb61bf9837117fad879f8c6a22a300006d2018cf42b25898ffc9a1bf507352e59e6a52e627cda160e17ea2f4600500317a89899b7cb3a0d33eafa02b0137a0fb1b05102b22b676f35b9ff6c050ddee9f185609ffb7f5165a769e440792b75044a43e838690d13f884aaae888bf5f86f0",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAMrmhfCAa7DTSm4wnZOfH9q7vEPth\nv5g3EX+th5+MaiKjAABtIBjPQrJYmP/Job9Qc1LlnmpS5ifNoWDhfqL0YAUAMXqJ\niZt8s6DTPq+gKwE3oPsbBRArIrZ281uf9sBQ3e6fGFYJ/7f1Flp2nkQHkrdQRKQ+\ng4aQ0T+ISqroiL9fhvA=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040032b9a17c201aec34d29b8c2764e7c7f6aeef10fb61bf9837117fad879f8c6a22a300006d2018cf42b25898ffc9a1bf507352e59e6a52e627cda160e17ea2f4600500317a89899b7cb3a0d33eafa02b0137a0fb1b05102b22b676f35b9ff6c050ddee9f185609ffb7f5165a769e440792b75044a43e838690d13f884aaae888bf5f86f0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAMrmhfCAa7DTSm4wnZOfH9q7vEPth\nv5g3EX+th5+MaiKjAABtIBjPQrJYmP/Job9Qc1LlnmpS5ifNoWDhfqL0YAUAMXqJ\niZt8s6DTPq+gKwE3oPsbBRArIrZ281uf9sBQ3e6fGFYJ/7f1Flp2nkQHkrdQRKQ+\ng4aQ0T+ISqroiL9fhvA=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 347,
+          "tcId" : 426,
           "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3006020101020103",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 348,
-          "comment" : "r is larger than n",
-          "msg" : "313233343030",
-          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640a020103",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
-        "uncompressed" : "040067dd456b52f82a5d4c4a71b3ea9302f62a852ddc04ad25b62fef1ddf657374fb4e80679ddf42d212f0711db32b626d8593bd70892e93ed0adb273157b6df187938014d2c78509f3bd6f7d0fba4a90cb456286e267f5dd9d967842a6086884d66c7b2a932833470c721a4a728cd8486d15314232d801f17e3a6fd7068bdebacdf82c0b4",
-        "wx" : "67dd456b52f82a5d4c4a71b3ea9302f62a852ddc04ad25b62fef1ddf657374fb4e80679ddf42d212f0711db32b626d8593bd70892e93ed0adb273157b6df187938",
-        "wy" : "14d2c78509f3bd6f7d0fba4a90cb456286e267f5dd9d967842a6086884d66c7b2a932833470c721a4a728cd8486d15314232d801f17e3a6fd7068bdebacdf82c0b4"
+        "uncompressed" : "040010b17d53711f5157f79062c0e034a43b63a8b9893e6032961a2914b78a63658579c6c069d3e03f47017f45d1c883724fa3d492aad8cb7f445b4a3d14926be29c2400a83583cf3b5b4e9e1bbfa0004feaf743d7294d6cf4bde726c0ce013db32cffeceb7d01d1af3fd2f214e98e6fc2e40e27bbf675d766f2ecfda075f260cb530b3a29",
+        "wx" : "10b17d53711f5157f79062c0e034a43b63a8b9893e6032961a2914b78a63658579c6c069d3e03f47017f45d1c883724fa3d492aad8cb7f445b4a3d14926be29c24",
+        "wy" : "00a83583cf3b5b4e9e1bbfa0004feaf743d7294d6cf4bde726c0ce013db32cffeceb7d01d1af3fd2f214e98e6fc2e40e27bbf675d766f2ecfda075f260cb530b3a29"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040067dd456b52f82a5d4c4a71b3ea9302f62a852ddc04ad25b62fef1ddf657374fb4e80679ddf42d212f0711db32b626d8593bd70892e93ed0adb273157b6df187938014d2c78509f3bd6f7d0fba4a90cb456286e267f5dd9d967842a6086884d66c7b2a932833470c721a4a728cd8486d15314232d801f17e3a6fd7068bdebacdf82c0b4",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAZ91Fa1L4Kl1MSnGz6pMC9iqFLdwE\nrSW2L+8d32VzdPtOgGed30LSEvBxHbMrYm2Fk71wiS6T7QrbJzFXtt8YeTgBTSx4\nUJ871vfQ+6SpDLRWKG4mf13Z2WeEKmCGiE1mx7KpMoM0cMchpKcozYSG0VMUIy2A\nHxfjpv1waL3rrN+CwLQ=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040010b17d53711f5157f79062c0e034a43b63a8b9893e6032961a2914b78a63658579c6c069d3e03f47017f45d1c883724fa3d492aad8cb7f445b4a3d14926be29c2400a83583cf3b5b4e9e1bbfa0004feaf743d7294d6cf4bde726c0ce013db32cffeceb7d01d1af3fd2f214e98e6fc2e40e27bbf675d766f2ecfda075f260cb530b3a29",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAELF9U3EfUVf3kGLA4DSkO2OouYk+\nYDKWGikUt4pjZYV5xsBp0+A/RwF/RdHIg3JPo9SSqtjLf0RbSj0UkmvinCQAqDWD\nzztbTp4bv6AAT+r3Q9cpTWz0vecmwM4BPbMs/+zrfQHRrz/S8hTpjm/C5A4nu/Z1\n12by7P2gdfJgy1MLOik=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 349,
-          "comment" : "s is larger than n",
+          "tcId" : 427,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
-          "sig" : "3047020101024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e914b3a90",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "3006020102020101",
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
+        "uncompressed" : "040019b553db7e685e34f50662436258a16cc2fc08bcdc5b44755aa24f1e9948e1da4d15e2bb14a2612c1990a43a7b8b81c0be2f614daba72abd551f78ab998f4ff541010a807a820f580b3b1f824c664d7d94f6850c167b2c867e7ac7b8b4b8b6905e2c09df4479ce2073f0bc83b73fd9de254aba29f6b5485385d9f647b3e57d475c6502",
+        "wx" : "19b553db7e685e34f50662436258a16cc2fc08bcdc5b44755aa24f1e9948e1da4d15e2bb14a2612c1990a43a7b8b81c0be2f614daba72abd551f78ab998f4ff541",
+        "wy" : "010a807a820f580b3b1f824c664d7d94f6850c167b2c867e7ac7b8b4b8b6905e2c09df4479ce2073f0bc83b73fd9de254aba29f6b5485385d9f647b3e57d475c6502"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040019b553db7e685e34f50662436258a16cc2fc08bcdc5b44755aa24f1e9948e1da4d15e2bb14a2612c1990a43a7b8b81c0be2f614daba72abd551f78ab998f4ff541010a807a820f580b3b1f824c664d7d94f6850c167b2c867e7ac7b8b4b8b6905e2c09df4479ce2073f0bc83b73fd9de254aba29f6b5485385d9f647b3e57d475c6502",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAGbVT235oXjT1BmJDYlihbML8CLzc\nW0R1WqJPHplI4dpNFeK7FKJhLBmQpDp7i4HAvi9hTaunKr1VH3irmY9P9UEBCoB6\ngg9YCzsfgkxmTX2U9oUMFnsshn56x7i0uLaQXiwJ30R5ziBz8LyDtz/Z3iVKuin2\ntUhThdn2R7PlfUdcZQI=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 428,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020102020102",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "0401daa911a9f08107cc86a60ae577b1e8a6d898d5a8714610fa5630b5096748c87ff3de68fd1c29695bb632380c335564afc1e82dac15c790775dc6d3a27e0f5ed97d0094869cf902444247d35dabc6ea924953d859a0b2e74b303c3a02def7ed51cb52e9aae611b6d6c9a488c561957cc5dcd652b42c121387d164fe57af38111226282e",
+        "wx" : "01daa911a9f08107cc86a60ae577b1e8a6d898d5a8714610fa5630b5096748c87ff3de68fd1c29695bb632380c335564afc1e82dac15c790775dc6d3a27e0f5ed97d",
+        "wy" : "0094869cf902444247d35dabc6ea924953d859a0b2e74b303c3a02def7ed51cb52e9aae611b6d6c9a488c561957cc5dcd652b42c121387d164fe57af38111226282e"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401daa911a9f08107cc86a60ae577b1e8a6d898d5a8714610fa5630b5096748c87ff3de68fd1c29695bb632380c335564afc1e82dac15c790775dc6d3a27e0f5ed97d0094869cf902444247d35dabc6ea924953d859a0b2e74b303c3a02def7ed51cb52e9aae611b6d6c9a488c561957cc5dcd652b42c121387d164fe57af38111226282e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB2qkRqfCBB8yGpgrld7HoptiY1ahx\nRhD6VjC1CWdIyH/z3mj9HClpW7YyOAwzVWSvwegtrBXHkHddxtOifg9e2X0AlIac\n+QJEQkfTXavG6pJJU9hZoLLnSzA8OgLe9+1Ry1LpquYRttbJpIjFYZV8xdzWUrQs\nEhOH0WT+V684ERImKC4=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 429,
+          "comment" : "small r and s",
+          "flags" : [
+            "SmallRandS",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3006020102020103",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 430,
+          "comment" : "r is larger than n",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640b020103",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "0401be3fd44e342b0a202a55ee167c4a98ae61cd5f7a02eb138774bf48075e966edc15054cb1e378ceb836fc648f3038243ed250f515dc8e7a6a129ec413aeb983963a0197a4055e496aa30e5233141c16ad5342cc9cc4fde6c4982ab6d20aa6b0124b76f16267bf40e0f14e87aff05720cd20e3c4f9b201252d61b4d64f3a3fd61cb186b4",
+        "wx" : "01be3fd44e342b0a202a55ee167c4a98ae61cd5f7a02eb138774bf48075e966edc15054cb1e378ceb836fc648f3038243ed250f515dc8e7a6a129ec413aeb983963a",
+        "wy" : "0197a4055e496aa30e5233141c16ad5342cc9cc4fde6c4982ab6d20aa6b0124b76f16267bf40e0f14e87aff05720cd20e3c4f9b201252d61b4d64f3a3fd61cb186b4"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401be3fd44e342b0a202a55ee167c4a98ae61cd5f7a02eb138774bf48075e966edc15054cb1e378ceb836fc648f3038243ed250f515dc8e7a6a129ec413aeb983963a0197a4055e496aa30e5233141c16ad5342cc9cc4fde6c4982ab6d20aa6b0124b76f16267bf40e0f14e87aff05720cd20e3c4f9b201252d61b4d64f3a3fd61cb186b4",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBvj/UTjQrCiAqVe4WfEqYrmHNX3oC\n6xOHdL9IB16WbtwVBUyx43jOuDb8ZI8wOCQ+0lD1FdyOemoSnsQTrrmDljoBl6QF\nXklqow5SMxQcFq1TQsycxP3mxJgqttIKprASS3bxYme/QODxToev8FcgzSDjxPmy\nASUtYbTWTzo/1hyxhrQ=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 431,
+          "comment" : "s is larger than n",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047020102024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e914b3a90",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
         "uncompressed" : "040068d7b518214766ac734a7461d499352444377d50af42a1bbdb7f0032065ee6dc341ccf231af65250e7d13a80733abebff559891d4211d6c28cf952c9222303b53b00a2f3d7e14d9d8fabe1939d664e4615c6e24f5490c815c7651ccf6cc65252f88bcfd3b07fbdbaa0ba00441e590ccbcea00658f388f22c42d8a6d0f781ae5bb4d78b",
         "wx" : "68d7b518214766ac734a7461d499352444377d50af42a1bbdb7f0032065ee6dc341ccf231af65250e7d13a80733abebff559891d4211d6c28cf952c9222303b53b",
-        "wy" : "0a2f3d7e14d9d8fabe1939d664e4615c6e24f5490c815c7651ccf6cc65252f88bcfd3b07fbdbaa0ba00441e590ccbcea00658f388f22c42d8a6d0f781ae5bb4d78b"
+        "wy" : "00a2f3d7e14d9d8fabe1939d664e4615c6e24f5490c815c7651ccf6cc65252f88bcfd3b07fbdbaa0ba00441e590ccbcea00658f388f22c42d8a6d0f781ae5bb4d78b"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040068d7b518214766ac734a7461d499352444377d50af42a1bbdb7f0032065ee6dc341ccf231af65250e7d13a80733abebff559891d4211d6c28cf952c9222303b53b00a2f3d7e14d9d8fabe1939d664e4615c6e24f5490c815c7651ccf6cc65252f88bcfd3b07fbdbaa0ba00441e590ccbcea00658f388f22c42d8a6d0f781ae5bb4d78b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAaNe1GCFHZqxzSnRh1Jk1JEQ3fVCv\nQqG7238AMgZe5tw0HM8jGvZSUOfROoBzOr6/9VmJHUIR1sKM+VLJIiMDtTsAovPX\n4U2dj6vhk51mTkYVxuJPVJDIFcdlHM9sxlJS+IvP07B/vbqgugBEHlkMy86gBljz\niPIsQtim0PeBrlu014s=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040068d7b518214766ac734a7461d499352444377d50af42a1bbdb7f0032065ee6dc341ccf231af65250e7d13a80733abebff559891d4211d6c28cf952c9222303b53b00a2f3d7e14d9d8fabe1939d664e4615c6e24f5490c815c7651ccf6cc65252f88bcfd3b07fbdbaa0ba00441e590ccbcea00658f388f22c42d8a6d0f781ae5bb4d78b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAaNe1GCFHZqxzSnRh1Jk1JEQ3fVCv\nQqG7238AMgZe5tw0HM8jGvZSUOfROoBzOr6/9VmJHUIR1sKM+VLJIiMDtTsAovPX\n4U2dj6vhk51mTkYVxuJPVJDIFcdlHM9sxlJS+IvP07B/vbqgugBEHlkMy86gBljz\niPIsQtim0PeBrlu014s=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 350,
+          "tcId" : 432,
           "comment" : "small r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304802020100024201efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7efdfbf7ef87b4de1fc92dd757639408a50bee10764e326fdd2fa308dfde3e5243fdf4ac5ac",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04011edc3b22b20f9a188b32b1e827d6e46b2ed61b9be6f4ada0b2c95835bee2738ec4dc5313831cce5f927210a7bc2f13abc02fa90e716fc1bd2f63c429a760ed23630118daad88fe9b9d66e66e71ce05d74137d277a9ca81c7d7aef1e74550890564103cc0d95d30f6205c9124829192e15d66fb1f4033032a42ba606e3edca6ec065c50",
-        "wx" : "11edc3b22b20f9a188b32b1e827d6e46b2ed61b9be6f4ada0b2c95835bee2738ec4dc5313831cce5f927210a7bc2f13abc02fa90e716fc1bd2f63c429a760ed2363",
-        "wy" : "118daad88fe9b9d66e66e71ce05d74137d277a9ca81c7d7aef1e74550890564103cc0d95d30f6205c9124829192e15d66fb1f4033032a42ba606e3edca6ec065c50"
+        "wx" : "011edc3b22b20f9a188b32b1e827d6e46b2ed61b9be6f4ada0b2c95835bee2738ec4dc5313831cce5f927210a7bc2f13abc02fa90e716fc1bd2f63c429a760ed2363",
+        "wy" : "0118daad88fe9b9d66e66e71ce05d74137d277a9ca81c7d7aef1e74550890564103cc0d95d30f6205c9124829192e15d66fb1f4033032a42ba606e3edca6ec065c50"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004011edc3b22b20f9a188b32b1e827d6e46b2ed61b9be6f4ada0b2c95835bee2738ec4dc5313831cce5f927210a7bc2f13abc02fa90e716fc1bd2f63c429a760ed23630118daad88fe9b9d66e66e71ce05d74137d277a9ca81c7d7aef1e74550890564103cc0d95d30f6205c9124829192e15d66fb1f4033032a42ba606e3edca6ec065c50",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBHtw7IrIPmhiLMrHoJ9bkay7WG5vm\n9K2gsslYNb7ic47E3FMTgxzOX5JyEKe8LxOrwC+pDnFvwb0vY8Qpp2DtI2MBGNqt\niP6bnWbmbnHOBddBN9J3qcqBx9eu8edFUIkFZBA8wNldMPYgXJEkgpGS4V1m+x9A\nMwMqQrpgbj7cpuwGXFA=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004011edc3b22b20f9a188b32b1e827d6e46b2ed61b9be6f4ada0b2c95835bee2738ec4dc5313831cce5f927210a7bc2f13abc02fa90e716fc1bd2f63c429a760ed23630118daad88fe9b9d66e66e71ce05d74137d277a9ca81c7d7aef1e74550890564103cc0d95d30f6205c9124829192e15d66fb1f4033032a42ba606e3edca6ec065c50",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBHtw7IrIPmhiLMrHoJ9bkay7WG5vm\n9K2gsslYNb7ic47E3FMTgxzOX5JyEKe8LxOrwC+pDnFvwb0vY8Qpp2DtI2MBGNqt\niP6bnWbmbnHOBddBN9J3qcqBx9eu8edFUIkFZBA8wNldMPYgXJEkgpGS4V1m+x9A\nMwMqQrpgbj7cpuwGXFA=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 351,
+          "tcId" : 433,
           "comment" : "smallish r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "304d02072d9b4d347952cd02420100508d073413de829275e76509fd81cff49adf4c80ed2ddd4a7937d1d918796878fec24cc46570982c3fb8f5e92ccdcb3e677f07e9bd0db0b84814be1c7949b0de",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04012f8b9863a1887eca6827ad4accc2ba607f8592e5be15d9692b697a4061fcc81560c8feb2ae3851d00e06df3e0091f1f1ca5ec64761f4f8bd6d0c2cab2a121024440174b4e34aec517a0d2ceb2fd152ed1736bc330efca5e6d530ea170802fb6af031425903fa6a378405be5e47d1e52f62f859f537df9c0f6a4a6479a0aadafe219821",
-        "wx" : "12f8b9863a1887eca6827ad4accc2ba607f8592e5be15d9692b697a4061fcc81560c8feb2ae3851d00e06df3e0091f1f1ca5ec64761f4f8bd6d0c2cab2a12102444",
-        "wy" : "174b4e34aec517a0d2ceb2fd152ed1736bc330efca5e6d530ea170802fb6af031425903fa6a378405be5e47d1e52f62f859f537df9c0f6a4a6479a0aadafe219821"
+        "wx" : "012f8b9863a1887eca6827ad4accc2ba607f8592e5be15d9692b697a4061fcc81560c8feb2ae3851d00e06df3e0091f1f1ca5ec64761f4f8bd6d0c2cab2a12102444",
+        "wy" : "0174b4e34aec517a0d2ceb2fd152ed1736bc330efca5e6d530ea170802fb6af031425903fa6a378405be5e47d1e52f62f859f537df9c0f6a4a6479a0aadafe219821"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004012f8b9863a1887eca6827ad4accc2ba607f8592e5be15d9692b697a4061fcc81560c8feb2ae3851d00e06df3e0091f1f1ca5ec64761f4f8bd6d0c2cab2a121024440174b4e34aec517a0d2ceb2fd152ed1736bc330efca5e6d530ea170802fb6af031425903fa6a378405be5e47d1e52f62f859f537df9c0f6a4a6479a0aadafe219821",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBL4uYY6GIfspoJ61KzMK6YH+FkuW+\nFdlpK2l6QGH8yBVgyP6yrjhR0A4G3z4AkfHxyl7GR2H0+L1tDCyrKhIQJEQBdLTj\nSuxReg0s6y/RUu0XNrwzDvyl5tUw6hcIAvtq8DFCWQP6ajeEBb5eR9HlL2L4WfU3\n35wPakpkeaCq2v4hmCE=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004012f8b9863a1887eca6827ad4accc2ba607f8592e5be15d9692b697a4061fcc81560c8feb2ae3851d00e06df3e0091f1f1ca5ec64761f4f8bd6d0c2cab2a121024440174b4e34aec517a0d2ceb2fd152ed1736bc330efca5e6d530ea170802fb6af031425903fa6a378405be5e47d1e52f62f859f537df9c0f6a4a6479a0aadafe219821",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBL4uYY6GIfspoJ61KzMK6YH+FkuW+\nFdlpK2l6QGH8yBVgyP6yrjhR0A4G3z4AkfHxyl7GR2H0+L1tDCyrKhIQJEQBdLTj\nSuxReg0s6y/RUu0XNrwzDvyl5tUw6hcIAvtq8DFCWQP6ajeEBb5eR9HlL2L4WfU3\n35wPakpkeaCq2v4hmCE=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 352,
+          "tcId" : 434,
           "comment" : "100-bit r and small s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3053020d1033e67e37b32b445580bf4eff0242013cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc33cc3393f632affd3eaa3c8fb64507bd5996497bd588fb9e3947c097ced7546b57c8998",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04008aed779a32b9bf56ea7ab46e4b914e55c65301cdbe9ea6e7ed44f7e978c0365989a19a5e48282fb1158f481c556505d66ff414a07003ebf82fca1698c33f2884c600a62426993ed5b177b6045e60b5fa1a1f8ce1ad5d70e7bc7b5af811dbf86e651f9ea02ec796ab991e1439bf07ffe2ac6052a8a0b0174d78a9441aaf4d8fc757d80f",
-        "wx" : "08aed779a32b9bf56ea7ab46e4b914e55c65301cdbe9ea6e7ed44f7e978c0365989a19a5e48282fb1158f481c556505d66ff414a07003ebf82fca1698c33f2884c6",
-        "wy" : "0a62426993ed5b177b6045e60b5fa1a1f8ce1ad5d70e7bc7b5af811dbf86e651f9ea02ec796ab991e1439bf07ffe2ac6052a8a0b0174d78a9441aaf4d8fc757d80f"
+        "wx" : "008aed779a32b9bf56ea7ab46e4b914e55c65301cdbe9ea6e7ed44f7e978c0365989a19a5e48282fb1158f481c556505d66ff414a07003ebf82fca1698c33f2884c6",
+        "wy" : "00a62426993ed5b177b6045e60b5fa1a1f8ce1ad5d70e7bc7b5af811dbf86e651f9ea02ec796ab991e1439bf07ffe2ac6052a8a0b0174d78a9441aaf4d8fc757d80f"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004008aed779a32b9bf56ea7ab46e4b914e55c65301cdbe9ea6e7ed44f7e978c0365989a19a5e48282fb1158f481c556505d66ff414a07003ebf82fca1698c33f2884c600a62426993ed5b177b6045e60b5fa1a1f8ce1ad5d70e7bc7b5af811dbf86e651f9ea02ec796ab991e1439bf07ffe2ac6052a8a0b0174d78a9441aaf4d8fc757d80f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAiu13mjK5v1bqerRuS5FOVcZTAc2+\nnqbn7UT36XjANlmJoZpeSCgvsRWPSBxVZQXWb/QUoHAD6/gvyhaYwz8ohMYApiQm\nmT7VsXe2BF5gtfoaH4zhrV1w57x7WvgR2/huZR+eoC7HlquZHhQ5vwf/4qxgUqig\nsBdNeKlEGq9Nj8dX2A8=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004008aed779a32b9bf56ea7ab46e4b914e55c65301cdbe9ea6e7ed44f7e978c0365989a19a5e48282fb1158f481c556505d66ff414a07003ebf82fca1698c33f2884c600a62426993ed5b177b6045e60b5fa1a1f8ce1ad5d70e7bc7b5af811dbf86e651f9ea02ec796ab991e1439bf07ffe2ac6052a8a0b0174d78a9441aaf4d8fc757d80f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAiu13mjK5v1bqerRuS5FOVcZTAc2+\nnqbn7UT36XjANlmJoZpeSCgvsRWPSBxVZQXWb/QUoHAD6/gvyhaYwz8ohMYApiQm\nmT7VsXe2BF5gtfoaH4zhrV1w57x7WvgR2/huZR+eoC7HlquZHhQ5vwf/4qxgUqig\nsBdNeKlEGq9Nj8dX2A8=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 353,
+          "tcId" : 435,
           "comment" : "small r and 100 bit s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "30480202010002420086ecbf54ab59a4e195f0be1402edd8657bb94618fab50f2fe20fe5ebbc9ff0e491397ed313cc918d438eedb9b5ecb4d9dfa305303505baf25400ed8c20fc3fc47b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040093697b0378312b38c31deae073f24a8163f086ac2116b7c37c99157cfae7970ab4201f5a7e06ec39eedbf7d87f3021ca439e3ff7c5988b84679937bab786dbe12e01c6987c86077c05423ac281de6d23f6a685870e12855463770eccabc9f3a1d23cb2a0c15479420b5dd40fbdc9886c463b62ee23239df3a8b861c3291d28224f6057",
-        "wx" : "093697b0378312b38c31deae073f24a8163f086ac2116b7c37c99157cfae7970ab4201f5a7e06ec39eedbf7d87f3021ca439e3ff7c5988b84679937bab786dbe12e",
-        "wy" : "1c6987c86077c05423ac281de6d23f6a685870e12855463770eccabc9f3a1d23cb2a0c15479420b5dd40fbdc9886c463b62ee23239df3a8b861c3291d28224f6057"
+        "wx" : "0093697b0378312b38c31deae073f24a8163f086ac2116b7c37c99157cfae7970ab4201f5a7e06ec39eedbf7d87f3021ca439e3ff7c5988b84679937bab786dbe12e",
+        "wy" : "01c6987c86077c05423ac281de6d23f6a685870e12855463770eccabc9f3a1d23cb2a0c15479420b5dd40fbdc9886c463b62ee23239df3a8b861c3291d28224f6057"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040093697b0378312b38c31deae073f24a8163f086ac2116b7c37c99157cfae7970ab4201f5a7e06ec39eedbf7d87f3021ca439e3ff7c5988b84679937bab786dbe12e01c6987c86077c05423ac281de6d23f6a685870e12855463770eccabc9f3a1d23cb2a0c15479420b5dd40fbdc9886c463b62ee23239df3a8b861c3291d28224f6057",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAk2l7A3gxKzjDHergc/JKgWPwhqwh\nFrfDfJkVfPrnlwq0IB9afgbsOe7b99h/MCHKQ54/98WYi4RnmTe6t4bb4S4Bxph8\nhgd8BUI6woHebSP2poWHDhKFVGN3DsyryfOh0jyyoMFUeUILXdQPvcmIbEY7Yu4j\nI53zqLhhwykdKCJPYFc=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040093697b0378312b38c31deae073f24a8163f086ac2116b7c37c99157cfae7970ab4201f5a7e06ec39eedbf7d87f3021ca439e3ff7c5988b84679937bab786dbe12e01c6987c86077c05423ac281de6d23f6a685870e12855463770eccabc9f3a1d23cb2a0c15479420b5dd40fbdc9886c463b62ee23239df3a8b861c3291d28224f6057",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAk2l7A3gxKzjDHergc/JKgWPwhqwh\nFrfDfJkVfPrnlwq0IB9afgbsOe7b99h/MCHKQ54/98WYi4RnmTe6t4bb4S4Bxph8\nhgd8BUI6woHebSP2poWHDhKFVGN3DsyryfOh0jyyoMFUeUILXdQPvcmIbEY7Yu4j\nI53zqLhhwykdKCJPYFc=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 354,
+          "tcId" : 436,
           "comment" : "100-bit r and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3053020d062522bbd3ecbe7c39e93e7c2402420086ecbf54ab59a4e195f0be1402edd8657bb94618fab50f2fe20fe5ebbc9ff0e491397ed313cc918d438eedb9b5ecb4d9dfa305303505baf25400ed8c20fc3fc47b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04019a9f1b7b7f574a021fedd8679a4e998b48524854eefbaae4104a3973d693e02104fa119243256e3d986f8b4966c286ab8cb1f5267c0bbd6bc182aeb57493a5d5b60158b97eb74862fbca41763e8d3a7beb5fccd05565b75a3a43c2b38b96eb2ccff149c23ef1ac09fc455d808ff28081e985f9e172fc62d0900585172cfbff87383595",
-        "wx" : "19a9f1b7b7f574a021fedd8679a4e998b48524854eefbaae4104a3973d693e02104fa119243256e3d986f8b4966c286ab8cb1f5267c0bbd6bc182aeb57493a5d5b6",
-        "wy" : "158b97eb74862fbca41763e8d3a7beb5fccd05565b75a3a43c2b38b96eb2ccff149c23ef1ac09fc455d808ff28081e985f9e172fc62d0900585172cfbff87383595"
+        "wx" : "019a9f1b7b7f574a021fedd8679a4e998b48524854eefbaae4104a3973d693e02104fa119243256e3d986f8b4966c286ab8cb1f5267c0bbd6bc182aeb57493a5d5b6",
+        "wy" : "0158b97eb74862fbca41763e8d3a7beb5fccd05565b75a3a43c2b38b96eb2ccff149c23ef1ac09fc455d808ff28081e985f9e172fc62d0900585172cfbff87383595"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004019a9f1b7b7f574a021fedd8679a4e998b48524854eefbaae4104a3973d693e02104fa119243256e3d986f8b4966c286ab8cb1f5267c0bbd6bc182aeb57493a5d5b60158b97eb74862fbca41763e8d3a7beb5fccd05565b75a3a43c2b38b96eb2ccff149c23ef1ac09fc455d808ff28081e985f9e172fc62d0900585172cfbff87383595",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBmp8be39XSgIf7dhnmk6Zi0hSSFTu\n+6rkEEo5c9aT4CEE+hGSQyVuPZhvi0lmwoarjLH1JnwLvWvBgq61dJOl1bYBWLl+\nt0hi+8pBdj6NOnvrX8zQVWW3WjpDwrOLlussz/FJwj7xrAn8RV2Aj/KAgemF+eFy\n/GLQkAWFFyz7/4c4NZU=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004019a9f1b7b7f574a021fedd8679a4e998b48524854eefbaae4104a3973d693e02104fa119243256e3d986f8b4966c286ab8cb1f5267c0bbd6bc182aeb57493a5d5b60158b97eb74862fbca41763e8d3a7beb5fccd05565b75a3a43c2b38b96eb2ccff149c23ef1ac09fc455d808ff28081e985f9e172fc62d0900585172cfbff87383595",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBmp8be39XSgIf7dhnmk6Zi0hSSFTu\n+6rkEEo5c9aT4CEE+hGSQyVuPZhvi0lmwoarjLH1JnwLvWvBgq61dJOl1bYBWLl+\nt0hi+8pBdj6NOnvrX8zQVWW3WjpDwrOLlussz/FJwj7xrAn8RV2Aj/KAgemF+eFy\n/GLQkAWFFyz7/4c4NZU=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 355,
+          "tcId" : 437,
           "comment" : "r and s^-1 are close to n",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024201fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138638a0242015555555555555555555555555555555555555555555555555555555555555555518baf05027f750ef25532ab85fa066e8ad2793125b112da747cf524bf0b7aed5b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
-        "uncompressed" : "0401aa9f3a894b727d7a01b09c4f051b469d661de1e06915b599e211463319ac1b7ca8a6097f1be401d70a71d0b53655cdf9bef748d886e08ee7de2fa781e93ec41a2601ba9ea67385e19894fc9cd4b0173ab215f7b96f23bc420665d46c75447bf200ae3ac7b42bd9b857fd1c85cce8ea9c8d2345e4687dd70df59f5149510735bb9c7b64",
-        "wx" : "1aa9f3a894b727d7a01b09c4f051b469d661de1e06915b599e211463319ac1b7ca8a6097f1be401d70a71d0b53655cdf9bef748d886e08ee7de2fa781e93ec41a26",
-        "wy" : "1ba9ea67385e19894fc9cd4b0173ab215f7b96f23bc420665d46c75447bf200ae3ac7b42bd9b857fd1c85cce8ea9c8d2345e4687dd70df59f5149510735bb9c7b64"
+        "uncompressed" : "04009b0ce9009af6a1acfa001901a4e94738d222ac7d140321cbcf029f9460f336dfd0655af02c3b98c421eee88648629e205c8a7b55fa41f51ec8cf855be632ba5ae0005304f9db29a81c82379f9e48d5ee47a469a450af8b737fbd93a6b9d813afef84ad3b92d5a5d06d96c90c05145d3fa8fcd335b2e17b1673534474cf9ed1c62ccd2f",
+        "wx" : "009b0ce9009af6a1acfa001901a4e94738d222ac7d140321cbcf029f9460f336dfd0655af02c3b98c421eee88648629e205c8a7b55fa41f51ec8cf855be632ba5ae0",
+        "wy" : "5304f9db29a81c82379f9e48d5ee47a469a450af8b737fbd93a6b9d813afef84ad3b92d5a5d06d96c90c05145d3fa8fcd335b2e17b1673534474cf9ed1c62ccd2f"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401aa9f3a894b727d7a01b09c4f051b469d661de1e06915b599e211463319ac1b7ca8a6097f1be401d70a71d0b53655cdf9bef748d886e08ee7de2fa781e93ec41a2601ba9ea67385e19894fc9cd4b0173ab215f7b96f23bc420665d46c75447bf200ae3ac7b42bd9b857fd1c85cce8ea9c8d2345e4687dd70df59f5149510735bb9c7b64",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBqp86iUtyfXoBsJxPBRtGnWYd4eBp\nFbWZ4hFGMxmsG3yopgl/G+QB1wpx0LU2Vc35vvdI2IbgjufeL6eB6T7EGiYBup6m\nc4XhmJT8nNSwFzqyFfe5byO8QgZl1Gx1RHvyAK46x7Qr2bhX/RyFzOjqnI0jReRo\nfdcN9Z9RSVEHNbuce2Q=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004009b0ce9009af6a1acfa001901a4e94738d222ac7d140321cbcf029f9460f336dfd0655af02c3b98c421eee88648629e205c8a7b55fa41f51ec8cf855be632ba5ae0005304f9db29a81c82379f9e48d5ee47a469a450af8b737fbd93a6b9d813afef84ad3b92d5a5d06d96c90c05145d3fa8fcd335b2e17b1673534474cf9ed1c62ccd2f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAmwzpAJr2oaz6ABkBpOlHONIirH0U\nAyHLzwKflGDzNt/QZVrwLDuYxCHu6IZIYp4gXIp7VfpB9R7Iz4Vb5jK6WuAAUwT5\n2ymoHII3n55I1e5HpGmkUK+Lc3+9k6a52BOv74StO5LVpdBtlskMBRRdP6j80zWy\n4XsWc1NEdM+e0cYszS8=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 356,
-          "comment" : "s == 1",
+          "tcId" : 438,
+          "comment" : "r and s are 64-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
-          "sig" : "3047024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad020101",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 357,
-          "comment" : "s == 0",
-          "msg" : "313233343030",
-          "sig" : "3047024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad020100",
-          "result" : "invalid",
-          "flags" : []
+          "sig" : "30160209009c44febf31c3594d020900839ed28247c2b06b",
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
+        "uncompressed" : "040056f677b935021e01f7ea71842c2b76479e807cd3fe2705b85ffb9e103788201282f4faf503502e85c695df022cf4ecafedb361751ada93f161c8e00a26f4bb988f007886ff30b81ffe355ecf0961f0e0deb775c1002758c6217e02d7b6c6eaee67a7d0f94c40c8607308eaaea840e4dfb57cd0539a4f2885d1475d43429b8cabda559d",
+        "wx" : "56f677b935021e01f7ea71842c2b76479e807cd3fe2705b85ffb9e103788201282f4faf503502e85c695df022cf4ecafedb361751ada93f161c8e00a26f4bb988f",
+        "wy" : "7886ff30b81ffe355ecf0961f0e0deb775c1002758c6217e02d7b6c6eaee67a7d0f94c40c8607308eaaea840e4dfb57cd0539a4f2885d1475d43429b8cabda559d"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040056f677b935021e01f7ea71842c2b76479e807cd3fe2705b85ffb9e103788201282f4faf503502e85c695df022cf4ecafedb361751ada93f161c8e00a26f4bb988f007886ff30b81ffe355ecf0961f0e0deb775c1002758c6217e02d7b6c6eaee67a7d0f94c40c8607308eaaea840e4dfb57cd0539a4f2885d1475d43429b8cabda559d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAVvZ3uTUCHgH36nGELCt2R56AfNP+\nJwW4X/ueEDeIIBKC9Pr1A1AuhcaV3wIs9Oyv7bNhdRrak/FhyOAKJvS7mI8AeIb/\nMLgf/jVezwlh8ODet3XBACdYxiF+Ate2xuruZ6fQ+UxAyGBzCOquqEDk37V80FOa\nTyiF0UddQ0KbjKvaVZ0=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 439,
+          "comment" : "r and s are 100-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "301e020d09df8b682430beef6f5fd7c7cf020d0fd0a62e13778f4222a0d61c8a",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "0400dea73c158a271a3474eea33025778112f45a8251be96ae8c01f832b7e4e241fd74249cbed4486183cd9f622f5436f8d7aa6967bf93ed9dd8e12831f82c1939cb5e011ed960d670a15c33e4b0e77a54383bc3d475bc48ca7686b8f0d2dbef972a840ca2b9d03073e3cae697710a98cf5adbf243c72382ac237693f11a713c2a5772327b",
+        "wx" : "00dea73c158a271a3474eea33025778112f45a8251be96ae8c01f832b7e4e241fd74249cbed4486183cd9f622f5436f8d7aa6967bf93ed9dd8e12831f82c1939cb5e",
+        "wy" : "011ed960d670a15c33e4b0e77a54383bc3d475bc48ca7686b8f0d2dbef972a840ca2b9d03073e3cae697710a98cf5adbf243c72382ac237693f11a713c2a5772327b"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400dea73c158a271a3474eea33025778112f45a8251be96ae8c01f832b7e4e241fd74249cbed4486183cd9f622f5436f8d7aa6967bf93ed9dd8e12831f82c1939cb5e011ed960d670a15c33e4b0e77a54383bc3d475bc48ca7686b8f0d2dbef972a840ca2b9d03073e3cae697710a98cf5adbf243c72382ac237693f11a713c2a5772327b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQA3qc8FYonGjR07qMwJXeBEvRaglG+\nlq6MAfgyt+TiQf10JJy+1Ehhg82fYi9UNvjXqmlnv5PtndjhKDH4LBk5y14BHtlg\n1nChXDPksOd6VDg7w9R1vEjKdoa48NLb75cqhAyiudAwc+PK5pdxCpjPWtvyQ8cj\ngqwjdpPxGnE8KldyMns=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 440,
+          "comment" : "r and s are 128-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "30260211008a598e563a89f526c32ebec8de26367a02110084f633e2042630e99dd0f1e16f7a04bf",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "0400011e78c7a24d477c1887ce80021d2db7c93b00b362d60e33926b2e872fda9619b4c5bb024d84412c959277445d21a6929041dcfb9467fa0dadb3a01a26a1a1ea9900802d13be68fa3360b1ea81f9319f2c861ebe336a3138e4f2e8ded1a3a8ba7d6c7064dcf84ca29e1e64125f375123737455eee95c9a5c2e4eb543124f58399c3813",
+        "wx" : "011e78c7a24d477c1887ce80021d2db7c93b00b362d60e33926b2e872fda9619b4c5bb024d84412c959277445d21a6929041dcfb9467fa0dadb3a01a26a1a1ea99",
+        "wy" : "00802d13be68fa3360b1ea81f9319f2c861ebe336a3138e4f2e8ded1a3a8ba7d6c7064dcf84ca29e1e64125f375123737455eee95c9a5c2e4eb543124f58399c3813"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400011e78c7a24d477c1887ce80021d2db7c93b00b362d60e33926b2e872fda9619b4c5bb024d84412c959277445d21a6929041dcfb9467fa0dadb3a01a26a1a1ea9900802d13be68fa3360b1ea81f9319f2c861ebe336a3138e4f2e8ded1a3a8ba7d6c7064dcf84ca29e1e64125f375123737455eee95c9a5c2e4eb543124f58399c3813",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAAR54x6JNR3wYh86AAh0tt8k7ALNi\n1g4zkmsuhy/alhm0xbsCTYRBLJWSd0RdIaaSkEHc+5Rn+g2ts6AaJqGh6pkAgC0T\nvmj6M2Cx6oH5MZ8shh6+M2oxOOTy6N7Ro6i6fWxwZNz4TKKeHmQSXzdRI3N0Ve7p\nXJpcLk61QxJPWDmcOBM=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 441,
+          "comment" : "r and s are 160-bit integer",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "302e021500aa6eeb5823f7fa31b466bb473797f0d0314c0bdf021500e2977c479e6d25703cebbc6bd561938cc9d1bfb9",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "0401aa9f3a894b727d7a01b09c4f051b469d661de1e06915b599e211463319ac1b7ca8a6097f1be401d70a71d0b53655cdf9bef748d886e08ee7de2fa781e93ec41a2601ba9ea67385e19894fc9cd4b0173ab215f7b96f23bc420665d46c75447bf200ae3ac7b42bd9b857fd1c85cce8ea9c8d2345e4687dd70df59f5149510735bb9c7b64",
+        "wx" : "01aa9f3a894b727d7a01b09c4f051b469d661de1e06915b599e211463319ac1b7ca8a6097f1be401d70a71d0b53655cdf9bef748d886e08ee7de2fa781e93ec41a26",
+        "wy" : "01ba9ea67385e19894fc9cd4b0173ab215f7b96f23bc420665d46c75447bf200ae3ac7b42bd9b857fd1c85cce8ea9c8d2345e4687dd70df59f5149510735bb9c7b64"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401aa9f3a894b727d7a01b09c4f051b469d661de1e06915b599e211463319ac1b7ca8a6097f1be401d70a71d0b53655cdf9bef748d886e08ee7de2fa781e93ec41a2601ba9ea67385e19894fc9cd4b0173ab215f7b96f23bc420665d46c75447bf200ae3ac7b42bd9b857fd1c85cce8ea9c8d2345e4687dd70df59f5149510735bb9c7b64",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBqp86iUtyfXoBsJxPBRtGnWYd4eBp\nFbWZ4hFGMxmsG3yopgl/G+QB1wpx0LU2Vc35vvdI2IbgjufeL6eB6T7EGiYBup6m\nc4XhmJT8nNSwFzqyFfe5byO8QgZl1Gx1RHvyAK46x7Qr2bhX/RyFzOjqnI0jReRo\nfdcN9Z9RSVEHNbuce2Q=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 442,
+          "comment" : "s == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad020101",
+          "result" : "valid"
+        },
+        {
+          "tcId" : 443,
+          "comment" : "s == 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "3047024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad020100",
+          "result" : "invalid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04003877bf6711c3c088da9b4a18e6e9f5d2d6611fa56d67b5664a142a744aebd31ab4b85672fce0eed8006fec114afcd1f6eeced0c9751ac62a684840f7e0ba2928a1004055ce08f42ce5aeeac80a2536e75dd936785e6e38691092b030cd2261f5ebd9d1529a8cb85657d95e30febd37a7f5e523fda7780d56e27570ecb626a2570661ba",
+        "wx" : "3877bf6711c3c088da9b4a18e6e9f5d2d6611fa56d67b5664a142a744aebd31ab4b85672fce0eed8006fec114afcd1f6eeced0c9751ac62a684840f7e0ba2928a1",
+        "wy" : "4055ce08f42ce5aeeac80a2536e75dd936785e6e38691092b030cd2261f5ebd9d1529a8cb85657d95e30febd37a7f5e523fda7780d56e27570ecb626a2570661ba"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004003877bf6711c3c088da9b4a18e6e9f5d2d6611fa56d67b5664a142a744aebd31ab4b85672fce0eed8006fec114afcd1f6eeced0c9751ac62a684840f7e0ba2928a1004055ce08f42ce5aeeac80a2536e75dd936785e6e38691092b030cd2261f5ebd9d1529a8cb85657d95e30febd37a7f5e523fda7780d56e27570ecb626a2570661ba",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAOHe/ZxHDwIjam0oY5un10tZhH6Vt\nZ7VmShQqdErr0xq0uFZy/ODu2ABv7BFK/NH27s7QyXUaxipoSED34LopKKEAQFXO\nCPQs5a7qyAolNudd2TZ4Xm44aRCSsDDNImH169nRUpqMuFZX2V4w/r03p/XlI/2n\neA1W4nVw7LYmolcGYbo=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 444,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad02413766c66283b12cbccb593f39d32c356cb4ab940931bedf5d8053458cd26d03b1e9ba364d2056a8c3c7fd8b8f47ab8277adee9bc701ffe1fabde72a01dc098f76db",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04013527482d58bebec6847877dcc18fa7e60c5fb2461b10a2907bb2bcba14ebdc4e708044387a80b194a03c6be62062f4a6cb8d2f33df3071d227ef1e875d8974ae4c012b5396dead33bc276ad1fe88709448aadde543d70b644acc5766de7e98ef91b766430e0a809a9ccd1ce859317d477ffedb7b10b788de8ca2cd9f0ab6b4a6db0e0e",
+        "wx" : "013527482d58bebec6847877dcc18fa7e60c5fb2461b10a2907bb2bcba14ebdc4e708044387a80b194a03c6be62062f4a6cb8d2f33df3071d227ef1e875d8974ae4c",
+        "wy" : "012b5396dead33bc276ad1fe88709448aadde543d70b644acc5766de7e98ef91b766430e0a809a9ccd1ce859317d477ffedb7b10b788de8ca2cd9f0ab6b4a6db0e0e"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004013527482d58bebec6847877dcc18fa7e60c5fb2461b10a2907bb2bcba14ebdc4e708044387a80b194a03c6be62062f4a6cb8d2f33df3071d227ef1e875d8974ae4c012b5396dead33bc276ad1fe88709448aadde543d70b644acc5766de7e98ef91b766430e0a809a9ccd1ce859317d477ffedb7b10b788de8ca2cd9f0ab6b4a6db0e0e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBNSdILVi+vsaEeHfcwY+n5gxfskYb\nEKKQe7K8uhTr3E5wgEQ4eoCxlKA8a+YgYvSmy40vM98wcdIn7x6HXYl0rkwBK1OW\n3q0zvCdq0f6IcJRIqt3lQ9cLZErMV2befpjvkbdmQw4KgJqczRzoWTF9R3/+23sQ\nt4jejKLNnwq2tKbbDg4=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 445,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad02411acee0a06a4b00e9da99cc1d47fcb1158787578728dc13cc74a95e51fe1ac074f88613bcd4d717c3206c2a73c76172416a94110b9141ad243ba87b51a042d45ee8",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04000f1a645168cb60d2de1a58ef3ec87d79dd60c3771cc6d5323e76caa7cb8f326aa38571c74c6c45830d3bcf00517680200e1af7afe0ea69e7a4930e51f67a9a30ff015141c86ff3e6cd8dcd3556974fe45dc0fcf6a9b6ef1e3635b0f444628ae8dd09d7ed7897701163a012ac37057f911673e8eb662431907859731850abaca59d82af",
+        "wx" : "0f1a645168cb60d2de1a58ef3ec87d79dd60c3771cc6d5323e76caa7cb8f326aa38571c74c6c45830d3bcf00517680200e1af7afe0ea69e7a4930e51f67a9a30ff",
+        "wy" : "015141c86ff3e6cd8dcd3556974fe45dc0fcf6a9b6ef1e3635b0f444628ae8dd09d7ed7897701163a012ac37057f911673e8eb662431907859731850abaca59d82af"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004000f1a645168cb60d2de1a58ef3ec87d79dd60c3771cc6d5323e76caa7cb8f326aa38571c74c6c45830d3bcf00517680200e1af7afe0ea69e7a4930e51f67a9a30ff015141c86ff3e6cd8dcd3556974fe45dc0fcf6a9b6ef1e3635b0f444628ae8dd09d7ed7897701163a012ac37057f911673e8eb662431907859731850abaca59d82af",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQADxpkUWjLYNLeGljvPsh9ed1gw3cc\nxtUyPnbKp8uPMmqjhXHHTGxFgw07zwBRdoAgDhr3r+Dqaeekkw5R9nqaMP8BUUHI\nb/PmzY3NNVaXT+RdwPz2qbbvHjY1sPREYoro3QnX7XiXcBFjoBKsNwV/kRZz6Otm\nJDGQeFlzGFCrrKWdgq8=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 446,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad02410ce1ddfffbb3185109966b647419ce8b553a6d70d6c73013af778f7b211aadeac70511ae766f0b74961a1019ffa18b3d42056fd9ed4d5fd982be75291f2532bb02",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "0400a2a67b569a113f13754483464a249b28f588cd71b87bb70373d8c6661cc862a3ed4293aca92386742248783492d524a429f404fceb3dc88711a79040b48b80a1730171075214d4547e37f94f674747a995046a8b8a6d7b307ebad9adcb03eba7f63daf925f02c7220da107eef3e4f19e668fea2718aa5c9d2deba1347a8128bdac670f",
+        "wx" : "00a2a67b569a113f13754483464a249b28f588cd71b87bb70373d8c6661cc862a3ed4293aca92386742248783492d524a429f404fceb3dc88711a79040b48b80a173",
+        "wy" : "0171075214d4547e37f94f674747a995046a8b8a6d7b307ebad9adcb03eba7f63daf925f02c7220da107eef3e4f19e668fea2718aa5c9d2deba1347a8128bdac670f"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400a2a67b569a113f13754483464a249b28f588cd71b87bb70373d8c6661cc862a3ed4293aca92386742248783492d524a429f404fceb3dc88711a79040b48b80a1730171075214d4547e37f94f674747a995046a8b8a6d7b307ebad9adcb03eba7f63daf925f02c7220da107eef3e4f19e668fea2718aa5c9d2deba1347a8128bdac670f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAoqZ7VpoRPxN1RINGSiSbKPWIzXG4\ne7cDc9jGZhzIYqPtQpOsqSOGdCJIeDSS1SSkKfQE/Os9yIcRp5BAtIuAoXMBcQdS\nFNRUfjf5T2dHR6mVBGqLim17MH662a3LA+un9j2vkl8CxyINoQfu8+TxnmaP6icY\nqlydLeuhNHqBKL2sZw8=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 447,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad024200ded82c833933ca141a3eb8fd1889f2fca4679437d28e9f867afeb37ecaccbb555dbc61ef83b3f7d57c6b4ac8ea27971716e6a1a0534d7f7ea1fb7197d1c4a0d5cb",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "0400a2ee867f515fe3a4cc539711d9539e0db9e85a49c9a6cd65634a4eb0824da585a353e25e04a3d7bade0a676622c078f7422f38cfb1e9d5b2bf031a63d2d037b4d201fd9cc1f25c07963d3b246c016a3e4f260a9b5894f5fd9261beae302ee64250385dcafedddf9871072f8d94c9a654ea364bc6c15115ac38ad3694303f2cba014f59",
+        "wx" : "00a2ee867f515fe3a4cc539711d9539e0db9e85a49c9a6cd65634a4eb0824da585a353e25e04a3d7bade0a676622c078f7422f38cfb1e9d5b2bf031a63d2d037b4d2",
+        "wy" : "01fd9cc1f25c07963d3b246c016a3e4f260a9b5894f5fd9261beae302ee64250385dcafedddf9871072f8d94c9a654ea364bc6c15115ac38ad3694303f2cba014f59"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400a2ee867f515fe3a4cc539711d9539e0db9e85a49c9a6cd65634a4eb0824da585a353e25e04a3d7bade0a676622c078f7422f38cfb1e9d5b2bf031a63d2d037b4d201fd9cc1f25c07963d3b246c016a3e4f260a9b5894f5fd9261beae302ee64250385dcafedddf9871072f8d94c9a654ea364bc6c15115ac38ad3694303f2cba014f59",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAou6Gf1Ff46TMU5cR2VOeDbnoWknJ\nps1lY0pOsIJNpYWjU+JeBKPXut4KZ2YiwHj3Qi84z7Hp1bK/Axpj0tA3tNIB/ZzB\n8lwHlj07JGwBaj5PJgqbWJT1/ZJhvq4wLuZCUDhdyv7d35hxBy+NlMmmVOo2S8bB\nURWsOK02lDA/LLoBT1k=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 448,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad024172ceb39ea97d82d3aebd01ee53d32fc02bca5887fc0a5fe373b7a0d3085249684731fd8157b3743d40caa8a7908699bc223d0df57ca11f6225f732119431b86b9a",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04008a0a0f504a308b80289ad4b9e8b741525bfdeab4732286b291c9e3228ae8ab60c1381462f5569f65cd770f5e9b395229445ea5e23622e9abbc6de460db98703dbb002290f4d20ba24e3d9279dc0f3e5a5e104d6b5d44731dc5180fc04afebb8a805c752afd022cbb8952f3cff2795f778298713ba1b76e6b78e5c0ffac44ca8b3c769f",
+        "wx" : "008a0a0f504a308b80289ad4b9e8b741525bfdeab4732286b291c9e3228ae8ab60c1381462f5569f65cd770f5e9b395229445ea5e23622e9abbc6de460db98703dbb",
+        "wy" : "2290f4d20ba24e3d9279dc0f3e5a5e104d6b5d44731dc5180fc04afebb8a805c752afd022cbb8952f3cff2795f778298713ba1b76e6b78e5c0ffac44ca8b3c769f"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004008a0a0f504a308b80289ad4b9e8b741525bfdeab4732286b291c9e3228ae8ab60c1381462f5569f65cd770f5e9b395229445ea5e23622e9abbc6de460db98703dbb002290f4d20ba24e3d9279dc0f3e5a5e104d6b5d44731dc5180fc04afebb8a805c752afd022cbb8952f3cff2795f778298713ba1b76e6b78e5c0ffac44ca8b3c769f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAigoPUEowi4AomtS56LdBUlv96rRz\nIoaykcnjIoroq2DBOBRi9VafZc13D16bOVIpRF6l4jYi6au8beRg25hwPbsAIpD0\n0guiTj2SedwPPlpeEE1rXURzHcUYD8BK/ruKgFx1Kv0CLLuJUvPP8nlfd4KYcTuh\nt25reOXA/6xEyos8dp8=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 449,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad02411834d4897e360d3622607611d64c4338039f8f7db00891bf5930711b2cf7d47be557b283d20aa85d9c5d2e472fdc59a35ff4ac0985bb06fa284838026cf0ba8571",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04008903f9a991de771e52ed5e5936626a5510f0b412a5b76156950ac545192105e03bae9bee413b5dafa9f7460934fba63470c992a63817db1dc9d853a6794c12264d011f50d0e1b644e47e02863a28233ca5528bbb56b97f25d87f2e1c9edd3c7e8b5f60b600d0e6fa901ba76b2fa4c66f5b03c9e96b774940a09e01ae17cb2885173e71",
+        "wx" : "008903f9a991de771e52ed5e5936626a5510f0b412a5b76156950ac545192105e03bae9bee413b5dafa9f7460934fba63470c992a63817db1dc9d853a6794c12264d",
+        "wy" : "011f50d0e1b644e47e02863a28233ca5528bbb56b97f25d87f2e1c9edd3c7e8b5f60b600d0e6fa901ba76b2fa4c66f5b03c9e96b774940a09e01ae17cb2885173e71"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004008903f9a991de771e52ed5e5936626a5510f0b412a5b76156950ac545192105e03bae9bee413b5dafa9f7460934fba63470c992a63817db1dc9d853a6794c12264d011f50d0e1b644e47e02863a28233ca5528bbb56b97f25d87f2e1c9edd3c7e8b5f60b600d0e6fa901ba76b2fa4c66f5b03c9e96b774940a09e01ae17cb2885173e71",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAiQP5qZHedx5S7V5ZNmJqVRDwtBKl\nt2FWlQrFRRkhBeA7rpvuQTtdr6n3Rgk0+6Y0cMmSpjgX2x3J2FOmeUwSJk0BH1DQ\n4bZE5H4ChjooIzylUou7Vrl/Jdh/Lhye3Tx+i19gtgDQ5vqQG6drL6TGb1sDyelr\nd0lAoJ4BrhfLKIUXPnE=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 450,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad024200a9c260ead3d423c0e8bd225f41ffaea6ace17b1e157b98ccf912c90865a4bb74169ff49b4b0d62e0772905ca62b0bdbda232955a3952cf3b83f50bc5f6ae33ee4f",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04010ec0b19ae35ee4eac34047eb1f13cc442c31457d28e025e3f75308916ebd7b8c0592481c39825e6988833f8e953ac47da830e8f49c0980963daa93c2d753df865f00bb702a4aa002162a1c7a7142404c159f7243a1ac809b59d6e420080f358861ce0d8af52d3d376f27ab7d778da4c74b1f8641bdccaa0f44e33695e022e9e5bb9641",
+        "wx" : "010ec0b19ae35ee4eac34047eb1f13cc442c31457d28e025e3f75308916ebd7b8c0592481c39825e6988833f8e953ac47da830e8f49c0980963daa93c2d753df865f",
+        "wy" : "00bb702a4aa002162a1c7a7142404c159f7243a1ac809b59d6e420080f358861ce0d8af52d3d376f27ab7d778da4c74b1f8641bdccaa0f44e33695e022e9e5bb9641"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004010ec0b19ae35ee4eac34047eb1f13cc442c31457d28e025e3f75308916ebd7b8c0592481c39825e6988833f8e953ac47da830e8f49c0980963daa93c2d753df865f00bb702a4aa002162a1c7a7142404c159f7243a1ac809b59d6e420080f358861ce0d8af52d3d376f27ab7d778da4c74b1f8641bdccaa0f44e33695e022e9e5bb9641",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBDsCxmuNe5OrDQEfrHxPMRCwxRX0o\n4CXj91MIkW69e4wFkkgcOYJeaYiDP46VOsR9qDDo9JwJgJY9qpPC11Pfhl8Au3Aq\nSqACFiocenFCQEwVn3JDoayAm1nW5CAIDzWIYc4NivUtPTdvJ6t9d42kx0sfhkG9\nzKoPROM2leAi6eW7lkE=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 451,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad02412e67568c48766d91884b0ecdebb8d9a39a359d77bc97063c625d6d3f1dcaae81cdfb198f4655d9853273bcfb60477cd0a1e435fc8bb93f8d05a20fb977e50cc434",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "0400d3f0cf50e9a4a6f1bc5468754c74bb6e7a7198c010ff73d37d36533c2ac55e46e736def95eed3c51a7ef357c14ef1ab7f4a3caccdc38d5368b9664bf952583e6c00160c26745748b22e5cb748348e5dd522099bb4b31d047d451fa492a2ae7c8adf349d4e5ef0738093f5099a6a334722c87cbc65fe5318d97ae0fc30459aff21cd306",
+        "wx" : "00d3f0cf50e9a4a6f1bc5468754c74bb6e7a7198c010ff73d37d36533c2ac55e46e736def95eed3c51a7ef357c14ef1ab7f4a3caccdc38d5368b9664bf952583e6c0",
+        "wy" : "0160c26745748b22e5cb748348e5dd522099bb4b31d047d451fa492a2ae7c8adf349d4e5ef0738093f5099a6a334722c87cbc65fe5318d97ae0fc30459aff21cd306"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400d3f0cf50e9a4a6f1bc5468754c74bb6e7a7198c010ff73d37d36533c2ac55e46e736def95eed3c51a7ef357c14ef1ab7f4a3caccdc38d5368b9664bf952583e6c00160c26745748b22e5cb748348e5dd522099bb4b31d047d451fa492a2ae7c8adf349d4e5ef0738093f5099a6a334722c87cbc65fe5318d97ae0fc30459aff21cd306",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQA0/DPUOmkpvG8VGh1THS7bnpxmMAQ\n/3PTfTZTPCrFXkbnNt75Xu08UafvNXwU7xq39KPKzNw41TaLlmS/lSWD5sABYMJn\nRXSLIuXLdINI5d1SIJm7SzHQR9RR+kkqKufIrfNJ1OXvBzgJP1CZpqM0ciyHy8Zf\n5TGNl64PwwRZr/Ic0wY=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 452,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad024139e6ac133eb88e5b5748ef6806e750175b100ac40e3efaa891ef7ef078c9d3f2cbfe6398dc776f72cd2f904f2067c63df677f3d8162cce1de557a5aa4db6561abe",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "0400f1dbdff93371aefcdb1ce696e46be28cfce9dca1b1ce220930612c0d9f64b32405a5abdde91bd19effa929e62791a3c9feaf73d6d707cbe25bff9aa1e0a438d52d00b789a0920d47787e795895ad9fd4c6752d521ce33fd19248e415c19c54cce95d54bffc3e55165104bdc9b0810f67ae1666b3e6ef5286ae897afdba2be4342d7e3f",
+        "wx" : "00f1dbdff93371aefcdb1ce696e46be28cfce9dca1b1ce220930612c0d9f64b32405a5abdde91bd19effa929e62791a3c9feaf73d6d707cbe25bff9aa1e0a438d52d",
+        "wy" : "00b789a0920d47787e795895ad9fd4c6752d521ce33fd19248e415c19c54cce95d54bffc3e55165104bdc9b0810f67ae1666b3e6ef5286ae897afdba2be4342d7e3f"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400f1dbdff93371aefcdb1ce696e46be28cfce9dca1b1ce220930612c0d9f64b32405a5abdde91bd19effa929e62791a3c9feaf73d6d707cbe25bff9aa1e0a438d52d00b789a0920d47787e795895ad9fd4c6752d521ce33fd19248e415c19c54cce95d54bffc3e55165104bdc9b0810f67ae1666b3e6ef5286ae897afdba2be4342d7e3f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQA8dvf+TNxrvzbHOaW5GvijPzp3KGx\nziIJMGEsDZ9ksyQFpavd6RvRnv+pKeYnkaPJ/q9z1tcHy+Jb/5qh4KQ41S0At4mg\nkg1HeH55WJWtn9TGdS1SHOM/0ZJI5BXBnFTM6V1Uv/w+VRZRBL3JsIEPZ64WZrPm\n71KGrol6/bor5DQtfj8=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 453,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad02416531ae6458fa556c74ce671a556e703038afd8f769c398d080be8fe434accae8dd35e8a28545297310992dfc74efdbcfc3335e0b9f9bbf970cf4361213eade27ed",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04005c9bc016ef6611449a430392918c530d8308d4e628275a5d2e140bc82e3e02a36d03031fbbc62e0109f107564df27c5c47e868bbf92edb3a3d1080aa0b6997a13b00159b04a43519ef8148d3832f76ae3d0d6bd5828759b8a64f0f365053c15473d61df1634e80f4e0023cfa97d71882289d9d86a32ae5380d21289d453599490b142b",
+        "wx" : "5c9bc016ef6611449a430392918c530d8308d4e628275a5d2e140bc82e3e02a36d03031fbbc62e0109f107564df27c5c47e868bbf92edb3a3d1080aa0b6997a13b",
+        "wy" : "159b04a43519ef8148d3832f76ae3d0d6bd5828759b8a64f0f365053c15473d61df1634e80f4e0023cfa97d71882289d9d86a32ae5380d21289d453599490b142b"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004005c9bc016ef6611449a430392918c530d8308d4e628275a5d2e140bc82e3e02a36d03031fbbc62e0109f107564df27c5c47e868bbf92edb3a3d1080aa0b6997a13b00159b04a43519ef8148d3832f76ae3d0d6bd5828759b8a64f0f365053c15473d61df1634e80f4e0023cfa97d71882289d9d86a32ae5380d21289d453599490b142b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAXJvAFu9mEUSaQwOSkYxTDYMI1OYo\nJ1pdLhQLyC4+AqNtAwMfu8YuAQnxB1ZN8nxcR+hou/ku2zo9EICqC2mXoTsAFZsE\npDUZ74FI04Mvdq49DWvVgodZuKZPDzZQU8FUc9Yd8WNOgPTgAjz6l9cYgiidnYaj\nKuU4DSEonUU1mUkLFCs=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 454,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad02417321260c7e56e586f4a7b9b47a18613f833097c0cdebc6fe488ae05d1c1f37a3a98f2e1af140e7fb1d2318c50b3b984bc4066bfa55fd98db18ac649ee7e47cdec6",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04019dabc758b8c0f680fd1c9757ae0e54a9bac35fe0d3666a4a5838cf551f78cf152e5a98d1f36bf533c15b478d292d084e42137b5c32b9cb1220745df41fde5da0a3004f3da3ae65b24eb8f61e934a35b3726ba4d71cd2b2c0692f58c24f96ea75193dea76bf88574c0c70a1ce6eb490aa69a9d5bbd299f53dd1e25ef7f2bef8779c3a52",
+        "wx" : "019dabc758b8c0f680fd1c9757ae0e54a9bac35fe0d3666a4a5838cf551f78cf152e5a98d1f36bf533c15b478d292d084e42137b5c32b9cb1220745df41fde5da0a3",
+        "wy" : "4f3da3ae65b24eb8f61e934a35b3726ba4d71cd2b2c0692f58c24f96ea75193dea76bf88574c0c70a1ce6eb490aa69a9d5bbd299f53dd1e25ef7f2bef8779c3a52"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004019dabc758b8c0f680fd1c9757ae0e54a9bac35fe0d3666a4a5838cf551f78cf152e5a98d1f36bf533c15b478d292d084e42137b5c32b9cb1220745df41fde5da0a3004f3da3ae65b24eb8f61e934a35b3726ba4d71cd2b2c0692f58c24f96ea75193dea76bf88574c0c70a1ce6eb490aa69a9d5bbd299f53dd1e25ef7f2bef8779c3a52",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBnavHWLjA9oD9HJdXrg5UqbrDX+DT\nZmpKWDjPVR94zxUuWpjR82v1M8FbR40pLQhOQhN7XDK5yxIgdF30H95doKMATz2j\nrmWyTrj2HpNKNbNya6TXHNKywGkvWMJPlup1GT3qdr+IV0wMcKHObrSQqmmp1bvS\nmfU90eJe9/K++HecOlI=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 455,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad02414f27499640288c52f93a87795bd7a0b83c95dbf69a5a3b6ef62f1308f2b9a817536173b45e687646255958f0cd08e0c469e66495d4e040217af2fbbd1311d21711",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "040035016d85e577a5bdafaaf2880d2d28daeebd64607c5246741fd952f78fc05a4c290fc689a78f09c0fd36fa3521bb1fa67445b559cffb0e59d65f5830222ad40ed100200cc3f2c981daea884444669a6036a1caa85a3bf7420beee18c65a33c11f32d31cd9e356f712af3800ffeee331e741d319daab97d9280b173a6869b94740d8d36",
+        "wx" : "35016d85e577a5bdafaaf2880d2d28daeebd64607c5246741fd952f78fc05a4c290fc689a78f09c0fd36fa3521bb1fa67445b559cffb0e59d65f5830222ad40ed1",
+        "wy" : "200cc3f2c981daea884444669a6036a1caa85a3bf7420beee18c65a33c11f32d31cd9e356f712af3800ffeee331e741d319daab97d9280b173a6869b94740d8d36"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040035016d85e577a5bdafaaf2880d2d28daeebd64607c5246741fd952f78fc05a4c290fc689a78f09c0fd36fa3521bb1fa67445b559cffb0e59d65f5830222ad40ed100200cc3f2c981daea884444669a6036a1caa85a3bf7420beee18c65a33c11f32d31cd9e356f712af3800ffeee331e741d319daab97d9280b173a6869b94740d8d36",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQANQFtheV3pb2vqvKIDS0o2u69ZGB8\nUkZ0H9lS94/AWkwpD8aJp48JwP02+jUhux+mdEW1Wc/7DlnWX1gwIirUDtEAIAzD\n8smB2uqIRERmmmA2ocqoWjv3Qgvu4YxlozwR8y0xzZ41b3Eq84AP/u4zHnQdMZ2q\nuX2SgLFzpoablHQNjTY=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 456,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad024140484262d596a23936806ef21ba6192c72023a535089ee524e2a32f61c7497e58b4dec0ae58178f7b6dd3587fa3124a4ccccb49de353541f610f7d3c97b63db11a",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04007d2b510d12496dd5cbb1a14b74f8b671c7ad6180d2154dc0a0334178b054105418639965c70251c28b831ebceae05d8da4239b80ec91f807a301800b709cae6ea80145d7f61e14b464e6014ac14c9ab71754e5ff41b569ec9e469368010ef7fb7aaa20c859f9c138a79969c46f0c20c7ea205585bb513d79fd5ae6017797d930f74c97",
+        "wx" : "7d2b510d12496dd5cbb1a14b74f8b671c7ad6180d2154dc0a0334178b054105418639965c70251c28b831ebceae05d8da4239b80ec91f807a301800b709cae6ea8",
+        "wy" : "0145d7f61e14b464e6014ac14c9ab71754e5ff41b569ec9e469368010ef7fb7aaa20c859f9c138a79969c46f0c20c7ea205585bb513d79fd5ae6017797d930f74c97"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004007d2b510d12496dd5cbb1a14b74f8b671c7ad6180d2154dc0a0334178b054105418639965c70251c28b831ebceae05d8da4239b80ec91f807a301800b709cae6ea80145d7f61e14b464e6014ac14c9ab71754e5ff41b569ec9e469368010ef7fb7aaa20c859f9c138a79969c46f0c20c7ea205585bb513d79fd5ae6017797d930f74c97",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAfStRDRJJbdXLsaFLdPi2ccetYYDS\nFU3AoDNBeLBUEFQYY5llxwJRwouDHrzq4F2NpCObgOyR+AejAYALcJyubqgBRdf2\nHhS0ZOYBSsFMmrcXVOX/QbVp7J5Gk2gBDvf7eqogyFn5wTinmWnEbwwgx+ogVYW7\nUT15/VrmAXeX2TD3TJc=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 457,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad02417fa623ad71573766571b8fd4ae0a5ce82b3805ae151a18515ef607f2228a95bafdbd24acde135cae5f3f899caf0c5efd1a4de2c53878dccc09f2b7a263c2844e3d",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "0400a41ad2be45772bdce5f3872f654e9320026726d3642fd8edc560363fef9ea1c12d1a5067ef236fbf4e22772e2066a818ed0de0976721ddd18446283506b8ea6e1e01a65ff3118f6c27595a01b387c6486a24ff38d59a757cb0a06cb0a8b8e1fd5adc2d1c6a3d4047ec2fc3f8d4e61f23a10c1bc87280692073cbb6d4774722e658f815",
+        "wx" : "00a41ad2be45772bdce5f3872f654e9320026726d3642fd8edc560363fef9ea1c12d1a5067ef236fbf4e22772e2066a818ed0de0976721ddd18446283506b8ea6e1e",
+        "wy" : "01a65ff3118f6c27595a01b387c6486a24ff38d59a757cb0a06cb0a8b8e1fd5adc2d1c6a3d4047ec2fc3f8d4e61f23a10c1bc87280692073cbb6d4774722e658f815"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400a41ad2be45772bdce5f3872f654e9320026726d3642fd8edc560363fef9ea1c12d1a5067ef236fbf4e22772e2066a818ed0de0976721ddd18446283506b8ea6e1e01a65ff3118f6c27595a01b387c6486a24ff38d59a757cb0a06cb0a8b8e1fd5adc2d1c6a3d4047ec2fc3f8d4e61f23a10c1bc87280692073cbb6d4774722e658f815",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQApBrSvkV3K9zl84cvZU6TIAJnJtNk\nL9jtxWA2P++eocEtGlBn7yNvv04idy4gZqgY7Q3gl2ch3dGERig1Brjqbh4Bpl/z\nEY9sJ1laAbOHxkhqJP841Zp1fLCgbLCouOH9WtwtHGo9QEfsL8P41OYfI6EMG8hy\ngGkgc8u21HdHIuZY+BU=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 458,
+          "comment" : "edge case modular inverse",
+          "flags" : [
+            "ModularInverse",
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308187024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad024154e096bc1b2ee6f5fa7d65ce54077cd07a379a7d1bcbf85651852fcc62037ac50c6e64b8c6c2cf8814653af7b87d2752e6f3af0a3ef75ec7415a58cdf2990ce4c0",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
         "uncompressed" : "04002a07f13f3e8df382145b7942fe6f91c12ff3064b314b4e3476bf3afbb982070f17f63b2de5fbe8c91a87ae632869facf17d5ce9d139b37ed557581bb9a7e4b8fa30024b904c5fc536ae53b323a7fd0b7b8e420302406ade84ea8a10ca7c5c934bad5489db6e3a8cc3064602cc83f309e9d247aae72afca08336bc8919e15f4be5ad77a",
         "wx" : "2a07f13f3e8df382145b7942fe6f91c12ff3064b314b4e3476bf3afbb982070f17f63b2de5fbe8c91a87ae632869facf17d5ce9d139b37ed557581bb9a7e4b8fa3",
         "wy" : "24b904c5fc536ae53b323a7fd0b7b8e420302406ade84ea8a10ca7c5c934bad5489db6e3a8cc3064602cc83f309e9d247aae72afca08336bc8919e15f4be5ad77a"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004002a07f13f3e8df382145b7942fe6f91c12ff3064b314b4e3476bf3afbb982070f17f63b2de5fbe8c91a87ae632869facf17d5ce9d139b37ed557581bb9a7e4b8fa30024b904c5fc536ae53b323a7fd0b7b8e420302406ade84ea8a10ca7c5c934bad5489db6e3a8cc3064602cc83f309e9d247aae72afca08336bc8919e15f4be5ad77a",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAKgfxPz6N84IUW3lC/m+RwS/zBksx\nS040dr86+7mCBw8X9jst5fvoyRqHrmMoafrPF9XOnRObN+1VdYG7mn5Lj6MAJLkE\nxfxTauU7Mjp/0Le45CAwJAat6E6ooQynxck0utVInbbjqMwwZGAsyD8wnp0keq5y\nr8oIM2vIkZ4V9L5a13o=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004002a07f13f3e8df382145b7942fe6f91c12ff3064b314b4e3476bf3afbb982070f17f63b2de5fbe8c91a87ae632869facf17d5ce9d139b37ed557581bb9a7e4b8fa30024b904c5fc536ae53b323a7fd0b7b8e420302406ade84ea8a10ca7c5c934bad5489db6e3a8cc3064602cc83f309e9d247aae72afca08336bc8919e15f4be5ad77a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAKgfxPz6N84IUW3lC/m+RwS/zBksx\nS040dr86+7mCBw8X9jst5fvoyRqHrmMoafrPF9XOnRObN+1VdYG7mn5Lj6MAJLkE\nxfxTauU7Mjp/0Le45CAwJAat6E6ooQynxck0utVInbbjqMwwZGAsyD8wnp0keq5y\nr8oIM2vIkZ4V9L5a13o=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 358,
+          "tcId" : 459,
           "comment" : "point at infinity during verify",
+          "flags" : [
+            "PointDuplication",
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd28c343c1df97cb35bfe600a47b84d2e81ddae4dc44ce23d75db7db8f489c3204024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
+        "uncompressed" : "04004bb904073cb6da9e5028df54fc22cf5a9d5ca73a01feedd2b4ce43b87bfd4300a72bdf26b146b2e7b506c03c7a0ad4a7e3e67204dddca9b65d43560ffaf9bfd540012b8895632e0406b78463fe1bc5360a3cf796fddda9db2b18ca9171558e6158fa4b0b1d0461d9a46b9b958d629bd62a29ee3942238e0fa83e932a66abb1b50c5f37",
+        "wx" : "4bb904073cb6da9e5028df54fc22cf5a9d5ca73a01feedd2b4ce43b87bfd4300a72bdf26b146b2e7b506c03c7a0ad4a7e3e67204dddca9b65d43560ffaf9bfd540",
+        "wy" : "012b8895632e0406b78463fe1bc5360a3cf796fddda9db2b18ca9171558e6158fa4b0b1d0461d9a46b9b958d629bd62a29ee3942238e0fa83e932a66abb1b50c5f37"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004004bb904073cb6da9e5028df54fc22cf5a9d5ca73a01feedd2b4ce43b87bfd4300a72bdf26b146b2e7b506c03c7a0ad4a7e3e67204dddca9b65d43560ffaf9bfd540012b8895632e0406b78463fe1bc5360a3cf796fddda9db2b18ca9171558e6158fa4b0b1d0461d9a46b9b958d629bd62a29ee3942238e0fa83e932a66abb1b50c5f37",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAS7kEBzy22p5QKN9U/CLPWp1cpzoB\n/u3StM5DuHv9QwCnK98msUay57UGwDx6CtSn4+ZyBN3cqbZdQ1YP+vm/1UABK4iV\nYy4EBreEY/4bxTYKPPeW/d2p2ysYypFxVY5hWPpLCx0EYdmka5uVjWKb1iop7jlC\nI44PqD6TKmarsbUMXzc=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 460,
+          "comment" : "edge case for signature malleability",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd28c343c1df97cb35bfe600a47b84d2e81ddae4dc44ce23d75db7db8f489c3206024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd28c343c1df97cb35bfe600a47b84d2e81ddae4dc44ce23d75db7db8f489c3204",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
+        "uncompressed" : "04016454afca385eb53eaeaab711537d95c50e01268b100a22656adf5cedf68b4a78a6c14a70245df707f6565ce15948c2e38e3d90e05dda3188ab43a73f30dbc6bda80151dca6dc5aec84fa35c79f21365993f0b267ca486ea66c2186a52a3fb62b53501ce2822d4691fbc25cf27adb70734071be523b9231dd8d33a401dea00cf0ae30a1",
+        "wx" : "016454afca385eb53eaeaab711537d95c50e01268b100a22656adf5cedf68b4a78a6c14a70245df707f6565ce15948c2e38e3d90e05dda3188ab43a73f30dbc6bda8",
+        "wy" : "0151dca6dc5aec84fa35c79f21365993f0b267ca486ea66c2186a52a3fb62b53501ce2822d4691fbc25cf27adb70734071be523b9231dd8d33a401dea00cf0ae30a1"
+      },
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004016454afca385eb53eaeaab711537d95c50e01268b100a22656adf5cedf68b4a78a6c14a70245df707f6565ce15948c2e38e3d90e05dda3188ab43a73f30dbc6bda80151dca6dc5aec84fa35c79f21365993f0b267ca486ea66c2186a52a3fb62b53501ce2822d4691fbc25cf27adb70734071be523b9231dd8d33a401dea00cf0ae30a1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBZFSvyjhetT6uqrcRU32VxQ4BJosQ\nCiJlat9c7faLSnimwUpwJF33B/ZWXOFZSMLjjj2Q4F3aMYirQ6c/MNvGvagBUdym\n3FrshPo1x58hNlmT8LJnykhupmwhhqUqP7YrU1Ac4oItRpH7wlzyettwc0BxvlI7\nkjHdjTOkAd6gDPCuMKE=\n-----END PUBLIC KEY-----\n",
+      "sha" : "SHA-512",
+      "tests" : [
+        {
+          "tcId" : 461,
+          "comment" : "edge case for signature malleability",
+          "flags" : [
+            "ArithmeticError"
+          ],
+          "msg" : "313233343030",
+          "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd28c343c1df97cb35bfe600a47b84d2e81ddae4dc44ce23d75db7db8f489c3206024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffd28c343c1df97cb35bfe600a47b84d2e81ddae4dc44ce23d75db7db8f489c3205",
+          "result" : "valid"
+        }
+      ]
+    },
+    {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
+        "curve" : "secp521r1",
+        "keySize" : 521,
         "uncompressed" : "040060daf59638158ed9d3d7e8428501334764162f9be239e168fae9af348c30a7be1cfa4d9636c3bb621d7e0aa71446f8d4a37f2d43274a4255b226f612382f63152e016e48300124a636b206fad4d0355862a852623799afee941e864d96dcbf55b801cabd6249b6f567506d5a503e7d03b4764c70fc44c5365f32c3603678476d62b09d",
         "wx" : "60daf59638158ed9d3d7e8428501334764162f9be239e168fae9af348c30a7be1cfa4d9636c3bb621d7e0aa71446f8d4a37f2d43274a4255b226f612382f63152e",
-        "wy" : "16e48300124a636b206fad4d0355862a852623799afee941e864d96dcbf55b801cabd6249b6f567506d5a503e7d03b4764c70fc44c5365f32c3603678476d62b09d"
+        "wy" : "016e48300124a636b206fad4d0355862a852623799afee941e864d96dcbf55b801cabd6249b6f567506d5a503e7d03b4764c70fc44c5365f32c3603678476d62b09d"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040060daf59638158ed9d3d7e8428501334764162f9be239e168fae9af348c30a7be1cfa4d9636c3bb621d7e0aa71446f8d4a37f2d43274a4255b226f612382f63152e016e48300124a636b206fad4d0355862a852623799afee941e864d96dcbf55b801cabd6249b6f567506d5a503e7d03b4764c70fc44c5365f32c3603678476d62b09d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAYNr1ljgVjtnT1+hChQEzR2QWL5vi\nOeFo+umvNIwwp74c+k2WNsO7Yh1+CqcURvjUo38tQydKQlWyJvYSOC9jFS4Bbkgw\nASSmNrIG+tTQNVhiqFJiN5mv7pQehk2W3L9VuAHKvWJJtvVnUG1aUD59A7R2THD8\nRMU2XzLDYDZ4R21isJ0=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040060daf59638158ed9d3d7e8428501334764162f9be239e168fae9af348c30a7be1cfa4d9636c3bb621d7e0aa71446f8d4a37f2d43274a4255b226f612382f63152e016e48300124a636b206fad4d0355862a852623799afee941e864d96dcbf55b801cabd6249b6f567506d5a503e7d03b4764c70fc44c5365f32c3603678476d62b09d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAYNr1ljgVjtnT1+hChQEzR2QWL5vi\nOeFo+umvNIwwp74c+k2WNsO7Yh1+CqcURvjUo38tQydKQlWyJvYSOC9jFS4Bbkgw\nASSmNrIG+tTQNVhiqFJiN5mv7pQehk2W3L9VuAHKvWJJtvVnUG1aUD59A7R2THD8\nRMU2XzLDYDZ4R21isJ0=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 359,
+          "tcId" : 462,
           "comment" : "u1 == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308186024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad024043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b023210281757b30e19218a37cbd612086fbc158caa8b4e1acb2ec00837e5d941f342fb3cc",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040051fe6a35a85070c7c29502a87672a38153d799aef734226b64d8fd3398621701117f0af9d9afaf6dbb8ca3007255dc79b0f41ed552512cb29207b15a01cdfdfaae01a16c61277586356efadcb24764f21f574ef96f2caabc3f47fa66fb8719d7785824061c2d6d7a4bcb851540e62b2f00960b283eac7808d1813ef51b46e1149d3e4d",
         "wx" : "51fe6a35a85070c7c29502a87672a38153d799aef734226b64d8fd3398621701117f0af9d9afaf6dbb8ca3007255dc79b0f41ed552512cb29207b15a01cdfdfaae",
-        "wy" : "1a16c61277586356efadcb24764f21f574ef96f2caabc3f47fa66fb8719d7785824061c2d6d7a4bcb851540e62b2f00960b283eac7808d1813ef51b46e1149d3e4d"
+        "wy" : "01a16c61277586356efadcb24764f21f574ef96f2caabc3f47fa66fb8719d7785824061c2d6d7a4bcb851540e62b2f00960b283eac7808d1813ef51b46e1149d3e4d"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040051fe6a35a85070c7c29502a87672a38153d799aef734226b64d8fd3398621701117f0af9d9afaf6dbb8ca3007255dc79b0f41ed552512cb29207b15a01cdfdfaae01a16c61277586356efadcb24764f21f574ef96f2caabc3f47fa66fb8719d7785824061c2d6d7a4bcb851540e62b2f00960b283eac7808d1813ef51b46e1149d3e4d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAUf5qNahQcMfClQKodnKjgVPXma73\nNCJrZNj9M5hiFwERfwr52a+vbbuMowByVdx5sPQe1VJRLLKSB7FaAc39+q4BoWxh\nJ3WGNW763LJHZPIfV075byyqvD9H+mb7hxnXeFgkBhwtbXpLy4UVQOYrLwCWCyg+\nrHgI0YE+9RtG4RSdPk0=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040051fe6a35a85070c7c29502a87672a38153d799aef734226b64d8fd3398621701117f0af9d9afaf6dbb8ca3007255dc79b0f41ed552512cb29207b15a01cdfdfaae01a16c61277586356efadcb24764f21f574ef96f2caabc3f47fa66fb8719d7785824061c2d6d7a4bcb851540e62b2f00960b283eac7808d1813ef51b46e1149d3e4d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAUf5qNahQcMfClQKodnKjgVPXma73\nNCJrZNj9M5hiFwERfwr52a+vbbuMowByVdx5sPQe1VJRLLKSB7FaAc39+q4BoWxh\nJ3WGNW763LJHZPIfV075byyqvD9H+mb7hxnXeFgkBhwtbXpLy4UVQOYrLwCWCyg+\nrHgI0YE+9RtG4RSdPk0=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 360,
+          "tcId" : 463,
           "comment" : "u1 == n - 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad024201ffbc07ff041506dc73a75086a43252fb43b6327af3c6b2cc7d6acca94fdcdefd78dc0b56a22d16f2eec26ae0c1fb484d059300e80bd6b0472b3d1222ff5d08b03d",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400b4ffc0fff087607ad26c4b23d6d31ae5f904cc064e350f47131ce2784fbb359867988a559d4386752e56277bef34e26544dedda88cc20a3411fa98834eeae869ad009d6e8ca99949b7b34fd06a789744ecac3356247317c4d7aa9296676dd623594f3684bc13064cab8d2db7edbca91f1c8beb542bc97978a3f31f3610a03f46a982d2",
-        "wx" : "0b4ffc0fff087607ad26c4b23d6d31ae5f904cc064e350f47131ce2784fbb359867988a559d4386752e56277bef34e26544dedda88cc20a3411fa98834eeae869ad",
-        "wy" : "09d6e8ca99949b7b34fd06a789744ecac3356247317c4d7aa9296676dd623594f3684bc13064cab8d2db7edbca91f1c8beb542bc97978a3f31f3610a03f46a982d2"
+        "wx" : "00b4ffc0fff087607ad26c4b23d6d31ae5f904cc064e350f47131ce2784fbb359867988a559d4386752e56277bef34e26544dedda88cc20a3411fa98834eeae869ad",
+        "wy" : "009d6e8ca99949b7b34fd06a789744ecac3356247317c4d7aa9296676dd623594f3684bc13064cab8d2db7edbca91f1c8beb542bc97978a3f31f3610a03f46a982d2"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400b4ffc0fff087607ad26c4b23d6d31ae5f904cc064e350f47131ce2784fbb359867988a559d4386752e56277bef34e26544dedda88cc20a3411fa98834eeae869ad009d6e8ca99949b7b34fd06a789744ecac3356247317c4d7aa9296676dd623594f3684bc13064cab8d2db7edbca91f1c8beb542bc97978a3f31f3610a03f46a982d2",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAtP/A//CHYHrSbEsj1tMa5fkEzAZO\nNQ9HExzieE+7NZhnmIpVnUOGdS5WJ3vvNOJlRN7dqIzCCjQR+piDTuroaa0AnW6M\nqZlJt7NP0Gp4l0TsrDNWJHMXxNeqkpZnbdYjWU82hLwTBkyrjS237bypHxyL61Qr\nyXl4o/MfNhCgP0apgtI=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400b4ffc0fff087607ad26c4b23d6d31ae5f904cc064e350f47131ce2784fbb359867988a559d4386752e56277bef34e26544dedda88cc20a3411fa98834eeae869ad009d6e8ca99949b7b34fd06a789744ecac3356247317c4d7aa9296676dd623594f3684bc13064cab8d2db7edbca91f1c8beb542bc97978a3f31f3610a03f46a982d2",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAtP/A//CHYHrSbEsj1tMa5fkEzAZO\nNQ9HExzieE+7NZhnmIpVnUOGdS5WJ3vvNOJlRN7dqIzCCjQR+piDTuroaa0AnW6M\nqZlJt7NP0Gp4l0TsrDNWJHMXxNeqkpZnbdYjWU82hLwTBkyrjS237bypHxyL61Qr\nyXl4o/MfNhCgP0apgtI=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 361,
+          "tcId" : 464,
           "comment" : "u2 == 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400809fba320fe96ded24611b72a2a5428fe46049ff080d6e0813ab7a35897018fe6418613abd860d1eb484959059a01af7d68cba69d1c52ea64ad0f28a18a41fc78a01108acc5577e9e8962e2a7cea0bb37df1d0ca4050fb6cfeba41a7f868d988dbbcebc962986748fa485183f6b60f453ec8606f8c33d43767dddbbef8c412b2c37939",
-        "wx" : "0809fba320fe96ded24611b72a2a5428fe46049ff080d6e0813ab7a35897018fe6418613abd860d1eb484959059a01af7d68cba69d1c52ea64ad0f28a18a41fc78a",
-        "wy" : "1108acc5577e9e8962e2a7cea0bb37df1d0ca4050fb6cfeba41a7f868d988dbbcebc962986748fa485183f6b60f453ec8606f8c33d43767dddbbef8c412b2c37939"
+        "wx" : "00809fba320fe96ded24611b72a2a5428fe46049ff080d6e0813ab7a35897018fe6418613abd860d1eb484959059a01af7d68cba69d1c52ea64ad0f28a18a41fc78a",
+        "wy" : "01108acc5577e9e8962e2a7cea0bb37df1d0ca4050fb6cfeba41a7f868d988dbbcebc962986748fa485183f6b60f453ec8606f8c33d43767dddbbef8c412b2c37939"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400809fba320fe96ded24611b72a2a5428fe46049ff080d6e0813ab7a35897018fe6418613abd860d1eb484959059a01af7d68cba69d1c52ea64ad0f28a18a41fc78a01108acc5577e9e8962e2a7cea0bb37df1d0ca4050fb6cfeba41a7f868d988dbbcebc962986748fa485183f6b60f453ec8606f8c33d43767dddbbef8c412b2c37939",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAgJ+6Mg/pbe0kYRtyoqVCj+RgSf8I\nDW4IE6t6NYlwGP5kGGE6vYYNHrSElZBZoBr31oy6adHFLqZK0PKKGKQfx4oBEIrM\nVXfp6JYuKnzqC7N98dDKQFD7bP66Qaf4aNmI27zryWKYZ0j6SFGD9rYPRT7IYG+M\nM9Q3Z93bvvjEErLDeTk=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400809fba320fe96ded24611b72a2a5428fe46049ff080d6e0813ab7a35897018fe6418613abd860d1eb484959059a01af7d68cba69d1c52ea64ad0f28a18a41fc78a01108acc5577e9e8962e2a7cea0bb37df1d0ca4050fb6cfeba41a7f868d988dbbcebc962986748fa485183f6b60f453ec8606f8c33d43767dddbbef8c412b2c37939",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAgJ+6Mg/pbe0kYRtyoqVCj+RgSf8I\nDW4IE6t6NYlwGP5kGGE6vYYNHrSElZBZoBr31oy6adHFLqZK0PKKGKQfx4oBEIrM\nVXfp6JYuKnzqC7N98dDKQFD7bP66Qaf4aNmI27zryWKYZ0j6SFGD9rYPRT7IYG+M\nM9Q3Z93bvvjEErLDeTk=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 362,
+          "tcId" : 465,
           "comment" : "u2 == n - 1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad0242015555555555555555555555555555555555555555555555555555555555555555518baf05027f750ef25532ab85fa066e8ad2793125b112da747cf524bf0b7aed5c",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040145130dca77d9674dfceffa851b4a2672e490e8fba8277622b0020e2fe9101e76933b0c01d248071f854e9bc523733936dc0b9930cbe154b9a402f681ee3c6cef6b000d0c94b2ad28556643aa3d27523048d227a1de82f8a664707e75394d21da181bec82e1afb0e627539531affa849a2409bcac83fb786c351c88bac2fb2e4322e54a",
-        "wx" : "145130dca77d9674dfceffa851b4a2672e490e8fba8277622b0020e2fe9101e76933b0c01d248071f854e9bc523733936dc0b9930cbe154b9a402f681ee3c6cef6b",
+        "wx" : "0145130dca77d9674dfceffa851b4a2672e490e8fba8277622b0020e2fe9101e76933b0c01d248071f854e9bc523733936dc0b9930cbe154b9a402f681ee3c6cef6b",
         "wy" : "0d0c94b2ad28556643aa3d27523048d227a1de82f8a664707e75394d21da181bec82e1afb0e627539531affa849a2409bcac83fb786c351c88bac2fb2e4322e54a"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040145130dca77d9674dfceffa851b4a2672e490e8fba8277622b0020e2fe9101e76933b0c01d248071f854e9bc523733936dc0b9930cbe154b9a402f681ee3c6cef6b000d0c94b2ad28556643aa3d27523048d227a1de82f8a664707e75394d21da181bec82e1afb0e627539531affa849a2409bcac83fb786c351c88bac2fb2e4322e54a",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBRRMNynfZZ0387/qFG0omcuSQ6Puo\nJ3YisAIOL+kQHnaTOwwB0kgHH4VOm8Ujczk23AuZMMvhVLmkAvaB7jxs72sADQyU\nsq0oVWZDqj0nUjBI0ieh3oL4pmRwfnU5TSHaGBvsguGvsOYnU5Uxr/qEmiQJvKyD\n+3hsNRyIusL7LkMi5Uo=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040145130dca77d9674dfceffa851b4a2672e490e8fba8277622b0020e2fe9101e76933b0c01d248071f854e9bc523733936dc0b9930cbe154b9a402f681ee3c6cef6b000d0c94b2ad28556643aa3d27523048d227a1de82f8a664707e75394d21da181bec82e1afb0e627539531affa849a2409bcac83fb786c351c88bac2fb2e4322e54a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBRRMNynfZZ0387/qFG0omcuSQ6Puo\nJ3YisAIOL+kQHnaTOwwB0kgHH4VOm8Ujczk23AuZMMvhVLmkAvaB7jxs72sADQyU\nsq0oVWZDqj0nUjBI0ieh3oL4pmRwfnU5TSHaGBvsguGvsOYnU5Uxr/qEmiQJvKyD\n+3hsNRyIusL7LkMi5Uo=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 363,
+          "tcId" : 466,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024201556bfd55a94e530bd972e52873ef39ac3ec34481aebdc46680dc66723ab66056275d82bff85ad29ac694530bb2f89c36ce600ad1b49761854afc69ab741ce0294a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400ed3e09809fe5985818f90592fd06e71d2c493d9a781714c9157cbafa5ba196b987fd49ae24274c76251c70b9f7970f1f713ad274590a702f463c73a0704831ce5d00cac278297093bd9f9ac2d00bef3d67a01b43b28b9f829407264c738117438300c7704772976916ea102a776262ccf4222cc348c34aac683d8f00179a348323babd",
-        "wx" : "0ed3e09809fe5985818f90592fd06e71d2c493d9a781714c9157cbafa5ba196b987fd49ae24274c76251c70b9f7970f1f713ad274590a702f463c73a0704831ce5d",
-        "wy" : "0cac278297093bd9f9ac2d00bef3d67a01b43b28b9f829407264c738117438300c7704772976916ea102a776262ccf4222cc348c34aac683d8f00179a348323babd"
+        "wx" : "00ed3e09809fe5985818f90592fd06e71d2c493d9a781714c9157cbafa5ba196b987fd49ae24274c76251c70b9f7970f1f713ad274590a702f463c73a0704831ce5d",
+        "wy" : "00cac278297093bd9f9ac2d00bef3d67a01b43b28b9f829407264c738117438300c7704772976916ea102a776262ccf4222cc348c34aac683d8f00179a348323babd"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400ed3e09809fe5985818f90592fd06e71d2c493d9a781714c9157cbafa5ba196b987fd49ae24274c76251c70b9f7970f1f713ad274590a702f463c73a0704831ce5d00cac278297093bd9f9ac2d00bef3d67a01b43b28b9f829407264c738117438300c7704772976916ea102a776262ccf4222cc348c34aac683d8f00179a348323babd",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQA7T4JgJ/lmFgY+QWS/QbnHSxJPZp4\nFxTJFXy6+luhlrmH/UmuJCdMdiUccLn3lw8fcTrSdFkKcC9GPHOgcEgxzl0AysJ4\nKXCTvZ+awtAL7z1noBtDsoufgpQHJkxzgRdDgwDHcEdyl2kW6hAqd2JizPQiLMNI\nw0qsaD2PABeaNIMjur0=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400ed3e09809fe5985818f90592fd06e71d2c493d9a781714c9157cbafa5ba196b987fd49ae24274c76251c70b9f7970f1f713ad274590a702f463c73a0704831ce5d00cac278297093bd9f9ac2d00bef3d67a01b43b28b9f829407264c738117438300c7704772976916ea102a776262ccf4222cc348c34aac683d8f00179a348323babd",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQA7T4JgJ/lmFgY+QWS/QbnHSxJPZp4\nFxTJFXy6+luhlrmH/UmuJCdMdiUccLn3lw8fcTrSdFkKcC9GPHOgcEgxzl0AysJ4\nKXCTvZ+awtAL7z1noBtDsoufgpQHJkxzgRdDgwDHcEdyl2kW6hAqd2JizPQiLMNI\nw0qsaD2PABeaNIMjur0=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 364,
+          "tcId" : 467,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024200dcf9e7f441448a125b96d72b989d9f4dac7508c7e036f6080d4758e736f5e0636b0ff503f128a98d08e0ae189921065219d2cc3aa83e3c660ca0cb85e7c11a24d0",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04000ac2c5a4c79309a5132d5d7494befb3905d33fda5f80eeaf63775183aae7af108a3d97f3a441532cf6fac47f6c898329d69182e1fa07ce45997ebec3781c9ad7410173a5b6b80a8b73d30ac97e1a4aacb773c1ad692c5ea63f68e373842782bd677864ff656cf8d1e6ec1e58e9a83856ef92677555916749fb95e800ae2e011618ca3a",
         "wx" : "0ac2c5a4c79309a5132d5d7494befb3905d33fda5f80eeaf63775183aae7af108a3d97f3a441532cf6fac47f6c898329d69182e1fa07ce45997ebec3781c9ad741",
-        "wy" : "173a5b6b80a8b73d30ac97e1a4aacb773c1ad692c5ea63f68e373842782bd677864ff656cf8d1e6ec1e58e9a83856ef92677555916749fb95e800ae2e011618ca3a"
+        "wy" : "0173a5b6b80a8b73d30ac97e1a4aacb773c1ad692c5ea63f68e373842782bd677864ff656cf8d1e6ec1e58e9a83856ef92677555916749fb95e800ae2e011618ca3a"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004000ac2c5a4c79309a5132d5d7494befb3905d33fda5f80eeaf63775183aae7af108a3d97f3a441532cf6fac47f6c898329d69182e1fa07ce45997ebec3781c9ad7410173a5b6b80a8b73d30ac97e1a4aacb773c1ad692c5ea63f68e373842782bd677864ff656cf8d1e6ec1e58e9a83856ef92677555916749fb95e800ae2e011618ca3a",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQACsLFpMeTCaUTLV10lL77OQXTP9pf\ngO6vY3dRg6rnrxCKPZfzpEFTLPb6xH9siYMp1pGC4foHzkWZfr7DeBya10EBc6W2\nuAqLc9MKyX4aSqy3c8GtaSxepj9o43OEJ4K9Z3hk/2Vs+NHm7B5Y6ag4Vu+SZ3VV\nkWdJ+5XoAK4uARYYyjo=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004000ac2c5a4c79309a5132d5d7494befb3905d33fda5f80eeaf63775183aae7af108a3d97f3a441532cf6fac47f6c898329d69182e1fa07ce45997ebec3781c9ad7410173a5b6b80a8b73d30ac97e1a4aacb773c1ad692c5ea63f68e373842782bd677864ff656cf8d1e6ec1e58e9a83856ef92677555916749fb95e800ae2e011618ca3a",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQACsLFpMeTCaUTLV10lL77OQXTP9pf\ngO6vY3dRg6rnrxCKPZfzpEFTLPb6xH9siYMp1pGC4foHzkWZfr7DeBya10EBc6W2\nuAqLc9MKyX4aSqy3c8GtaSxepj9o43OEJ4K9Z3hk/2Vs+NHm7B5Y6ag4Vu+SZ3VV\nkWdJ+5XoAK4uARYYyjo=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 365,
+          "tcId" : 468,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308187024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024166eb57733c19a7003cf8253279fce41907bc4f127153c4576dd4814f8b335a0b51560b4447f0382c69b3fe509522c891f0eec3999ad2526835f33ae22a642843af",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401eb2a353dec6b460fbda49c67f431190fff6f195639c226ef8fefcbf191d72529a12cc5485b282a52704c1fd84529a1aa0ad794f96493e299718d2618a1b83a526c01f704604d5b2b94a42bfc3ab93317d66a54de15258337433fc96a965d8e2d056fd1134b7989d7b3f709adc28227bdabc11fe2f359c6a6e5111ab43379ca25b66f2f",
-        "wx" : "1eb2a353dec6b460fbda49c67f431190fff6f195639c226ef8fefcbf191d72529a12cc5485b282a52704c1fd84529a1aa0ad794f96493e299718d2618a1b83a526c",
-        "wy" : "1f704604d5b2b94a42bfc3ab93317d66a54de15258337433fc96a965d8e2d056fd1134b7989d7b3f709adc28227bdabc11fe2f359c6a6e5111ab43379ca25b66f2f"
+        "wx" : "01eb2a353dec6b460fbda49c67f431190fff6f195639c226ef8fefcbf191d72529a12cc5485b282a52704c1fd84529a1aa0ad794f96493e299718d2618a1b83a526c",
+        "wy" : "01f704604d5b2b94a42bfc3ab93317d66a54de15258337433fc96a965d8e2d056fd1134b7989d7b3f709adc28227bdabc11fe2f359c6a6e5111ab43379ca25b66f2f"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401eb2a353dec6b460fbda49c67f431190fff6f195639c226ef8fefcbf191d72529a12cc5485b282a52704c1fd84529a1aa0ad794f96493e299718d2618a1b83a526c01f704604d5b2b94a42bfc3ab93317d66a54de15258337433fc96a965d8e2d056fd1134b7989d7b3f709adc28227bdabc11fe2f359c6a6e5111ab43379ca25b66f2f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB6yo1PexrRg+9pJxn9DEZD/9vGVY5\nwibvj+/L8ZHXJSmhLMVIWygqUnBMH9hFKaGqCteU+WST4plxjSYYobg6UmwB9wRg\nTVsrlKQr/Dq5MxfWalTeFSWDN0M/yWqWXY4tBW/RE0t5idez9wmtwoInvavBH+Lz\nWcam5REatDN5yiW2by8=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401eb2a353dec6b460fbda49c67f431190fff6f195639c226ef8fefcbf191d72529a12cc5485b282a52704c1fd84529a1aa0ad794f96493e299718d2618a1b83a526c01f704604d5b2b94a42bfc3ab93317d66a54de15258337433fc96a965d8e2d056fd1134b7989d7b3f709adc28227bdabc11fe2f359c6a6e5111ab43379ca25b66f2f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB6yo1PexrRg+9pJxn9DEZD/9vGVY5\nwibvj+/L8ZHXJSmhLMVIWygqUnBMH9hFKaGqCteU+WST4plxjSYYobg6UmwB9wRg\nTVsrlKQr/Dq5MxfWalTeFSWDN0M/yWqWXY4tBW/RE0t5idez9wmtwoInvavBH+Lz\nWcam5REatDN5yiW2by8=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 366,
+          "tcId" : 469,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0242017106d1131b3300d7ffbc07ff041506dc73a75086a43252fb43b6327af3c6b2cc79527ac09f0a3f0a8aa38285585b6afceac5ff6692842232d106d15d4df1b66aa8",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401e43dfecc7e6caad03d17b407322c878f701c5add6eb2afcd786ff3803622dfbb6baa01246e1ea059f7b78842919b2507daa9e3434efa7e8d3ae6c35499f82d0ac8018b0e4d6378222a07ccdb4214001f97b1a503d1aac3ab925ea64faa9c739ba04ee3480b147cb07f93edf40b6856a22f4159c3f5cd6c9e7165452907c8d02fab201e",
-        "wx" : "1e43dfecc7e6caad03d17b407322c878f701c5add6eb2afcd786ff3803622dfbb6baa01246e1ea059f7b78842919b2507daa9e3434efa7e8d3ae6c35499f82d0ac8",
-        "wy" : "18b0e4d6378222a07ccdb4214001f97b1a503d1aac3ab925ea64faa9c739ba04ee3480b147cb07f93edf40b6856a22f4159c3f5cd6c9e7165452907c8d02fab201e"
+        "wx" : "01e43dfecc7e6caad03d17b407322c878f701c5add6eb2afcd786ff3803622dfbb6baa01246e1ea059f7b78842919b2507daa9e3434efa7e8d3ae6c35499f82d0ac8",
+        "wy" : "018b0e4d6378222a07ccdb4214001f97b1a503d1aac3ab925ea64faa9c739ba04ee3480b147cb07f93edf40b6856a22f4159c3f5cd6c9e7165452907c8d02fab201e"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401e43dfecc7e6caad03d17b407322c878f701c5add6eb2afcd786ff3803622dfbb6baa01246e1ea059f7b78842919b2507daa9e3434efa7e8d3ae6c35499f82d0ac8018b0e4d6378222a07ccdb4214001f97b1a503d1aac3ab925ea64faa9c739ba04ee3480b147cb07f93edf40b6856a22f4159c3f5cd6c9e7165452907c8d02fab201e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB5D3+zH5sqtA9F7QHMiyHj3AcWt1u\nsq/NeG/zgDYi37trqgEkbh6gWfe3iEKRmyUH2qnjQ076fo065sNUmfgtCsgBiw5N\nY3giKgfM20IUAB+XsaUD0arDq5Jepk+qnHOboE7jSAsUfLB/k+30C2hWoi9BWcP1\nzWyecWVFKQfI0C+rIB4=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401e43dfecc7e6caad03d17b407322c878f701c5add6eb2afcd786ff3803622dfbb6baa01246e1ea059f7b78842919b2507daa9e3434efa7e8d3ae6c35499f82d0ac8018b0e4d6378222a07ccdb4214001f97b1a503d1aac3ab925ea64faa9c739ba04ee3480b147cb07f93edf40b6856a22f4159c3f5cd6c9e7165452907c8d02fab201e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB5D3+zH5sqtA9F7QHMiyHj3AcWt1u\nsq/NeG/zgDYi37trqgEkbh6gWfe3iEKRmyUH2qnjQ076fo065sNUmfgtCsgBiw5N\nY3giKgfM20IUAB+XsaUD0arDq5Jepk+qnHOboE7jSAsUfLB/k+30C2hWoi9BWcP1\nzWyecWVFKQfI0C+rIB4=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 367,
+          "tcId" : 470,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308187024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02416d1131b3300d7ffbc07ff041506dc73a75086a43252fb43b6327af3c6b2cc7d6ab94bf496f53ea229e7fe6b456088ea32f6e2b104f5112798bb59d46a0d468f838",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040141a4d714628c192b8ace1a42854da06e0e1ddb82a07618e4efb05d7095cd1eb65425078160594715eaf59fcb41c9e573fe10298c75c9e9135c775ca73f63d13aac0089524b475170d4391cc032a0543ea22dab60ea07538f3a37607f0d4ed516634fde545e2f0a6ba8d0d2fe6aded0a771b4b134a5a280e54799fa476ef0ec87d44e1c",
-        "wx" : "141a4d714628c192b8ace1a42854da06e0e1ddb82a07618e4efb05d7095cd1eb65425078160594715eaf59fcb41c9e573fe10298c75c9e9135c775ca73f63d13aac",
-        "wy" : "089524b475170d4391cc032a0543ea22dab60ea07538f3a37607f0d4ed516634fde545e2f0a6ba8d0d2fe6aded0a771b4b134a5a280e54799fa476ef0ec87d44e1c"
+        "wx" : "0141a4d714628c192b8ace1a42854da06e0e1ddb82a07618e4efb05d7095cd1eb65425078160594715eaf59fcb41c9e573fe10298c75c9e9135c775ca73f63d13aac",
+        "wy" : "0089524b475170d4391cc032a0543ea22dab60ea07538f3a37607f0d4ed516634fde545e2f0a6ba8d0d2fe6aded0a771b4b134a5a280e54799fa476ef0ec87d44e1c"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040141a4d714628c192b8ace1a42854da06e0e1ddb82a07618e4efb05d7095cd1eb65425078160594715eaf59fcb41c9e573fe10298c75c9e9135c775ca73f63d13aac0089524b475170d4391cc032a0543ea22dab60ea07538f3a37607f0d4ed516634fde545e2f0a6ba8d0d2fe6aded0a771b4b134a5a280e54799fa476ef0ec87d44e1c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBQaTXFGKMGSuKzhpChU2gbg4d24Kg\ndhjk77BdcJXNHrZUJQeBYFlHFer1n8tByeVz/hApjHXJ6RNcd1ynP2PROqwAiVJL\nR1Fw1DkcwDKgVD6iLatg6gdTjzo3YH8NTtUWY0/eVF4vCmuo0NL+at7Qp3G0sTSl\nooDlR5n6R27w7IfUThw=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040141a4d714628c192b8ace1a42854da06e0e1ddb82a07618e4efb05d7095cd1eb65425078160594715eaf59fcb41c9e573fe10298c75c9e9135c775ca73f63d13aac0089524b475170d4391cc032a0543ea22dab60ea07538f3a37607f0d4ed516634fde545e2f0a6ba8d0d2fe6aded0a771b4b134a5a280e54799fa476ef0ec87d44e1c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBQaTXFGKMGSuKzhpChU2gbg4d24Kg\ndhjk77BdcJXNHrZUJQeBYFlHFer1n8tByeVz/hApjHXJ6RNcd1ynP2PROqwAiVJL\nR1Fw1DkcwDKgVD6iLatg6gdTjzo3YH8NTtUWY0/eVF4vCmuo0NL+at7Qp3G0sTSl\nooDlR5n6R27w7IfUThw=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 368,
+          "tcId" : 471,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024200da226366601afff780ffe082a0db8e74ea10d4864a5f6876c64f5e78d6598fad57297e92dea7d4453cffcd68ac111d465edc56209ea224f3176b3a8d41a8d1f070",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040147fbcc65d4818e029e0a3af13a1f7c90f0605a00cd0781200eb656a591d669a787620e6fc8cc594aa28a0b0f2939ec73472c494e09cecaf5f331dafd32d5ac31c30075432bdaeecaa0bec7feddc298c565723fb669ee76e38a4c5ff1701f1b38cda9dc9ac43bff18da2047e4dcd80c05a7bb7e7464829d608b68176b04c87f409f46d6",
-        "wx" : "147fbcc65d4818e029e0a3af13a1f7c90f0605a00cd0781200eb656a591d669a787620e6fc8cc594aa28a0b0f2939ec73472c494e09cecaf5f331dafd32d5ac31c3",
+        "wx" : "0147fbcc65d4818e029e0a3af13a1f7c90f0605a00cd0781200eb656a591d669a787620e6fc8cc594aa28a0b0f2939ec73472c494e09cecaf5f331dafd32d5ac31c3",
         "wy" : "75432bdaeecaa0bec7feddc298c565723fb669ee76e38a4c5ff1701f1b38cda9dc9ac43bff18da2047e4dcd80c05a7bb7e7464829d608b68176b04c87f409f46d6"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040147fbcc65d4818e029e0a3af13a1f7c90f0605a00cd0781200eb656a591d669a787620e6fc8cc594aa28a0b0f2939ec73472c494e09cecaf5f331dafd32d5ac31c30075432bdaeecaa0bec7feddc298c565723fb669ee76e38a4c5ff1701f1b38cda9dc9ac43bff18da2047e4dcd80c05a7bb7e7464829d608b68176b04c87f409f46d6",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBR/vMZdSBjgKeCjrxOh98kPBgWgDN\nB4EgDrZWpZHWaaeHYg5vyMxZSqKKCw8pOexzRyxJTgnOyvXzMdr9MtWsMcMAdUMr\n2u7KoL7H/t3CmMVlcj+2ae5244pMX/FwHxs4zancmsQ7/xjaIEfk3NgMBae7fnRk\ngp1gi2gXawTIf0CfRtY=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040147fbcc65d4818e029e0a3af13a1f7c90f0605a00cd0781200eb656a591d669a787620e6fc8cc594aa28a0b0f2939ec73472c494e09cecaf5f331dafd32d5ac31c30075432bdaeecaa0bec7feddc298c565723fb669ee76e38a4c5ff1701f1b38cda9dc9ac43bff18da2047e4dcd80c05a7bb7e7464829d608b68176b04c87f409f46d6",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBR/vMZdSBjgKeCjrxOh98kPBgWgDN\nB4EgDrZWpZHWaaeHYg5vyMxZSqKKCw8pOexzRyxJTgnOyvXzMdr9MtWsMcMAdUMr\n2u7KoL7H/t3CmMVlcj+2ae5244pMX/FwHxs4zancmsQ7/xjaIEfk3NgMBae7fnRk\ngp1gi2gXawTIf0CfRtY=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 369,
+          "tcId" : 472,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0242011b3300d7ffbc07ff041506dc73a75086a43252fb43b6327af3c6b2cc7d6acca94cb85df5e6c1125394fcd34f6521ffdaddd98f88a99fedcedd9384288bb793cf2f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400b5b1c3998589b25c96a700bbd450d04da1f273df8053767a3b03ed1a763ed089c0de99bcf54d49c1520d3a09b845296f0445b3bd5b87918d3752cf651e0ff3007b00e896380876b9419c56096914ff6eec01aee247eefef0741895f14ee280f360e11508c37826af82cd915b9002f046cb51008d9ead21124c591bd8265d1492b35ffb",
-        "wx" : "0b5b1c3998589b25c96a700bbd450d04da1f273df8053767a3b03ed1a763ed089c0de99bcf54d49c1520d3a09b845296f0445b3bd5b87918d3752cf651e0ff3007b",
-        "wy" : "0e896380876b9419c56096914ff6eec01aee247eefef0741895f14ee280f360e11508c37826af82cd915b9002f046cb51008d9ead21124c591bd8265d1492b35ffb"
+        "wx" : "00b5b1c3998589b25c96a700bbd450d04da1f273df8053767a3b03ed1a763ed089c0de99bcf54d49c1520d3a09b845296f0445b3bd5b87918d3752cf651e0ff3007b",
+        "wy" : "00e896380876b9419c56096914ff6eec01aee247eefef0741895f14ee280f360e11508c37826af82cd915b9002f046cb51008d9ead21124c591bd8265d1492b35ffb"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400b5b1c3998589b25c96a700bbd450d04da1f273df8053767a3b03ed1a763ed089c0de99bcf54d49c1520d3a09b845296f0445b3bd5b87918d3752cf651e0ff3007b00e896380876b9419c56096914ff6eec01aee247eefef0741895f14ee280f360e11508c37826af82cd915b9002f046cb51008d9ead21124c591bd8265d1492b35ffb",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAtbHDmYWJslyWpwC71FDQTaHyc9+A\nU3Z6OwPtGnY+0InA3pm89U1JwVINOgm4RSlvBEWzvVuHkY03Us9lHg/zAHsA6JY4\nCHa5QZxWCWkU/27sAa7iR+7+8HQYlfFO4oDzYOEVCMN4Jq+CzZFbkALwRstRAI2e\nrSESTFkb2CZdFJKzX/s=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400b5b1c3998589b25c96a700bbd450d04da1f273df8053767a3b03ed1a763ed089c0de99bcf54d49c1520d3a09b845296f0445b3bd5b87918d3752cf651e0ff3007b00e896380876b9419c56096914ff6eec01aee247eefef0741895f14ee280f360e11508c37826af82cd915b9002f046cb51008d9ead21124c591bd8265d1492b35ffb",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAtbHDmYWJslyWpwC71FDQTaHyc9+A\nU3Z6OwPtGnY+0InA3pm89U1JwVINOgm4RSlvBEWzvVuHkY03Us9lHg/zAHsA6JY4\nCHa5QZxWCWkU/27sAa7iR+7+8HQYlfFO4oDzYOEVCMN4Jq+CzZFbkALwRstRAI2e\nrSESTFkb2CZdFJKzX/s=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 370,
+          "tcId" : 473,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02420161be37ed5f748e06a89d72c4b7051cae809d9567848b1d8d7ed019221efb06ae81e1264ce49c5d29ee5fe22ccf70899002643aca7b99f57756f2639b6d459ae410",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401aadb41fadc35cf6d11a7c7d01d049b74b37677f04e1bd3dc08450fabae28adcd2d135f966616d283fb18a5e69eabfe7ec41e1a0edb3682f1d39f2af64a94d602b9014ae81ebf5e3d2d0529479d4ae8eb05f4b42e519608466ad69e7662d6e9b236765f9be535c058f00f0866bbb4b172ef47a03cb97c58dde5750344bb293035f8e97e",
-        "wx" : "1aadb41fadc35cf6d11a7c7d01d049b74b37677f04e1bd3dc08450fabae28adcd2d135f966616d283fb18a5e69eabfe7ec41e1a0edb3682f1d39f2af64a94d602b9",
-        "wy" : "14ae81ebf5e3d2d0529479d4ae8eb05f4b42e519608466ad69e7662d6e9b236765f9be535c058f00f0866bbb4b172ef47a03cb97c58dde5750344bb293035f8e97e"
+        "wx" : "01aadb41fadc35cf6d11a7c7d01d049b74b37677f04e1bd3dc08450fabae28adcd2d135f966616d283fb18a5e69eabfe7ec41e1a0edb3682f1d39f2af64a94d602b9",
+        "wy" : "014ae81ebf5e3d2d0529479d4ae8eb05f4b42e519608466ad69e7662d6e9b236765f9be535c058f00f0866bbb4b172ef47a03cb97c58dde5750344bb293035f8e97e"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401aadb41fadc35cf6d11a7c7d01d049b74b37677f04e1bd3dc08450fabae28adcd2d135f966616d283fb18a5e69eabfe7ec41e1a0edb3682f1d39f2af64a94d602b9014ae81ebf5e3d2d0529479d4ae8eb05f4b42e519608466ad69e7662d6e9b236765f9be535c058f00f0866bbb4b172ef47a03cb97c58dde5750344bb293035f8e97e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBqttB+tw1z20Rp8fQHQSbdLN2d/BO\nG9PcCEUPq64orc0tE1+WZhbSg/sYpeaeq/5+xB4aDts2gvHTnyr2SpTWArkBSuge\nv149LQUpR51K6OsF9LQuUZYIRmrWnnZi1umyNnZfm+U1wFjwDwhmu7Sxcu9HoDy5\nfFjd5XUDRLspMDX46X4=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401aadb41fadc35cf6d11a7c7d01d049b74b37677f04e1bd3dc08450fabae28adcd2d135f966616d283fb18a5e69eabfe7ec41e1a0edb3682f1d39f2af64a94d602b9014ae81ebf5e3d2d0529479d4ae8eb05f4b42e519608466ad69e7662d6e9b236765f9be535c058f00f0866bbb4b172ef47a03cb97c58dde5750344bb293035f8e97e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBqttB+tw1z20Rp8fQHQSbdLN2d/BO\nG9PcCEUPq64orc0tE1+WZhbSg/sYpeaeq/5+xB4aDts2gvHTnyr2SpTWArkBSuge\nv149LQUpR51K6OsF9LQuUZYIRmrWnnZi1umyNnZfm+U1wFjwDwhmu7Sxcu9HoDy5\nfFjd5XUDRLspMDX46X4=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 371,
+          "tcId" : 474,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024201e9bbbd64270b9668f7623ef7cbead5483eb07b883cf39fb6884aab67dac7958b0e03144357b9433e69adc696c86c63a23d35724cbd749b7c34f8e34232d21ea420",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401b706fc3f4aae5b86da261a66fbce47eb3b3e1e91544a40a9989fccf74154bbecac042dbbbf411a39090058b62c46fccd1d5eaba0c4879a688ea5fd0a7b4f9a0b4f01eda01930c6b22745a97f2d59e182598dfdfbfdb463335293901de7fc9d49cf55ed7fcf5d767d4c22f89f171b4137c8415c3ed438089270c41f88eadef3018140e1",
-        "wx" : "1b706fc3f4aae5b86da261a66fbce47eb3b3e1e91544a40a9989fccf74154bbecac042dbbbf411a39090058b62c46fccd1d5eaba0c4879a688ea5fd0a7b4f9a0b4f",
-        "wy" : "1eda01930c6b22745a97f2d59e182598dfdfbfdb463335293901de7fc9d49cf55ed7fcf5d767d4c22f89f171b4137c8415c3ed438089270c41f88eadef3018140e1"
+        "wx" : "01b706fc3f4aae5b86da261a66fbce47eb3b3e1e91544a40a9989fccf74154bbecac042dbbbf411a39090058b62c46fccd1d5eaba0c4879a688ea5fd0a7b4f9a0b4f",
+        "wy" : "01eda01930c6b22745a97f2d59e182598dfdfbfdb463335293901de7fc9d49cf55ed7fcf5d767d4c22f89f171b4137c8415c3ed438089270c41f88eadef3018140e1"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401b706fc3f4aae5b86da261a66fbce47eb3b3e1e91544a40a9989fccf74154bbecac042dbbbf411a39090058b62c46fccd1d5eaba0c4879a688ea5fd0a7b4f9a0b4f01eda01930c6b22745a97f2d59e182598dfdfbfdb463335293901de7fc9d49cf55ed7fcf5d767d4c22f89f171b4137c8415c3ed438089270c41f88eadef3018140e1",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBtwb8P0quW4baJhpm+85H6zs+HpFU\nSkCpmJ/M90FUu+ysBC27v0EaOQkAWLYsRvzNHV6roMSHmmiOpf0Ke0+aC08B7aAZ\nMMayJ0Wpfy1Z4YJZjf37/bRjM1KTkB3n/J1Jz1Xtf89ddn1MIvifFxtBN8hBXD7U\nOAiScMQfiOre8wGBQOE=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401b706fc3f4aae5b86da261a66fbce47eb3b3e1e91544a40a9989fccf74154bbecac042dbbbf411a39090058b62c46fccd1d5eaba0c4879a688ea5fd0a7b4f9a0b4f01eda01930c6b22745a97f2d59e182598dfdfbfdb463335293901de7fc9d49cf55ed7fcf5d767d4c22f89f171b4137c8415c3ed438089270c41f88eadef3018140e1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBtwb8P0quW4baJhpm+85H6zs+HpFU\nSkCpmJ/M90FUu+ysBC27v0EaOQkAWLYsRvzNHV6roMSHmmiOpf0Ke0+aC08B7aAZ\nMMayJ0Wpfy1Z4YJZjf37/bRjM1KTkB3n/J1Jz1Xtf89ddn1MIvifFxtBN8hBXD7U\nOAiScMQfiOre8wGBQOE=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 372,
+          "tcId" : 475,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024200924449b6c96f3758e3b085c079714f11f28d039b11699f0e9b3e7c553c8fc6c8f5212fec5eac3068713b8ec72fc6e2a90872b94e161a89822887f4a9bd5c9efd74",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040058a1fa96111bf30be76c3b8ba4435666677b6dd05031b5c4a840e1ea81f6025f70e1d395ef63cb59fa71e3674cb678f7250887f5d734e3ec377dbe3ae637d24f82007a4eaf02cc57e658b5b9fa08ee30e0ef5b3429bb5a10438b0e05bacaebc60317010a334d7f896028aef620f5d9c7cabc38306e032b1b91c2376c3fef3e455a10df",
         "wx" : "58a1fa96111bf30be76c3b8ba4435666677b6dd05031b5c4a840e1ea81f6025f70e1d395ef63cb59fa71e3674cb678f7250887f5d734e3ec377dbe3ae637d24f82",
         "wy" : "7a4eaf02cc57e658b5b9fa08ee30e0ef5b3429bb5a10438b0e05bacaebc60317010a334d7f896028aef620f5d9c7cabc38306e032b1b91c2376c3fef3e455a10df"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040058a1fa96111bf30be76c3b8ba4435666677b6dd05031b5c4a840e1ea81f6025f70e1d395ef63cb59fa71e3674cb678f7250887f5d734e3ec377dbe3ae637d24f82007a4eaf02cc57e658b5b9fa08ee30e0ef5b3429bb5a10438b0e05bacaebc60317010a334d7f896028aef620f5d9c7cabc38306e032b1b91c2376c3fef3e455a10df",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAWKH6lhEb8wvnbDuLpENWZmd7bdBQ\nMbXEqEDh6oH2Al9w4dOV72PLWfpx42dMtnj3JQiH9dc04+w3fb465jfST4IAek6v\nAsxX5li1ufoI7jDg71s0KbtaEEOLDgW6yuvGAxcBCjNNf4lgKK72IPXZx8q8ODBu\nAysbkcI3bD/vPkVaEN8=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040058a1fa96111bf30be76c3b8ba4435666677b6dd05031b5c4a840e1ea81f6025f70e1d395ef63cb59fa71e3674cb678f7250887f5d734e3ec377dbe3ae637d24f82007a4eaf02cc57e658b5b9fa08ee30e0ef5b3429bb5a10438b0e05bacaebc60317010a334d7f896028aef620f5d9c7cabc38306e032b1b91c2376c3fef3e455a10df",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAWKH6lhEb8wvnbDuLpENWZmd7bdBQ\nMbXEqEDh6oH2Al9w4dOV72PLWfpx42dMtnj3JQiH9dc04+w3fb465jfST4IAek6v\nAsxX5li1ufoI7jDg71s0KbtaEEOLDgW6yuvGAxcBCjNNf4lgKK72IPXZx8q8ODBu\nAysbkcI3bD/vPkVaEN8=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 373,
+          "tcId" : 476,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024201554a01552b58d67a13468d6bc6086329e09e5dbf28a11dccbf91ccc6e2a4cfd4e6a2c5278791c6490835a27b6f7abb8a690bb060de3deb85093d3ae16482c84f64",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400303ba5ef90b05110002fdf74d2b8d4c7ab189c64004859c69d7c4730fcacb5f4d9b761ae987d1f3b63bb3ecb78aeecf4a04ff60f5f367a96ac2da8da27a3687a3e006673d0d4ccd4c3ce1abc9980fd1885002c3e7b86078214caf7f0962fa51e116363032d7a1b93c92a4d62827549d5a33e4e6b9b6c2ab6ad9c2a15e410c5b1a846b2",
         "wx" : "303ba5ef90b05110002fdf74d2b8d4c7ab189c64004859c69d7c4730fcacb5f4d9b761ae987d1f3b63bb3ecb78aeecf4a04ff60f5f367a96ac2da8da27a3687a3e",
         "wy" : "6673d0d4ccd4c3ce1abc9980fd1885002c3e7b86078214caf7f0962fa51e116363032d7a1b93c92a4d62827549d5a33e4e6b9b6c2ab6ad9c2a15e410c5b1a846b2"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400303ba5ef90b05110002fdf74d2b8d4c7ab189c64004859c69d7c4730fcacb5f4d9b761ae987d1f3b63bb3ecb78aeecf4a04ff60f5f367a96ac2da8da27a3687a3e006673d0d4ccd4c3ce1abc9980fd1885002c3e7b86078214caf7f0962fa51e116363032d7a1b93c92a4d62827549d5a33e4e6b9b6c2ab6ad9c2a15e410c5b1a846b2",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAMDul75CwURAAL9900rjUx6sYnGQA\nSFnGnXxHMPystfTZt2GumH0fO2O7Pst4ruz0oE/2D182epasLajaJ6Noej4AZnPQ\n1MzUw84avJmA/RiFACw+e4YHghTK9/CWL6UeEWNjAy16G5PJKk1ignVJ1aM+Tmub\nbCq2rZwqFeQQxbGoRrI=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400303ba5ef90b05110002fdf74d2b8d4c7ab189c64004859c69d7c4730fcacb5f4d9b761ae987d1f3b63bb3ecb78aeecf4a04ff60f5f367a96ac2da8da27a3687a3e006673d0d4ccd4c3ce1abc9980fd1885002c3e7b86078214caf7f0962fa51e116363032d7a1b93c92a4d62827549d5a33e4e6b9b6c2ab6ad9c2a15e410c5b1a846b2",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAMDul75CwURAAL9900rjUx6sYnGQA\nSFnGnXxHMPystfTZt2GumH0fO2O7Pst4ruz0oE/2D182epasLajaJ6Noej4AZnPQ\n1MzUw84avJmA/RiFACw+e4YHghTK9/CWL6UeEWNjAy16G5PJKk1ignVJ1aM+Tmub\nbCq2rZwqFeQQxbGoRrI=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 374,
+          "tcId" : 477,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024200aa9402aa56b1acf4268d1ad78c10c653c13cbb7e51423b997f23998dc5499fa9d2f403c78b645cfba4eb78f595fe6d6f01dbaaf803f23ac263bf060baa74583abf",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400a94eea843a5c49637041598e30c381f7173bf8cd127f3caf5c16cbc728aa4d99173fb38d6a1b1ec21e40336e8d802249272b0ccbf4f8c3636ef66290a81b58fa5b01116c23464fad61df8d2d5d1250a5a4c427e9c58e2cf1d059cdd88a7c34984fdd22a4cf18411e1b0224d444a5bd39d5fc97fc0b3648600f19d6ab80aa6a7c083a17",
-        "wx" : "0a94eea843a5c49637041598e30c381f7173bf8cd127f3caf5c16cbc728aa4d99173fb38d6a1b1ec21e40336e8d802249272b0ccbf4f8c3636ef66290a81b58fa5b",
-        "wy" : "1116c23464fad61df8d2d5d1250a5a4c427e9c58e2cf1d059cdd88a7c34984fdd22a4cf18411e1b0224d444a5bd39d5fc97fc0b3648600f19d6ab80aa6a7c083a17"
+        "wx" : "00a94eea843a5c49637041598e30c381f7173bf8cd127f3caf5c16cbc728aa4d99173fb38d6a1b1ec21e40336e8d802249272b0ccbf4f8c3636ef66290a81b58fa5b",
+        "wy" : "01116c23464fad61df8d2d5d1250a5a4c427e9c58e2cf1d059cdd88a7c34984fdd22a4cf18411e1b0224d444a5bd39d5fc97fc0b3648600f19d6ab80aa6a7c083a17"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400a94eea843a5c49637041598e30c381f7173bf8cd127f3caf5c16cbc728aa4d99173fb38d6a1b1ec21e40336e8d802249272b0ccbf4f8c3636ef66290a81b58fa5b01116c23464fad61df8d2d5d1250a5a4c427e9c58e2cf1d059cdd88a7c34984fdd22a4cf18411e1b0224d444a5bd39d5fc97fc0b3648600f19d6ab80aa6a7c083a17",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAqU7qhDpcSWNwQVmOMMOB9xc7+M0S\nfzyvXBbLxyiqTZkXP7ONahsewh5AM26NgCJJJysMy/T4w2Nu9mKQqBtY+lsBEWwj\nRk+tYd+NLV0SUKWkxCfpxY4s8dBZzdiKfDSYT90ipM8YQR4bAiTURKW9OdX8l/wL\nNkhgDxnWq4CqanwIOhc=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400a94eea843a5c49637041598e30c381f7173bf8cd127f3caf5c16cbc728aa4d99173fb38d6a1b1ec21e40336e8d802249272b0ccbf4f8c3636ef66290a81b58fa5b01116c23464fad61df8d2d5d1250a5a4c427e9c58e2cf1d059cdd88a7c34984fdd22a4cf18411e1b0224d444a5bd39d5fc97fc0b3648600f19d6ab80aa6a7c083a17",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAqU7qhDpcSWNwQVmOMMOB9xc7+M0S\nfzyvXBbLxyiqTZkXP7ONahsewh5AM26NgCJJJysMy/T4w2Nu9mKQqBtY+lsBEWwj\nRk+tYd+NLV0SUKWkxCfpxY4s8dBZzdiKfDSYT90ipM8YQR4bAiTURKW9OdX8l/wL\nNkhgDxnWq4CqanwIOhc=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 375,
+          "tcId" : 478,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024201ffde03ff820a836e39d3a8435219297da1db193d79e359663eb56654a7ee6f7eb996c8ef12f62344ad211b71057928f96ae75b58e23026476cfc40ed0ef7208a23",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04014f71d2ca5bd2051336854657f09a1fab14c7f2f7865d71bd3fa354bf27b69dc8738972140553b525658b6fd203cc05ca0822e0904bad21b632e0de74a2ad3f0e72004525f90519f9497425460b31cbb69ab3701a9ea68aaab72c6d65d364d0f0ed4d0524280f113bd69ef1ba9825202b10287a088c4bf30debecb720ac0739ec67434d",
-        "wx" : "14f71d2ca5bd2051336854657f09a1fab14c7f2f7865d71bd3fa354bf27b69dc8738972140553b525658b6fd203cc05ca0822e0904bad21b632e0de74a2ad3f0e72",
+        "wx" : "014f71d2ca5bd2051336854657f09a1fab14c7f2f7865d71bd3fa354bf27b69dc8738972140553b525658b6fd203cc05ca0822e0904bad21b632e0de74a2ad3f0e72",
         "wy" : "4525f90519f9497425460b31cbb69ab3701a9ea68aaab72c6d65d364d0f0ed4d0524280f113bd69ef1ba9825202b10287a088c4bf30debecb720ac0739ec67434d"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004014f71d2ca5bd2051336854657f09a1fab14c7f2f7865d71bd3fa354bf27b69dc8738972140553b525658b6fd203cc05ca0822e0904bad21b632e0de74a2ad3f0e72004525f90519f9497425460b31cbb69ab3701a9ea68aaab72c6d65d364d0f0ed4d0524280f113bd69ef1ba9825202b10287a088c4bf30debecb720ac0739ec67434d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBT3HSylvSBRM2hUZX8JofqxTH8veG\nXXG9P6NUvye2nchziXIUBVO1JWWLb9IDzAXKCCLgkEutIbYy4N50oq0/DnIARSX5\nBRn5SXQlRgsxy7aas3AanqaKqrcsbWXTZNDw7U0FJCgPETvWnvG6mCUgKxAoegiM\nS/MN6+y3IKwHOexnQ00=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004014f71d2ca5bd2051336854657f09a1fab14c7f2f7865d71bd3fa354bf27b69dc8738972140553b525658b6fd203cc05ca0822e0904bad21b632e0de74a2ad3f0e72004525f90519f9497425460b31cbb69ab3701a9ea68aaab72c6d65d364d0f0ed4d0524280f113bd69ef1ba9825202b10287a088c4bf30debecb720ac0739ec67434d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBT3HSylvSBRM2hUZX8JofqxTH8veG\nXXG9P6NUvye2nchziXIUBVO1JWWLb9IDzAXKCCLgkEutIbYy4N50oq0/DnIARSX5\nBRn5SXQlRgsxy7aas3AanqaKqrcsbWXTZNDw7U0FJCgPETvWnvG6mCUgKxAoegiM\nS/MN6+y3IKwHOexnQ00=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 376,
+          "tcId" : 479,
           "comment" : "edge case for u1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0242013375abb99e0cd3801e7c12993cfe720c83de278938a9e22bb6ea40a7c599ad05a5d3c8e5e5d7b3e16a99e528ef0ce91be0953cb1a9adf757f257554ca47ab053dc",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401d2ecad921dd100a8dc1a7b824b0ac6c9b654ab179833c2881ce237f1b8497ade851302cf50ea5ea169c2a50c0c09cb6ea539a7290a0f3437044b7a2e9ca8d40500003fd5651535dcba1f331981c216a1c7d9842f65c5f38ca43dd71c41e19efcac384617656fd0afdd83c50c5e524e9b672b7aa8a66b289afa688e45ca6edb3477a8b0",
-        "wx" : "1d2ecad921dd100a8dc1a7b824b0ac6c9b654ab179833c2881ce237f1b8497ade851302cf50ea5ea169c2a50c0c09cb6ea539a7290a0f3437044b7a2e9ca8d40500",
+        "wx" : "01d2ecad921dd100a8dc1a7b824b0ac6c9b654ab179833c2881ce237f1b8497ade851302cf50ea5ea169c2a50c0c09cb6ea539a7290a0f3437044b7a2e9ca8d40500",
         "wy" : "3fd5651535dcba1f331981c216a1c7d9842f65c5f38ca43dd71c41e19efcac384617656fd0afdd83c50c5e524e9b672b7aa8a66b289afa688e45ca6edb3477a8b0"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401d2ecad921dd100a8dc1a7b824b0ac6c9b654ab179833c2881ce237f1b8497ade851302cf50ea5ea169c2a50c0c09cb6ea539a7290a0f3437044b7a2e9ca8d40500003fd5651535dcba1f331981c216a1c7d9842f65c5f38ca43dd71c41e19efcac384617656fd0afdd83c50c5e524e9b672b7aa8a66b289afa688e45ca6edb3477a8b0",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB0uytkh3RAKjcGnuCSwrGybZUqxeY\nM8KIHOI38bhJet6FEwLPUOpeoWnCpQwMCctupTmnKQoPNDcES3ounKjUBQAAP9Vl\nFTXcuh8zGYHCFqHH2YQvZcXzjKQ91xxB4Z78rDhGF2Vv0K/dg8UMXlJOm2creqim\nayia+miORcpu2zR3qLA=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401d2ecad921dd100a8dc1a7b824b0ac6c9b654ab179833c2881ce237f1b8497ade851302cf50ea5ea169c2a50c0c09cb6ea539a7290a0f3437044b7a2e9ca8d40500003fd5651535dcba1f331981c216a1c7d9842f65c5f38ca43dd71c41e19efcac384617656fd0afdd83c50c5e524e9b672b7aa8a66b289afa688e45ca6edb3477a8b0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB0uytkh3RAKjcGnuCSwrGybZUqxeY\nM8KIHOI38bhJet6FEwLPUOpeoWnCpQwMCctupTmnKQoPNDcES3ounKjUBQAAP9Vl\nFTXcuh8zGYHCFqHH2YQvZcXzjKQ91xxB4Z78rDhGF2Vv0K/dg8UMXlJOm2creqim\nayia+miORcpu2zR3qLA=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 377,
+          "tcId" : 480,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308187024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc02415555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555555554",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040165d67972a48fddc2f41c03f79ab5e0d42fd0992c013ead135c3394049645e26ad7c7be96510df59ba677dc94f1146e8e8e8fbe56debcb66920639581956b92b4d1008aeb66ee0be18abaa909a973c70b5749d688f8e2cd2e6e1613af93d0033492d26a6e82cfb80ac6925ac6bc79b984f73e3ebbff2f223a38676891c1ecd784a8a789",
-        "wx" : "165d67972a48fddc2f41c03f79ab5e0d42fd0992c013ead135c3394049645e26ad7c7be96510df59ba677dc94f1146e8e8e8fbe56debcb66920639581956b92b4d1",
-        "wy" : "08aeb66ee0be18abaa909a973c70b5749d688f8e2cd2e6e1613af93d0033492d26a6e82cfb80ac6925ac6bc79b984f73e3ebbff2f223a38676891c1ecd784a8a789"
+        "wx" : "0165d67972a48fddc2f41c03f79ab5e0d42fd0992c013ead135c3394049645e26ad7c7be96510df59ba677dc94f1146e8e8e8fbe56debcb66920639581956b92b4d1",
+        "wy" : "008aeb66ee0be18abaa909a973c70b5749d688f8e2cd2e6e1613af93d0033492d26a6e82cfb80ac6925ac6bc79b984f73e3ebbff2f223a38676891c1ecd784a8a789"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040165d67972a48fddc2f41c03f79ab5e0d42fd0992c013ead135c3394049645e26ad7c7be96510df59ba677dc94f1146e8e8e8fbe56debcb66920639581956b92b4d1008aeb66ee0be18abaa909a973c70b5749d688f8e2cd2e6e1613af93d0033492d26a6e82cfb80ac6925ac6bc79b984f73e3ebbff2f223a38676891c1ecd784a8a789",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBZdZ5cqSP3cL0HAP3mrXg1C/QmSwB\nPq0TXDOUBJZF4mrXx76WUQ31m6Z33JTxFG6Ojo++Vt68tmkgY5WBlWuStNEAiutm\n7gvhirqpCalzxwtXSdaI+OLNLm4WE6+T0AM0ktJqboLPuArGklrGvHm5hPc+Prv/\nLyI6OGdokcHs14Sop4k=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040165d67972a48fddc2f41c03f79ab5e0d42fd0992c013ead135c3394049645e26ad7c7be96510df59ba677dc94f1146e8e8e8fbe56debcb66920639581956b92b4d1008aeb66ee0be18abaa909a973c70b5749d688f8e2cd2e6e1613af93d0033492d26a6e82cfb80ac6925ac6bc79b984f73e3ebbff2f223a38676891c1ecd784a8a789",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBZdZ5cqSP3cL0HAP3mrXg1C/QmSwB\nPq0TXDOUBJZF4mrXx76WUQ31m6Z33JTxFG6Ojo++Vt68tmkgY5WBlWuStNEAiutm\n7gvhirqpCalzxwtXSdaI+OLNLm4WE6+T0AM0ktJqboLPuArGklrGvHm5hPc+Prv/\nLyI6OGdokcHs14Sop4k=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 378,
+          "tcId" : 481,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0242009f57708fa97eba94c6d4782cdd4e33bb95c1353bde095232e3e2bab277bb5d2b48f55a53ffe928d034c29970a9e5f384a003907d3d9b82a86817cc61fb17f4c59e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04018cd11252f0a434f446d3af18518c6b84cb0b7bf33758b4d83b97c2a56e0037b54d57d2b0b842e9c17d70504e01896389c066db8f2bfec025259a51dff51466830801cca54365156c59e2c73c17664f09fcdcfd5b910f9ab48d0899b6a7064de8b80fc7a992e47ee7f23ec82fd80179a19f4cf89b4c02b7218f435298da5d322a982c1e",
-        "wx" : "18cd11252f0a434f446d3af18518c6b84cb0b7bf33758b4d83b97c2a56e0037b54d57d2b0b842e9c17d70504e01896389c066db8f2bfec025259a51dff514668308",
-        "wy" : "1cca54365156c59e2c73c17664f09fcdcfd5b910f9ab48d0899b6a7064de8b80fc7a992e47ee7f23ec82fd80179a19f4cf89b4c02b7218f435298da5d322a982c1e"
+        "wx" : "018cd11252f0a434f446d3af18518c6b84cb0b7bf33758b4d83b97c2a56e0037b54d57d2b0b842e9c17d70504e01896389c066db8f2bfec025259a51dff514668308",
+        "wy" : "01cca54365156c59e2c73c17664f09fcdcfd5b910f9ab48d0899b6a7064de8b80fc7a992e47ee7f23ec82fd80179a19f4cf89b4c02b7218f435298da5d322a982c1e"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004018cd11252f0a434f446d3af18518c6b84cb0b7bf33758b4d83b97c2a56e0037b54d57d2b0b842e9c17d70504e01896389c066db8f2bfec025259a51dff51466830801cca54365156c59e2c73c17664f09fcdcfd5b910f9ab48d0899b6a7064de8b80fc7a992e47ee7f23ec82fd80179a19f4cf89b4c02b7218f435298da5d322a982c1e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBjNESUvCkNPRG068YUYxrhMsLe/M3\nWLTYO5fCpW4AN7VNV9KwuELpwX1wUE4BiWOJwGbbjyv+wCUlmlHf9RRmgwgBzKVD\nZRVsWeLHPBdmTwn83P1bkQ+atI0ImbanBk3ouA/HqZLkfufyPsgv2AF5oZ9M+JtM\nArchj0NSmNpdMiqYLB4=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004018cd11252f0a434f446d3af18518c6b84cb0b7bf33758b4d83b97c2a56e0037b54d57d2b0b842e9c17d70504e01896389c066db8f2bfec025259a51dff51466830801cca54365156c59e2c73c17664f09fcdcfd5b910f9ab48d0899b6a7064de8b80fc7a992e47ee7f23ec82fd80179a19f4cf89b4c02b7218f435298da5d322a982c1e",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBjNESUvCkNPRG068YUYxrhMsLe/M3\nWLTYO5fCpW4AN7VNV9KwuELpwX1wUE4BiWOJwGbbjyv+wCUlmlHf9RRmgwgBzKVD\nZRVsWeLHPBdmTwn83P1bkQ+atI0ImbanBk3ouA/HqZLkfufyPsgv2AF5oZ9M+JtM\nArchj0NSmNpdMiqYLB4=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 379,
+          "tcId" : 482,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308187024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024168d98fa90736eff3e90f8fcfe50838b6fa0bf2cde77bc51e3f41019c8006f4e9cbaeadce7dbb44462da6425be9cfdaecb234c41749ce695be1b5ead2e6b1205f35",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401d6329a8afdea27cf1028a44d19c3c72927590d64628775f324514c81de301aa9be9c775c53a6349d1cbd5ecfc7bd39b373e613a10c1439441b141430fdadac168c00071342d63dba901b93bdc444a1fe2ec6a15108bdf49eb1dfd218373884520d84bce03c5012f5837051cb8abf6a0be78dfdfeeb3a5872dff75b3f874faa6d2243bf",
-        "wx" : "1d6329a8afdea27cf1028a44d19c3c72927590d64628775f324514c81de301aa9be9c775c53a6349d1cbd5ecfc7bd39b373e613a10c1439441b141430fdadac168c",
-        "wy" : "71342d63dba901b93bdc444a1fe2ec6a15108bdf49eb1dfd218373884520d84bce03c5012f5837051cb8abf6a0be78dfdfeeb3a5872dff75b3f874faa6d2243bf"
+        "wx" : "01d6329a8afdea27cf1028a44d19c3c72927590d64628775f324514c81de301aa9be9c775c53a6349d1cbd5ecfc7bd39b373e613a10c1439441b141430fdadac168c",
+        "wy" : "071342d63dba901b93bdc444a1fe2ec6a15108bdf49eb1dfd218373884520d84bce03c5012f5837051cb8abf6a0be78dfdfeeb3a5872dff75b3f874faa6d2243bf"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401d6329a8afdea27cf1028a44d19c3c72927590d64628775f324514c81de301aa9be9c775c53a6349d1cbd5ecfc7bd39b373e613a10c1439441b141430fdadac168c00071342d63dba901b93bdc444a1fe2ec6a15108bdf49eb1dfd218373884520d84bce03c5012f5837051cb8abf6a0be78dfdfeeb3a5872dff75b3f874faa6d2243bf",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB1jKaiv3qJ88QKKRNGcPHKSdZDWRi\nh3XzJFFMgd4wGqm+nHdcU6Y0nRy9Xs/HvTmzc+YToQwUOUQbFBQw/a2sFowABxNC\n1j26kBuTvcREof4uxqFRCL30nrHf0hg3OIRSDYS84DxQEvWDcFHLir9qC+eN/f7r\nOlhy3/dbP4dPqm0iQ78=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401d6329a8afdea27cf1028a44d19c3c72927590d64628775f324514c81de301aa9be9c775c53a6349d1cbd5ecfc7bd39b373e613a10c1439441b141430fdadac168c00071342d63dba901b93bdc444a1fe2ec6a15108bdf49eb1dfd218373884520d84bce03c5012f5837051cb8abf6a0be78dfdfeeb3a5872dff75b3f874faa6d2243bf",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB1jKaiv3qJ88QKKRNGcPHKSdZDWRi\nh3XzJFFMgd4wGqm+nHdcU6Y0nRy9Xs/HvTmzc+YToQwUOUQbFBQw/a2sFowABxNC\n1j26kBuTvcREof4uxqFRCL30nrHf0hg3OIRSDYS84DxQEvWDcFHLir9qC+eN/f7r\nOlhy3/dbP4dPqm0iQ78=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 380,
+          "tcId" : 483,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024200e97ae66bcd4cae36fffffffffffffffffffffffffffffffffffffffffffffffffd68bc9726f02dbf8598a98b3e5077eff6f2491eb678ed040fb338c084a9ea8a4c",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401c963b64cdc3ecb1c35cda5ced9419ac146b060adb04c638cf6b66658013cb25e915a6ad0055668342881ed27f438b50ae4bb86ae3c7c02b727a130c77bad69800800481bfffaead856b4137fd4268ecd74a6c2d4bd6cd13998ce7f0e828b220135d8df23253e681dc90673e0537e7590769a2a441aaaaa3a9901c4fbe44fa9513951ef",
-        "wx" : "1c963b64cdc3ecb1c35cda5ced9419ac146b060adb04c638cf6b66658013cb25e915a6ad0055668342881ed27f438b50ae4bb86ae3c7c02b727a130c77bad698008",
+        "wx" : "01c963b64cdc3ecb1c35cda5ced9419ac146b060adb04c638cf6b66658013cb25e915a6ad0055668342881ed27f438b50ae4bb86ae3c7c02b727a130c77bad698008",
         "wy" : "481bfffaead856b4137fd4268ecd74a6c2d4bd6cd13998ce7f0e828b220135d8df23253e681dc90673e0537e7590769a2a441aaaaa3a9901c4fbe44fa9513951ef"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401c963b64cdc3ecb1c35cda5ced9419ac146b060adb04c638cf6b66658013cb25e915a6ad0055668342881ed27f438b50ae4bb86ae3c7c02b727a130c77bad69800800481bfffaead856b4137fd4268ecd74a6c2d4bd6cd13998ce7f0e828b220135d8df23253e681dc90673e0537e7590769a2a441aaaaa3a9901c4fbe44fa9513951ef",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQByWO2TNw+yxw1zaXO2UGawUawYK2w\nTGOM9rZmWAE8sl6RWmrQBVZoNCiB7Sf0OLUK5LuGrjx8ArcnoTDHe61pgAgASBv/\n+urYVrQTf9Qmjs10psLUvWzROZjOfw6CiyIBNdjfIyU+aB3JBnPgU351kHaaKkQa\nqqo6mQHE++RPqVE5Ue8=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401c963b64cdc3ecb1c35cda5ced9419ac146b060adb04c638cf6b66658013cb25e915a6ad0055668342881ed27f438b50ae4bb86ae3c7c02b727a130c77bad69800800481bfffaead856b4137fd4268ecd74a6c2d4bd6cd13998ce7f0e828b220135d8df23253e681dc90673e0537e7590769a2a441aaaaa3a9901c4fbe44fa9513951ef",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQByWO2TNw+yxw1zaXO2UGawUawYK2w\nTGOM9rZmWAE8sl6RWmrQBVZoNCiB7Sf0OLUK5LuGrjx8ArcnoTDHe61pgAgASBv/\n+urYVrQTf9Qmjs10psLUvWzROZjOfw6CiyIBNdjfIyU+aB3JBnPgU351kHaaKkQa\nqqo6mQHE++RPqVE5Ue8=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 381,
+          "tcId" : 484,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024201ae66bcd4cae36ffffffffffffffffffffffffffffffffffffffffffffffffffffb3954212f8bea578d93e685e5dba329811b2542bb398233e2944bceb19263325d",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04005dfbc867d53c57b2945502b8e56d96ca2d4d485aa33452200a2f4ba16042357976afeecf3e63b2fdcd5cdd76076c1a73e496caf9d6de3e8831d955d138e05884ae01e04aa0b5360a0d3badd0120fbb8cc42a38bf1c61755d00858e40e4b10da4ea2575830dc92e312c20af2b8b167d7a58d178661d48cd932fe47a4bc7145e620ae22c",
         "wx" : "5dfbc867d53c57b2945502b8e56d96ca2d4d485aa33452200a2f4ba16042357976afeecf3e63b2fdcd5cdd76076c1a73e496caf9d6de3e8831d955d138e05884ae",
-        "wy" : "1e04aa0b5360a0d3badd0120fbb8cc42a38bf1c61755d00858e40e4b10da4ea2575830dc92e312c20af2b8b167d7a58d178661d48cd932fe47a4bc7145e620ae22c"
+        "wy" : "01e04aa0b5360a0d3badd0120fbb8cc42a38bf1c61755d00858e40e4b10da4ea2575830dc92e312c20af2b8b167d7a58d178661d48cd932fe47a4bc7145e620ae22c"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004005dfbc867d53c57b2945502b8e56d96ca2d4d485aa33452200a2f4ba16042357976afeecf3e63b2fdcd5cdd76076c1a73e496caf9d6de3e8831d955d138e05884ae01e04aa0b5360a0d3badd0120fbb8cc42a38bf1c61755d00858e40e4b10da4ea2575830dc92e312c20af2b8b167d7a58d178661d48cd932fe47a4bc7145e620ae22c",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAXfvIZ9U8V7KUVQK45W2Wyi1NSFqj\nNFIgCi9LoWBCNXl2r+7PPmOy/c1c3XYHbBpz5JbK+dbePogx2VXROOBYhK4B4Eqg\ntTYKDTut0BIPu4zEKji/HGF1XQCFjkDksQ2k6iV1gw3JLjEsIK8rixZ9eljReGYd\nSM2TL+R6S8cUXmIK4iw=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004005dfbc867d53c57b2945502b8e56d96ca2d4d485aa33452200a2f4ba16042357976afeecf3e63b2fdcd5cdd76076c1a73e496caf9d6de3e8831d955d138e05884ae01e04aa0b5360a0d3badd0120fbb8cc42a38bf1c61755d00858e40e4b10da4ea2575830dc92e312c20af2b8b167d7a58d178661d48cd932fe47a4bc7145e620ae22c",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAXfvIZ9U8V7KUVQK45W2Wyi1NSFqj\nNFIgCi9LoWBCNXl2r+7PPmOy/c1c3XYHbBpz5JbK+dbePogx2VXROOBYhK4B4Eqg\ntTYKDTut0BIPu4zEKji/HGF1XQCFjkDksQ2k6iV1gw3JLjEsIK8rixZ9eljReGYd\nSM2TL+R6S8cUXmIK4iw=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 382,
+          "tcId" : 485,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0242015ccd79a995c6dffffffffffffffffffffffffffffffffffffffffffffffffffffc2121badb58a518afa8010a82c03cad31fa94bbbde96820166d27e644938e00b1",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040078be6c43e366cf63ddc4235e8b969386e95012fbca5cebf1b0a6fe3c03c1257df7cf47b002eb6c4497f310bff6131b5ccb54fd0e8ee7fcf6b49d487e1b54508f68009b61a547104c8516e0dc35d3d17659ca098d023b0593908fe979c29e62373738a3c30094ba47105a49edbc6e1d37cce317b49d2701470eeb53d9b24dce9d809166",
         "wx" : "78be6c43e366cf63ddc4235e8b969386e95012fbca5cebf1b0a6fe3c03c1257df7cf47b002eb6c4497f310bff6131b5ccb54fd0e8ee7fcf6b49d487e1b54508f68",
-        "wy" : "09b61a547104c8516e0dc35d3d17659ca098d023b0593908fe979c29e62373738a3c30094ba47105a49edbc6e1d37cce317b49d2701470eeb53d9b24dce9d809166"
+        "wy" : "009b61a547104c8516e0dc35d3d17659ca098d023b0593908fe979c29e62373738a3c30094ba47105a49edbc6e1d37cce317b49d2701470eeb53d9b24dce9d809166"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040078be6c43e366cf63ddc4235e8b969386e95012fbca5cebf1b0a6fe3c03c1257df7cf47b002eb6c4497f310bff6131b5ccb54fd0e8ee7fcf6b49d487e1b54508f68009b61a547104c8516e0dc35d3d17659ca098d023b0593908fe979c29e62373738a3c30094ba47105a49edbc6e1d37cce317b49d2701470eeb53d9b24dce9d809166",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAeL5sQ+Nmz2PdxCNei5aThulQEvvK\nXOvxsKb+PAPBJX33z0ewAutsRJfzEL/2Extcy1T9Do7n/Pa0nUh+G1RQj2gAm2Gl\nRxBMhRbg3DXT0XZZygmNAjsFk5CP6XnCnmI3NzijwwCUukcQWkntvG4dN8zjF7Sd\nJwFHDutT2bJNzp2AkWY=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040078be6c43e366cf63ddc4235e8b969386e95012fbca5cebf1b0a6fe3c03c1257df7cf47b002eb6c4497f310bff6131b5ccb54fd0e8ee7fcf6b49d487e1b54508f68009b61a547104c8516e0dc35d3d17659ca098d023b0593908fe979c29e62373738a3c30094ba47105a49edbc6e1d37cce317b49d2701470eeb53d9b24dce9d809166",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAeL5sQ+Nmz2PdxCNei5aThulQEvvK\nXOvxsKb+PAPBJX33z0ewAutsRJfzEL/2Extcy1T9Do7n/Pa0nUh+G1RQj2gAm2Gl\nRxBMhRbg3DXT0XZZygmNAjsFk5CP6XnCnmI3NzijwwCUukcQWkntvG4dN8zjF7Sd\nJwFHDutT2bJNzp2AkWY=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 383,
+          "tcId" : 486,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024201cd4cae36fffffffffffffffffffffffffffffffffffffffffffffffffffffffffae18dcc11dff7526233d923a0b202cb29e713f22de8bb6ab0a12821c5abbe3f23",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040093f68961005f3040dc1a8ff1416c917bdcc77f1dfa85506c3bb62dac47f7be9529b4cbe57dd2c19e860bd2a0db71d47ef1eca8a20bfc3e0bc5e05c8303001c1960002b9a3d45f2f5120fee06445f0d34e6138e3ac5b16d2a22f0460cea258c368ca9e478eb7b8253e7c6f2f7250fdc7dcd7243761f8d56f2350ac51e47ee063f41da31",
-        "wx" : "093f68961005f3040dc1a8ff1416c917bdcc77f1dfa85506c3bb62dac47f7be9529b4cbe57dd2c19e860bd2a0db71d47ef1eca8a20bfc3e0bc5e05c8303001c1960",
+        "wx" : "0093f68961005f3040dc1a8ff1416c917bdcc77f1dfa85506c3bb62dac47f7be9529b4cbe57dd2c19e860bd2a0db71d47ef1eca8a20bfc3e0bc5e05c8303001c1960",
         "wy" : "2b9a3d45f2f5120fee06445f0d34e6138e3ac5b16d2a22f0460cea258c368ca9e478eb7b8253e7c6f2f7250fdc7dcd7243761f8d56f2350ac51e47ee063f41da31"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040093f68961005f3040dc1a8ff1416c917bdcc77f1dfa85506c3bb62dac47f7be9529b4cbe57dd2c19e860bd2a0db71d47ef1eca8a20bfc3e0bc5e05c8303001c1960002b9a3d45f2f5120fee06445f0d34e6138e3ac5b16d2a22f0460cea258c368ca9e478eb7b8253e7c6f2f7250fdc7dcd7243761f8d56f2350ac51e47ee063f41da31",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAk/aJYQBfMEDcGo/xQWyRe9zHfx36\nhVBsO7YtrEf3vpUptMvlfdLBnoYL0qDbcdR+8eyoogv8PgvF4FyDAwAcGWAAK5o9\nRfL1Eg/uBkRfDTTmE446xbFtKiLwRgzqJYw2jKnkeOt7glPnxvL3JQ/cfc1yQ3Yf\njVbyNQrFHkfuBj9B2jE=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040093f68961005f3040dc1a8ff1416c917bdcc77f1dfa85506c3bb62dac47f7be9529b4cbe57dd2c19e860bd2a0db71d47ef1eca8a20bfc3e0bc5e05c8303001c1960002b9a3d45f2f5120fee06445f0d34e6138e3ac5b16d2a22f0460cea258c368ca9e478eb7b8253e7c6f2f7250fdc7dcd7243761f8d56f2350ac51e47ee063f41da31",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAk/aJYQBfMEDcGo/xQWyRe9zHfx36\nhVBsO7YtrEf3vpUptMvlfdLBnoYL0qDbcdR+8eyoogv8PgvF4FyDAwAcGWAAK5o9\nRfL1Eg/uBkRfDTTmE446xbFtKiLwRgzqJYw2jKnkeOt7glPnxvL3JQ/cfc1yQ3Yf\njVbyNQrFHkfuBj9B2jE=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 384,
+          "tcId" : 487,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308187024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024122e8ba2e8ba2e8ba2e8ba2e8ba2e8ba2e8ba2e8ba2e8ba2e8ba2e8ba2e8ba2e8b9c4c3f73cc816143fac3412b62de4c63db08f8c57e4c58c31f1b457ca5e57e20a",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04002d2d7d40bf17c4e8b18757e451ddded95e6b1007cd144809d21af31353b03038372c4af204d4414b71060b48b3a8439c632809bd33c4736263044405a1ad766e3600bb0c5a8848f93fa3e85376b012bf064e303746529a673b852bb5a969c24c0156a8dd26242d0aad4bae43e23631b01fb9d050f9744b59f3b52b1c572217a1d70588",
         "wx" : "2d2d7d40bf17c4e8b18757e451ddded95e6b1007cd144809d21af31353b03038372c4af204d4414b71060b48b3a8439c632809bd33c4736263044405a1ad766e36",
-        "wy" : "0bb0c5a8848f93fa3e85376b012bf064e303746529a673b852bb5a969c24c0156a8dd26242d0aad4bae43e23631b01fb9d050f9744b59f3b52b1c572217a1d70588"
+        "wy" : "00bb0c5a8848f93fa3e85376b012bf064e303746529a673b852bb5a969c24c0156a8dd26242d0aad4bae43e23631b01fb9d050f9744b59f3b52b1c572217a1d70588"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004002d2d7d40bf17c4e8b18757e451ddded95e6b1007cd144809d21af31353b03038372c4af204d4414b71060b48b3a8439c632809bd33c4736263044405a1ad766e3600bb0c5a8848f93fa3e85376b012bf064e303746529a673b852bb5a969c24c0156a8dd26242d0aad4bae43e23631b01fb9d050f9744b59f3b52b1c572217a1d70588",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQALS19QL8XxOixh1fkUd3e2V5rEAfN\nFEgJ0hrzE1OwMDg3LEryBNRBS3EGC0izqEOcYygJvTPEc2JjBEQFoa12bjYAuwxa\niEj5P6PoU3awEr8GTjA3RlKaZzuFK7WpacJMAVao3SYkLQqtS65D4jYxsB+50FD5\ndEtZ87UrHFciF6HXBYg=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004002d2d7d40bf17c4e8b18757e451ddded95e6b1007cd144809d21af31353b03038372c4af204d4414b71060b48b3a8439c632809bd33c4736263044405a1ad766e3600bb0c5a8848f93fa3e85376b012bf064e303746529a673b852bb5a969c24c0156a8dd26242d0aad4bae43e23631b01fb9d050f9744b59f3b52b1c572217a1d70588",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQALS19QL8XxOixh1fkUd3e2V5rEAfN\nFEgJ0hrzE1OwMDg3LEryBNRBS3EGC0izqEOcYygJvTPEc2JjBEQFoa12bjYAuwxa\niEj5P6PoU3awEr8GTjA3RlKaZzuFK7WpacJMAVao3SYkLQqtS65D4jYxsB+50FD5\ndEtZ87UrHFciF6HXBYg=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 385,
+          "tcId" : 488,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0242010590b21642c8590b21642c8590b21642c8590b21642c8590b21642c8590b2164298eb57e5aff9343597a542d3132f9e734fdc305125e0ec139c5f780ee8e8cb9c2",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04018ac11dfe62d1f2a8202732c79b423d29f43bec4db6080a220796a10f2685f92c71c7f72d9da0a8acb22680cca018eba2e8ba3bfde1db9a4ef3b97da16474364e96005aad3b286707bd3ad07a060cabca49c53de4f56c05a0a8de40fd969d7d4f995f7c6701fe5c5321f85318b98be66251fa490088fd727da2454e00b3b94dc6e1241b",
-        "wx" : "18ac11dfe62d1f2a8202732c79b423d29f43bec4db6080a220796a10f2685f92c71c7f72d9da0a8acb22680cca018eba2e8ba3bfde1db9a4ef3b97da16474364e96",
+        "wx" : "018ac11dfe62d1f2a8202732c79b423d29f43bec4db6080a220796a10f2685f92c71c7f72d9da0a8acb22680cca018eba2e8ba3bfde1db9a4ef3b97da16474364e96",
         "wy" : "5aad3b286707bd3ad07a060cabca49c53de4f56c05a0a8de40fd969d7d4f995f7c6701fe5c5321f85318b98be66251fa490088fd727da2454e00b3b94dc6e1241b"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004018ac11dfe62d1f2a8202732c79b423d29f43bec4db6080a220796a10f2685f92c71c7f72d9da0a8acb22680cca018eba2e8ba3bfde1db9a4ef3b97da16474364e96005aad3b286707bd3ad07a060cabca49c53de4f56c05a0a8de40fd969d7d4f995f7c6701fe5c5321f85318b98be66251fa490088fd727da2454e00b3b94dc6e1241b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBisEd/mLR8qggJzLHm0I9KfQ77E22\nCAoiB5ahDyaF+Sxxx/ctnaCorLImgMygGOui6Lo7/eHbmk7zuX2hZHQ2TpYAWq07\nKGcHvTrQegYMq8pJxT3k9WwFoKjeQP2WnX1PmV98ZwH+XFMh+FMYuYvmYlH6SQCI\n/XJ9okVOALO5TcbhJBs=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004018ac11dfe62d1f2a8202732c79b423d29f43bec4db6080a220796a10f2685f92c71c7f72d9da0a8acb22680cca018eba2e8ba3bfde1db9a4ef3b97da16474364e96005aad3b286707bd3ad07a060cabca49c53de4f56c05a0a8de40fd969d7d4f995f7c6701fe5c5321f85318b98be66251fa490088fd727da2454e00b3b94dc6e1241b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBisEd/mLR8qggJzLHm0I9KfQ77E22\nCAoiB5ahDyaF+Sxxx/ctnaCorLImgMygGOui6Lo7/eHbmk7zuX2hZHQ2TpYAWq07\nKGcHvTrQegYMq8pJxT3k9WwFoKjeQP2WnX1PmV98ZwH+XFMh+FMYuYvmYlH6SQCI\n/XJ9okVOALO5TcbhJBs=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 386,
+          "tcId" : 489,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024201a4924924924924924924924924924924924924924924924924924924924924924445e10670ed0437c9db4125ac4175fbd70e9bd1799a85f44ca0a8e61a3354e808",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040051b2c3e0494564ed48ed3479b596ea4078240550a3c28da33d71d259e8e623e37ab43f396c49363f31c8de8a4644d37e94ed80e0dd4f92c3df2106e2795c2798b800a530d5e961f0696bbeb962aca8e71f65956ae04cdc22a4ac65146943e99a4a2fdb477df75aa069c8dd37a5daaea3848079a6a7bc03e0faa3d65d42f8053db2078b",
         "wx" : "51b2c3e0494564ed48ed3479b596ea4078240550a3c28da33d71d259e8e623e37ab43f396c49363f31c8de8a4644d37e94ed80e0dd4f92c3df2106e2795c2798b8",
-        "wy" : "0a530d5e961f0696bbeb962aca8e71f65956ae04cdc22a4ac65146943e99a4a2fdb477df75aa069c8dd37a5daaea3848079a6a7bc03e0faa3d65d42f8053db2078b"
+        "wy" : "00a530d5e961f0696bbeb962aca8e71f65956ae04cdc22a4ac65146943e99a4a2fdb477df75aa069c8dd37a5daaea3848079a6a7bc03e0faa3d65d42f8053db2078b"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040051b2c3e0494564ed48ed3479b596ea4078240550a3c28da33d71d259e8e623e37ab43f396c49363f31c8de8a4644d37e94ed80e0dd4f92c3df2106e2795c2798b800a530d5e961f0696bbeb962aca8e71f65956ae04cdc22a4ac65146943e99a4a2fdb477df75aa069c8dd37a5daaea3848079a6a7bc03e0faa3d65d42f8053db2078b",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAUbLD4ElFZO1I7TR5tZbqQHgkBVCj\nwo2jPXHSWejmI+N6tD85bEk2PzHI3opGRNN+lO2A4N1PksPfIQbieVwnmLgApTDV\n6WHwaWu+uWKsqOcfZZVq4EzcIqSsZRRpQ+maSi/bR333WqBpyN03pdquo4SAeaan\nvAPg+qPWXUL4BT2yB4s=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040051b2c3e0494564ed48ed3479b596ea4078240550a3c28da33d71d259e8e623e37ab43f396c49363f31c8de8a4644d37e94ed80e0dd4f92c3df2106e2795c2798b800a530d5e961f0696bbeb962aca8e71f65956ae04cdc22a4ac65146943e99a4a2fdb477df75aa069c8dd37a5daaea3848079a6a7bc03e0faa3d65d42f8053db2078b",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAUbLD4ElFZO1I7TR5tZbqQHgkBVCj\nwo2jPXHSWejmI+N6tD85bEk2PzHI3opGRNN+lO2A4N1PksPfIQbieVwnmLgApTDV\n6WHwaWu+uWKsqOcfZZVq4EzcIqSsZRRpQ+maSi/bR333WqBpyN03pdquo4SAeaan\nvAPg+qPWXUL4BT2yB4s=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 387,
+          "tcId" : 490,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024201d5555555555555555555555555555555555555555555555555555555555555554fa6dbdcd91484ebc0d521569e4c5efb25910b1f0ddef19d0410c50c73e68db95f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401ba31a6f9c2d227da57de00759e2e844d607bc9bd92bcdf282006884dc347c9284f0dc0623af1e9db22117364a7a80a5b067efa19b204dac8faf2230d80b704addc00d88b761cd3a4b0947bfc17e204b4d751f76880a82c9b7c6fd93ded55883c995002d8b8bfff1e021189c08d829d16b088f4fb39ad9456eafbc77c20353bc0f3c038",
-        "wx" : "1ba31a6f9c2d227da57de00759e2e844d607bc9bd92bcdf282006884dc347c9284f0dc0623af1e9db22117364a7a80a5b067efa19b204dac8faf2230d80b704addc",
-        "wy" : "0d88b761cd3a4b0947bfc17e204b4d751f76880a82c9b7c6fd93ded55883c995002d8b8bfff1e021189c08d829d16b088f4fb39ad9456eafbc77c20353bc0f3c038"
+        "wx" : "01ba31a6f9c2d227da57de00759e2e844d607bc9bd92bcdf282006884dc347c9284f0dc0623af1e9db22117364a7a80a5b067efa19b204dac8faf2230d80b704addc",
+        "wy" : "00d88b761cd3a4b0947bfc17e204b4d751f76880a82c9b7c6fd93ded55883c995002d8b8bfff1e021189c08d829d16b088f4fb39ad9456eafbc77c20353bc0f3c038"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401ba31a6f9c2d227da57de00759e2e844d607bc9bd92bcdf282006884dc347c9284f0dc0623af1e9db22117364a7a80a5b067efa19b204dac8faf2230d80b704addc00d88b761cd3a4b0947bfc17e204b4d751f76880a82c9b7c6fd93ded55883c995002d8b8bfff1e021189c08d829d16b088f4fb39ad9456eafbc77c20353bc0f3c038",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBujGm+cLSJ9pX3gB1ni6ETWB7yb2S\nvN8oIAaITcNHyShPDcBiOvHp2yIRc2SnqApbBn76GbIE2sj68iMNgLcErdwA2It2\nHNOksJR7/BfiBLTXUfdogKgsm3xv2T3tVYg8mVAC2Li//x4CEYnAjYKdFrCI9Ps5\nrZRW6vvHfCA1O8DzwDg=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401ba31a6f9c2d227da57de00759e2e844d607bc9bd92bcdf282006884dc347c9284f0dc0623af1e9db22117364a7a80a5b067efa19b204dac8faf2230d80b704addc00d88b761cd3a4b0947bfc17e204b4d751f76880a82c9b7c6fd93ded55883c995002d8b8bfff1e021189c08d829d16b088f4fb39ad9456eafbc77c20353bc0f3c038",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBujGm+cLSJ9pX3gB1ni6ETWB7yb2S\nvN8oIAaITcNHyShPDcBiOvHp2yIRc2SnqApbBn76GbIE2sj68iMNgLcErdwA2It2\nHNOksJR7/BfiBLTXUfdogKgsm3xv2T3tVYg8mVAC2Li//x4CEYnAjYKdFrCI9Ps5\nrZRW6vvHfCA1O8DzwDg=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 388,
+          "tcId" : 491,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024201aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa4fc31322e69da41162a76abf3a1b4507ae66074633446f259661a61c93be30eb5",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040137bbb48ef281133849ed723f5662a19fff9cc7389a0170d311bd34f4dbdc656246db695ea0712d8aceff9d1d0ef7921ec2e3f8b533e4ca122f9f7f4460738893340163e4500d998095f60fa3fed4149d2d9b5b018e03eb5344efe8ffcc1c7d276e7401a4df639c4ab108820062495471be7b29398aadbae440a9bdcd55cf0bb5d96f79",
-        "wx" : "137bbb48ef281133849ed723f5662a19fff9cc7389a0170d311bd34f4dbdc656246db695ea0712d8aceff9d1d0ef7921ec2e3f8b533e4ca122f9f7f446073889334",
-        "wy" : "163e4500d998095f60fa3fed4149d2d9b5b018e03eb5344efe8ffcc1c7d276e7401a4df639c4ab108820062495471be7b29398aadbae440a9bdcd55cf0bb5d96f79"
+        "wx" : "0137bbb48ef281133849ed723f5662a19fff9cc7389a0170d311bd34f4dbdc656246db695ea0712d8aceff9d1d0ef7921ec2e3f8b533e4ca122f9f7f446073889334",
+        "wy" : "0163e4500d998095f60fa3fed4149d2d9b5b018e03eb5344efe8ffcc1c7d276e7401a4df639c4ab108820062495471be7b29398aadbae440a9bdcd55cf0bb5d96f79"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040137bbb48ef281133849ed723f5662a19fff9cc7389a0170d311bd34f4dbdc656246db695ea0712d8aceff9d1d0ef7921ec2e3f8b533e4ca122f9f7f4460738893340163e4500d998095f60fa3fed4149d2d9b5b018e03eb5344efe8ffcc1c7d276e7401a4df639c4ab108820062495471be7b29398aadbae440a9bdcd55cf0bb5d96f79",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBN7u0jvKBEzhJ7XI/VmKhn/+cxzia\nAXDTEb009NvcZWJG22leoHEtis7/nR0O95IewuP4tTPkyhIvn39EYHOIkzQBY+RQ\nDZmAlfYPo/7UFJ0tm1sBjgPrU0Tv6P/MHH0nbnQBpN9jnEqxCIIAYklUcb57KTmK\nrbrkQKm9zVXPC7XZb3k=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040137bbb48ef281133849ed723f5662a19fff9cc7389a0170d311bd34f4dbdc656246db695ea0712d8aceff9d1d0ef7921ec2e3f8b533e4ca122f9f7f4460738893340163e4500d998095f60fa3fed4149d2d9b5b018e03eb5344efe8ffcc1c7d276e7401a4df639c4ab108820062495471be7b29398aadbae440a9bdcd55cf0bb5d96f79",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBN7u0jvKBEzhJ7XI/VmKhn/+cxzia\nAXDTEb009NvcZWJG22leoHEtis7/nR0O95IewuP4tTPkyhIvn39EYHOIkzQBY+RQ\nDZmAlfYPo/7UFJ0tm1sBjgPrU0Tv6P/MHH0nbnQBpN9jnEqxCIIAYklUcb57KTmK\nrbrkQKm9zVXPC7XZb3k=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 389,
+          "tcId" : 492,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc0242017ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffa51868783bf2f966b7fcc0148f709a5d03bb5c9b8899c47aebb6fb71e9138640b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400726dda8b7b6ed25f97f1fc6c3ccf554d60fc71e4fab2a578286d32612e7f3e669faed0b97619aef2d5aff9c8ffd987feddc0d6c38b7eec028191400874803f498b00c0b8870c612e06c13c57ed6f7ef3d53b5e5fa2db62707b034b5ec13fb47018e31da7ecc991d575943468d701e118eca33122cf6d394b8a6ec0f45bc09701603a26",
         "wx" : "726dda8b7b6ed25f97f1fc6c3ccf554d60fc71e4fab2a578286d32612e7f3e669faed0b97619aef2d5aff9c8ffd987feddc0d6c38b7eec028191400874803f498b",
-        "wy" : "0c0b8870c612e06c13c57ed6f7ef3d53b5e5fa2db62707b034b5ec13fb47018e31da7ecc991d575943468d701e118eca33122cf6d394b8a6ec0f45bc09701603a26"
+        "wy" : "00c0b8870c612e06c13c57ed6f7ef3d53b5e5fa2db62707b034b5ec13fb47018e31da7ecc991d575943468d701e118eca33122cf6d394b8a6ec0f45bc09701603a26"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400726dda8b7b6ed25f97f1fc6c3ccf554d60fc71e4fab2a578286d32612e7f3e669faed0b97619aef2d5aff9c8ffd987feddc0d6c38b7eec028191400874803f498b00c0b8870c612e06c13c57ed6f7ef3d53b5e5fa2db62707b034b5ec13fb47018e31da7ecc991d575943468d701e118eca33122cf6d394b8a6ec0f45bc09701603a26",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAcm3ai3tu0l+X8fxsPM9VTWD8ceT6\nsqV4KG0yYS5/PmafrtC5dhmu8tWv+cj/2Yf+3cDWw4t+7AKBkUAIdIA/SYsAwLiH\nDGEuBsE8V+1vfvPVO15fotticHsDS17BP7RwGOMdp+zJkdV1lDRo1wHhGOyjMSLP\nbTlLim7A9FvAlwFgOiY=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400726dda8b7b6ed25f97f1fc6c3ccf554d60fc71e4fab2a578286d32612e7f3e669faed0b97619aef2d5aff9c8ffd987feddc0d6c38b7eec028191400874803f498b00c0b8870c612e06c13c57ed6f7ef3d53b5e5fa2db62707b034b5ec13fb47018e31da7ecc991d575943468d701e118eca33122cf6d394b8a6ec0f45bc09701603a26",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAcm3ai3tu0l+X8fxsPM9VTWD8ceT6\nsqV4KG0yYS5/PmafrtC5dhmu8tWv+cj/2Yf+3cDWw4t+7AKBkUAIdIA/SYsAwLiH\nDGEuBsE8V+1vfvPVO15fotticHsDS17BP7RwGOMdp+zJkdV1lDRo1wHhGOyjMSLP\nbTlLim7A9FvAlwFgOiY=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 390,
+          "tcId" : 493,
           "comment" : "edge case for u2",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffc024201346cc7d4839b77f9f487c7e7f2841c5b7d05f966f3bde28f1fa080ce40037a74e3001a2b00bd39ee4c93072e9963724941383cf0812c02d1c838ad4502a12c619f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04016fce9f375bbd2968adaaf3575595129ef3e721c3b7c83d5a4a79f4b5dfbbdb1f66da7243e5120c5dbd7be1ca073e04b4cc58ca8ce2f34ff6a3d02a929bf2fc27970083f130792d6c45c8f2a67471e51246e2b8781465b8291cbda66d22719cd536bf801e0076030919d5701732ce7678bf472846ed0777937ed77caad74d05664614a2",
-        "wx" : "16fce9f375bbd2968adaaf3575595129ef3e721c3b7c83d5a4a79f4b5dfbbdb1f66da7243e5120c5dbd7be1ca073e04b4cc58ca8ce2f34ff6a3d02a929bf2fc2797",
-        "wy" : "083f130792d6c45c8f2a67471e51246e2b8781465b8291cbda66d22719cd536bf801e0076030919d5701732ce7678bf472846ed0777937ed77caad74d05664614a2"
+        "wx" : "016fce9f375bbd2968adaaf3575595129ef3e721c3b7c83d5a4a79f4b5dfbbdb1f66da7243e5120c5dbd7be1ca073e04b4cc58ca8ce2f34ff6a3d02a929bf2fc2797",
+        "wy" : "0083f130792d6c45c8f2a67471e51246e2b8781465b8291cbda66d22719cd536bf801e0076030919d5701732ce7678bf472846ed0777937ed77caad74d05664614a2"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004016fce9f375bbd2968adaaf3575595129ef3e721c3b7c83d5a4a79f4b5dfbbdb1f66da7243e5120c5dbd7be1ca073e04b4cc58ca8ce2f34ff6a3d02a929bf2fc27970083f130792d6c45c8f2a67471e51246e2b8781465b8291cbda66d22719cd536bf801e0076030919d5701732ce7678bf472846ed0777937ed77caad74d05664614a2",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBb86fN1u9KWitqvNXVZUSnvPnIcO3\nyD1aSnn0td+72x9m2nJD5RIMXb174coHPgS0zFjKjOLzT/aj0CqSm/L8J5cAg/Ew\neS1sRcjypnRx5RJG4rh4FGW4KRy9pm0icZzVNr+AHgB2AwkZ1XAXMs52eL9HKEbt\nB3eTftd8qtdNBWZGFKI=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004016fce9f375bbd2968adaaf3575595129ef3e721c3b7c83d5a4a79f4b5dfbbdb1f66da7243e5120c5dbd7be1ca073e04b4cc58ca8ce2f34ff6a3d02a929bf2fc27970083f130792d6c45c8f2a67471e51246e2b8781465b8291cbda66d22719cd536bf801e0076030919d5701732ce7678bf472846ed0777937ed77caad74d05664614a2",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBb86fN1u9KWitqvNXVZUSnvPnIcO3\nyD1aSnn0td+72x9m2nJD5RIMXb174coHPgS0zFjKjOLzT/aj0CqSm/L8J5cAg/Ew\neS1sRcjypnRx5RJG4rh4FGW4KRy9pm0icZzVNr+AHgB2AwkZ1XAXMs52eL9HKEbt\nB3eTftd8qtdNBWZGFKI=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 391,
+          "tcId" : 494,
           "comment" : "point duplication during verification",
-          "msg" : "313233343030",
-          "sig" : "30818802420090c8d0d718cb9d8d81094e6d068fb13c16b4df8c77bac676dddfe3e68855bed06b9ba8d0f8a80edce03a9fac7da561e24b1cd22d459239a146695a671f81f73aaf024201150b0fe9f0dff27fa180cc9442c3bfc9e395232898607b110a51bcb1086cb9726e251a07c9557808df32460715950a3dc446ae4229b9ed59fe241b389aee3a6963",
-          "result" : "valid",
           "flags" : [
             "PointDuplication"
-          ]
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818802420090c8d0d718cb9d8d81094e6d068fb13c16b4df8c77bac676dddfe3e68855bed06b9ba8d0f8a80edce03a9fac7da561e24b1cd22d459239a146695a671f81f73aaf024201150b0fe9f0dff27fa180cc9442c3bfc9e395232898607b110a51bcb1086cb9726e251a07c9557808df32460715950a3dc446ae4229b9ed59fe241b389aee3a6963",
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04016fce9f375bbd2968adaaf3575595129ef3e721c3b7c83d5a4a79f4b5dfbbdb1f66da7243e5120c5dbd7be1ca073e04b4cc58ca8ce2f34ff6a3d02a929bf2fc2797017c0ecf86d293ba370d598b8e1aedb91d4787eb9a47d6e3425992dd8e632ac9407fe1ff89fcf6e62a8fe8cd31898740b8d7b912f8886c8128835528b2fa99b9eb5d",
-        "wx" : "16fce9f375bbd2968adaaf3575595129ef3e721c3b7c83d5a4a79f4b5dfbbdb1f66da7243e5120c5dbd7be1ca073e04b4cc58ca8ce2f34ff6a3d02a929bf2fc2797",
-        "wy" : "17c0ecf86d293ba370d598b8e1aedb91d4787eb9a47d6e3425992dd8e632ac9407fe1ff89fcf6e62a8fe8cd31898740b8d7b912f8886c8128835528b2fa99b9eb5d"
+        "wx" : "016fce9f375bbd2968adaaf3575595129ef3e721c3b7c83d5a4a79f4b5dfbbdb1f66da7243e5120c5dbd7be1ca073e04b4cc58ca8ce2f34ff6a3d02a929bf2fc2797",
+        "wy" : "017c0ecf86d293ba370d598b8e1aedb91d4787eb9a47d6e3425992dd8e632ac9407fe1ff89fcf6e62a8fe8cd31898740b8d7b912f8886c8128835528b2fa99b9eb5d"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004016fce9f375bbd2968adaaf3575595129ef3e721c3b7c83d5a4a79f4b5dfbbdb1f66da7243e5120c5dbd7be1ca073e04b4cc58ca8ce2f34ff6a3d02a929bf2fc2797017c0ecf86d293ba370d598b8e1aedb91d4787eb9a47d6e3425992dd8e632ac9407fe1ff89fcf6e62a8fe8cd31898740b8d7b912f8886c8128835528b2fa99b9eb5d",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBb86fN1u9KWitqvNXVZUSnvPnIcO3\nyD1aSnn0td+72x9m2nJD5RIMXb174coHPgS0zFjKjOLzT/aj0CqSm/L8J5cBfA7P\nhtKTujcNWYuOGu25HUeH65pH1uNCWZLdjmMqyUB/4f+J/PbmKo/ozTGJh0C417kS\n+IhsgSiDVSiy+pm5610=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004016fce9f375bbd2968adaaf3575595129ef3e721c3b7c83d5a4a79f4b5dfbbdb1f66da7243e5120c5dbd7be1ca073e04b4cc58ca8ce2f34ff6a3d02a929bf2fc2797017c0ecf86d293ba370d598b8e1aedb91d4787eb9a47d6e3425992dd8e632ac9407fe1ff89fcf6e62a8fe8cd31898740b8d7b912f8886c8128835528b2fa99b9eb5d",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBb86fN1u9KWitqvNXVZUSnvPnIcO3\nyD1aSnn0td+72x9m2nJD5RIMXb174coHPgS0zFjKjOLzT/aj0CqSm/L8J5cBfA7P\nhtKTujcNWYuOGu25HUeH65pH1uNCWZLdjmMqyUB/4f+J/PbmKo/ozTGJh0C417kS\n+IhsgSiDVSiy+pm5610=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 392,
+          "tcId" : 495,
           "comment" : "duplication bug",
-          "msg" : "313233343030",
-          "sig" : "30818802420090c8d0d718cb9d8d81094e6d068fb13c16b4df8c77bac676dddfe3e68855bed06b9ba8d0f8a80edce03a9fac7da561e24b1cd22d459239a146695a671f81f73aaf024201150b0fe9f0dff27fa180cc9442c3bfc9e395232898607b110a51bcb1086cb9726e251a07c9557808df32460715950a3dc446ae4229b9ed59fe241b389aee3a6963",
-          "result" : "invalid",
           "flags" : [
             "PointDuplication"
-          ]
+          ],
+          "msg" : "313233343030",
+          "sig" : "30818802420090c8d0d718cb9d8d81094e6d068fb13c16b4df8c77bac676dddfe3e68855bed06b9ba8d0f8a80edce03a9fac7da561e24b1cd22d459239a146695a671f81f73aaf024201150b0fe9f0dff27fa180cc9442c3bfc9e395232898607b110a51bcb1086cb9726e251a07c9557808df32460715950a3dc446ae4229b9ed59fe241b389aee3a6963",
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040110fb89aff135edb801a1cb5bc49525b81dc74da45090d228122871814f489fdcb02ebee46b703e6b4e6af56c5024422b31fd4252c44d0bfd29d945de782d98543f01ec425b4c4928e12b619227f1da6d0a9675070d9c5b49ca523050acb718e62643b0e5801543b76dc11f8d694ba09436d8391b477ad2c143ec50c2384c4f688512dc",
-        "wx" : "110fb89aff135edb801a1cb5bc49525b81dc74da45090d228122871814f489fdcb02ebee46b703e6b4e6af56c5024422b31fd4252c44d0bfd29d945de782d98543f",
-        "wy" : "1ec425b4c4928e12b619227f1da6d0a9675070d9c5b49ca523050acb718e62643b0e5801543b76dc11f8d694ba09436d8391b477ad2c143ec50c2384c4f688512dc"
+        "wx" : "0110fb89aff135edb801a1cb5bc49525b81dc74da45090d228122871814f489fdcb02ebee46b703e6b4e6af56c5024422b31fd4252c44d0bfd29d945de782d98543f",
+        "wy" : "01ec425b4c4928e12b619227f1da6d0a9675070d9c5b49ca523050acb718e62643b0e5801543b76dc11f8d694ba09436d8391b477ad2c143ec50c2384c4f688512dc"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040110fb89aff135edb801a1cb5bc49525b81dc74da45090d228122871814f489fdcb02ebee46b703e6b4e6af56c5024422b31fd4252c44d0bfd29d945de782d98543f01ec425b4c4928e12b619227f1da6d0a9675070d9c5b49ca523050acb718e62643b0e5801543b76dc11f8d694ba09436d8391b477ad2c143ec50c2384c4f688512dc",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBEPuJr/E17bgBoctbxJUluB3HTaRQ\nkNIoEihxgU9In9ywLr7ka3A+a05q9WxQJEIrMf1CUsRNC/0p2UXeeC2YVD8B7EJb\nTEko4Sthkifx2m0KlnUHDZxbScpSMFCstxjmJkOw5YAVQ7dtwR+NaUuglDbYORtH\netLBQ+xQwjhMT2iFEtw=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040110fb89aff135edb801a1cb5bc49525b81dc74da45090d228122871814f489fdcb02ebee46b703e6b4e6af56c5024422b31fd4252c44d0bfd29d945de782d98543f01ec425b4c4928e12b619227f1da6d0a9675070d9c5b49ca523050acb718e62643b0e5801543b76dc11f8d694ba09436d8391b477ad2c143ec50c2384c4f688512dc",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBEPuJr/E17bgBoctbxJUluB3HTaRQ\nkNIoEihxgU9In9ywLr7ka3A+a05q9WxQJEIrMf1CUsRNC/0p2UXeeC2YVD8B7EJb\nTEko4Sthkifx2m0KlnUHDZxbScpSMFCstxjmJkOw5YAVQ7dtwR+NaUuglDbYORtH\netLBQ+xQwjhMT2iFEtw=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 393,
+          "tcId" : 496,
           "comment" : "point with x-coordinate 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3047020101024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401c693a3fccbc9f625284239c2725f2a5c90b29b7ce3d07730f7de6031c9e74446d217888ae023aae23df6a4aa153f58c79597d57f42ce5c1354e5dc43a5eb311e13015f99658443b2e39c3edcbcda70707fc5a4d39545eabe354816d09284a6265e47ebf0a47355828e818a767f8452a6d18451e0e3817a896ff404cb1611bfc4c4b4a3",
-        "wx" : "1c693a3fccbc9f625284239c2725f2a5c90b29b7ce3d07730f7de6031c9e74446d217888ae023aae23df6a4aa153f58c79597d57f42ce5c1354e5dc43a5eb311e13",
-        "wy" : "15f99658443b2e39c3edcbcda70707fc5a4d39545eabe354816d09284a6265e47ebf0a47355828e818a767f8452a6d18451e0e3817a896ff404cb1611bfc4c4b4a3"
+        "wx" : "01c693a3fccbc9f625284239c2725f2a5c90b29b7ce3d07730f7de6031c9e74446d217888ae023aae23df6a4aa153f58c79597d57f42ce5c1354e5dc43a5eb311e13",
+        "wy" : "015f99658443b2e39c3edcbcda70707fc5a4d39545eabe354816d09284a6265e47ebf0a47355828e818a767f8452a6d18451e0e3817a896ff404cb1611bfc4c4b4a3"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401c693a3fccbc9f625284239c2725f2a5c90b29b7ce3d07730f7de6031c9e74446d217888ae023aae23df6a4aa153f58c79597d57f42ce5c1354e5dc43a5eb311e13015f99658443b2e39c3edcbcda70707fc5a4d39545eabe354816d09284a6265e47ebf0a47355828e818a767f8452a6d18451e0e3817a896ff404cb1611bfc4c4b4a3",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBxpOj/MvJ9iUoQjnCcl8qXJCym3zj\n0Hcw995gMcnnREbSF4iK4COq4j32pKoVP1jHlZfVf0LOXBNU5dxDpesxHhMBX5ll\nhEOy45w+3LzacHB/xaTTlUXqvjVIFtCShKYmXkfr8KRzVYKOgYp2f4RSptGEUeDj\ngXqJb/QEyxYRv8TEtKM=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401c693a3fccbc9f625284239c2725f2a5c90b29b7ce3d07730f7de6031c9e74446d217888ae023aae23df6a4aa153f58c79597d57f42ce5c1354e5dc43a5eb311e13015f99658443b2e39c3edcbcda70707fc5a4d39545eabe354816d09284a6265e47ebf0a47355828e818a767f8452a6d18451e0e3817a896ff404cb1611bfc4c4b4a3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBxpOj/MvJ9iUoQjnCcl8qXJCym3zj\n0Hcw995gMcnnREbSF4iK4COq4j32pKoVP1jHlZfVf0LOXBNU5dxDpesxHhMBX5ll\nhEOy45w+3LzacHB/xaTTlUXqvjVIFtCShKYmXkfr8KRzVYKOgYp2f4RSptGEUeDj\ngXqJb/QEyxYRv8TEtKM=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 394,
+          "tcId" : 497,
           "comment" : "point with x-coordinate 0",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3081870242020000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000024166666666666666666666666666666666666666666666666666666666666666666543814e4d8ca31e157ff599db649b87900bf128581b85a7efbf1657d2e9d81401",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04017d7bf723678df574ce4366741e1d3787f834af9997b41c8260a074cb1f325d2bae9f8565dc6b51b6cb02dceeb5a1b774ee8dd7057c99e2d94c3c71299a9ce0f1b00162c65632fff88bdbb17ce2525ccac8df37c501ab0e6626e273fb6cf99000424344c0ac539c9fd6c4f3d28876b257c010d347a45bb010cc058443843a758328d491",
-        "wx" : "17d7bf723678df574ce4366741e1d3787f834af9997b41c8260a074cb1f325d2bae9f8565dc6b51b6cb02dceeb5a1b774ee8dd7057c99e2d94c3c71299a9ce0f1b0",
-        "wy" : "162c65632fff88bdbb17ce2525ccac8df37c501ab0e6626e273fb6cf99000424344c0ac539c9fd6c4f3d28876b257c010d347a45bb010cc058443843a758328d491"
+        "wx" : "017d7bf723678df574ce4366741e1d3787f834af9997b41c8260a074cb1f325d2bae9f8565dc6b51b6cb02dceeb5a1b774ee8dd7057c99e2d94c3c71299a9ce0f1b0",
+        "wy" : "0162c65632fff88bdbb17ce2525ccac8df37c501ab0e6626e273fb6cf99000424344c0ac539c9fd6c4f3d28876b257c010d347a45bb010cc058443843a758328d491"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004017d7bf723678df574ce4366741e1d3787f834af9997b41c8260a074cb1f325d2bae9f8565dc6b51b6cb02dceeb5a1b774ee8dd7057c99e2d94c3c71299a9ce0f1b00162c65632fff88bdbb17ce2525ccac8df37c501ab0e6626e273fb6cf99000424344c0ac539c9fd6c4f3d28876b257c010d347a45bb010cc058443843a758328d491",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBfXv3I2eN9XTOQ2Z0Hh03h/g0r5mX\ntByCYKB0yx8yXSuun4Vl3GtRtssC3O61obd07o3XBXyZ4tlMPHEpmpzg8bABYsZW\nMv/4i9uxfOJSXMrI3zfFAasOZibic/ts+ZAAQkNEwKxTnJ/WxPPSiHayV8AQ00ek\nW7AQzAWEQ4Q6dYMo1JE=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004017d7bf723678df574ce4366741e1d3787f834af9997b41c8260a074cb1f325d2bae9f8565dc6b51b6cb02dceeb5a1b774ee8dd7057c99e2d94c3c71299a9ce0f1b00162c65632fff88bdbb17ce2525ccac8df37c501ab0e6626e273fb6cf99000424344c0ac539c9fd6c4f3d28876b257c010d347a45bb010cc058443843a758328d491",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBfXv3I2eN9XTOQ2Z0Hh03h/g0r5mX\ntByCYKB0yx8yXSuun4Vl3GtRtssC3O61obd07o3XBXyZ4tlMPHEpmpzg8bABYsZW\nMv/4i9uxfOJSXMrI3zfFAasOZibic/ts+ZAAQkNEwKxTnJ/WxPPSiHayV8AQ00ek\nW7AQzAWEQ4Q6dYMo1JE=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 395,
+          "tcId" : 498,
           "comment" : "comparison with point at infinity ",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308187024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad024166666666666666666666666666666666666666666666666666666666666666666543814e4d8ca31e157ff599db649b87900bf128581b85a7efbf1657d2e9d81401",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401e06db423a902e239b97340ab052534ead37e79412c675bf0eb823999e6b731040bff2b0e4fa64edf3962a328921ea5ae4e8f4079eab439e12f92335dfc4863c07f007ee9f0ecb409cb133c0cd08b85e840b076f3d615e1ef1393b5222338b227d768003da5f3ba1f72f6654ca54ac11c2ba91a6cb5883d6d1a82304ad2b79de09215f3",
-        "wx" : "1e06db423a902e239b97340ab052534ead37e79412c675bf0eb823999e6b731040bff2b0e4fa64edf3962a328921ea5ae4e8f4079eab439e12f92335dfc4863c07f",
+        "wx" : "01e06db423a902e239b97340ab052534ead37e79412c675bf0eb823999e6b731040bff2b0e4fa64edf3962a328921ea5ae4e8f4079eab439e12f92335dfc4863c07f",
         "wy" : "7ee9f0ecb409cb133c0cd08b85e840b076f3d615e1ef1393b5222338b227d768003da5f3ba1f72f6654ca54ac11c2ba91a6cb5883d6d1a82304ad2b79de09215f3"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401e06db423a902e239b97340ab052534ead37e79412c675bf0eb823999e6b731040bff2b0e4fa64edf3962a328921ea5ae4e8f4079eab439e12f92335dfc4863c07f007ee9f0ecb409cb133c0cd08b85e840b076f3d615e1ef1393b5222338b227d768003da5f3ba1f72f6654ca54ac11c2ba91a6cb5883d6d1a82304ad2b79de09215f3",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB4G20I6kC4jm5c0CrBSU06tN+eUEs\nZ1vw64I5mea3MQQL/ysOT6ZO3zlioyiSHqWuTo9Aeeq0OeEvkjNd/EhjwH8Afunw\n7LQJyxM8DNCLhehAsHbz1hXh7xOTtSIjOLIn12gAPaXzuh9y9mVMpUrBHCupGmy1\niD1tGoIwStK3neCSFfM=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401e06db423a902e239b97340ab052534ead37e79412c675bf0eb823999e6b731040bff2b0e4fa64edf3962a328921ea5ae4e8f4079eab439e12f92335dfc4863c07f007ee9f0ecb409cb133c0cd08b85e840b076f3d615e1ef1393b5222338b227d768003da5f3ba1f72f6654ca54ac11c2ba91a6cb5883d6d1a82304ad2b79de09215f3",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB4G20I6kC4jm5c0CrBSU06tN+eUEs\nZ1vw64I5mea3MQQL/ysOT6ZO3zlioyiSHqWuTo9Aeeq0OeEvkjNd/EhjwH8Afunw\n7LQJyxM8DNCLhehAsHbz1hXh7xOTtSIjOLIn12gAPaXzuh9y9mVMpUrBHCupGmy1\niD1tGoIwStK3neCSFfM=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 396,
+          "tcId" : 499,
           "comment" : "extreme value for k and edgecase s",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3081870241433c219024277e7e682fcb288148c282747403279b1ccc06352c6e5505d769be97b3b204da6ef55507aa104a3a35c5af41cf2fa364d60fd967f43e3933ba6d783d024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04015053744d53811dbed8880f38d3a34578a7f1c172ec65bd8ad8183ba0ae10093416107f3c942742bde60719949b2c4f026f43582125c99ed48cbc7c5a051a5a744800b36d4c91a2b0367c566b2c12981ce0fdbc3beb983717403f69bf4264fc6182478af0b236ff120bcfca116924c552abef6663b6023be1986b70206d9bb89b5ed298",
-        "wx" : "15053744d53811dbed8880f38d3a34578a7f1c172ec65bd8ad8183ba0ae10093416107f3c942742bde60719949b2c4f026f43582125c99ed48cbc7c5a051a5a7448",
-        "wy" : "0b36d4c91a2b0367c566b2c12981ce0fdbc3beb983717403f69bf4264fc6182478af0b236ff120bcfca116924c552abef6663b6023be1986b70206d9bb89b5ed298"
+        "wx" : "015053744d53811dbed8880f38d3a34578a7f1c172ec65bd8ad8183ba0ae10093416107f3c942742bde60719949b2c4f026f43582125c99ed48cbc7c5a051a5a7448",
+        "wy" : "00b36d4c91a2b0367c566b2c12981ce0fdbc3beb983717403f69bf4264fc6182478af0b236ff120bcfca116924c552abef6663b6023be1986b70206d9bb89b5ed298"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004015053744d53811dbed8880f38d3a34578a7f1c172ec65bd8ad8183ba0ae10093416107f3c942742bde60719949b2c4f026f43582125c99ed48cbc7c5a051a5a744800b36d4c91a2b0367c566b2c12981ce0fdbc3beb983717403f69bf4264fc6182478af0b236ff120bcfca116924c552abef6663b6023be1986b70206d9bb89b5ed298",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBUFN0TVOBHb7YiA8406NFeKfxwXLs\nZb2K2Bg7oK4QCTQWEH88lCdCveYHGZSbLE8Cb0NYISXJntSMvHxaBRpadEgAs21M\nkaKwNnxWaywSmBzg/bw765g3F0A/ab9CZPxhgkeK8LI2/xILz8oRaSTFUqvvZmO2\nAjvhmGtwIG2buJte0pg=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004015053744d53811dbed8880f38d3a34578a7f1c172ec65bd8ad8183ba0ae10093416107f3c942742bde60719949b2c4f026f43582125c99ed48cbc7c5a051a5a744800b36d4c91a2b0367c566b2c12981ce0fdbc3beb983717403f69bf4264fc6182478af0b236ff120bcfca116924c552abef6663b6023be1986b70206d9bb89b5ed298",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBUFN0TVOBHb7YiA8406NFeKfxwXLs\nZb2K2Bg7oK4QCTQWEH88lCdCveYHGZSbLE8Cb0NYISXJntSMvHxaBRpadEgAs21M\nkaKwNnxWaywSmBzg/bw765g3F0A/ab9CZPxhgkeK8LI2/xILz8oRaSTFUqvvZmO2\nAjvhmGtwIG2buJte0pg=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 397,
+          "tcId" : 500,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3081860241433c219024277e7e682fcb288148c282747403279b1ccc06352c6e5505d769be97b3b204da6ef55507aa104a3a35c5af41cf2fa364d60fd967f43e3933ba6d783d0241492492492492492492492492492492492492492492492492492492492492492491795c5c808906cc587ff89278234a8566e3f565f5ca840a3d887dac7214bee9b8",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401fb2e26596cc80473917dd46b4a1d14bd9a1ca9769dd12bfac1bff17cdc282e74c73a801ec1be83edfe4bfe9813ec943ac151678f0a9a0bf27d9ef308177eb0400f019e03a5da3da67e6b8d068dbdacf091b9d5efadaf63f4a7e9c6b6ed0a1c9a5d3cbc3e0244d481066018fba7674a2b59139a5656780563bb4618014f176752e177e0",
-        "wx" : "1fb2e26596cc80473917dd46b4a1d14bd9a1ca9769dd12bfac1bff17cdc282e74c73a801ec1be83edfe4bfe9813ec943ac151678f0a9a0bf27d9ef308177eb0400f",
-        "wy" : "19e03a5da3da67e6b8d068dbdacf091b9d5efadaf63f4a7e9c6b6ed0a1c9a5d3cbc3e0244d481066018fba7674a2b59139a5656780563bb4618014f176752e177e0"
+        "wx" : "01fb2e26596cc80473917dd46b4a1d14bd9a1ca9769dd12bfac1bff17cdc282e74c73a801ec1be83edfe4bfe9813ec943ac151678f0a9a0bf27d9ef308177eb0400f",
+        "wy" : "019e03a5da3da67e6b8d068dbdacf091b9d5efadaf63f4a7e9c6b6ed0a1c9a5d3cbc3e0244d481066018fba7674a2b59139a5656780563bb4618014f176752e177e0"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401fb2e26596cc80473917dd46b4a1d14bd9a1ca9769dd12bfac1bff17cdc282e74c73a801ec1be83edfe4bfe9813ec943ac151678f0a9a0bf27d9ef308177eb0400f019e03a5da3da67e6b8d068dbdacf091b9d5efadaf63f4a7e9c6b6ed0a1c9a5d3cbc3e0244d481066018fba7674a2b59139a5656780563bb4618014f176752e177e0",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB+y4mWWzIBHORfdRrSh0UvZocqXad\n0Sv6wb/xfNwoLnTHOoAewb6D7f5L/pgT7JQ6wVFnjwqaC/J9nvMIF36wQA8BngOl\n2j2mfmuNBo29rPCRudXvra9j9KfpxrbtChyaXTy8PgJE1IEGYBj7p2dKK1kTmlZW\neAVju0YYAU8XZ1Lhd+A=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401fb2e26596cc80473917dd46b4a1d14bd9a1ca9769dd12bfac1bff17cdc282e74c73a801ec1be83edfe4bfe9813ec943ac151678f0a9a0bf27d9ef308177eb0400f019e03a5da3da67e6b8d068dbdacf091b9d5efadaf63f4a7e9c6b6ed0a1c9a5d3cbc3e0244d481066018fba7674a2b59139a5656780563bb4618014f176752e177e0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB+y4mWWzIBHORfdRrSh0UvZocqXad\n0Sv6wb/xfNwoLnTHOoAewb6D7f5L/pgT7JQ6wVFnjwqaC/J9nvMIF36wQA8BngOl\n2j2mfmuNBo29rPCRudXvra9j9KfpxrbtChyaXTy8PgJE1IEGYBj7p2dKK1kTmlZW\neAVju0YYAU8XZ1Lhd+A=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 398,
+          "tcId" : 501,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3081870241433c219024277e7e682fcb288148c282747403279b1ccc06352c6e5505d769be97b3b204da6ef55507aa104a3a35c5af41cf2fa364d60fd967f43e3933ba6d783d0242019999999999999999999999999999999999999999999999999999999999999999950e053936328c7855ffd6676d926e1e402fc4a1606e169fbefc595f4ba7605007",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04008422cea9dcf8ae01f7a157888f018a40a66461d3566ec4a4dfc89ecb3c2404be734d329137d630387b012d033221857d5bfb290fa8027640b4063072a3e5b14c860025a219e724b81814901a677a8bee9b716b33b16a5b65f2272956a46b5e8683dc896984309ac79449657a1895c9f62bde99c7f5e24ed2defbc9f8dde35ebd0bddc1",
-        "wx" : "08422cea9dcf8ae01f7a157888f018a40a66461d3566ec4a4dfc89ecb3c2404be734d329137d630387b012d033221857d5bfb290fa8027640b4063072a3e5b14c86",
+        "wx" : "008422cea9dcf8ae01f7a157888f018a40a66461d3566ec4a4dfc89ecb3c2404be734d329137d630387b012d033221857d5bfb290fa8027640b4063072a3e5b14c86",
         "wy" : "25a219e724b81814901a677a8bee9b716b33b16a5b65f2272956a46b5e8683dc896984309ac79449657a1895c9f62bde99c7f5e24ed2defbc9f8dde35ebd0bddc1"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004008422cea9dcf8ae01f7a157888f018a40a66461d3566ec4a4dfc89ecb3c2404be734d329137d630387b012d033221857d5bfb290fa8027640b4063072a3e5b14c860025a219e724b81814901a677a8bee9b716b33b16a5b65f2272956a46b5e8683dc896984309ac79449657a1895c9f62bde99c7f5e24ed2defbc9f8dde35ebd0bddc1",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAhCLOqdz4rgH3oVeIjwGKQKZkYdNW\nbsSk38ieyzwkBL5zTTKRN9YwOHsBLQMyIYV9W/spD6gCdkC0BjByo+WxTIYAJaIZ\n5yS4GBSQGmd6i+6bcWszsWpbZfInKVaka16Gg9yJaYQwmseUSWV6GJXJ9ivemcf1\n4k7S3vvJ+N3jXr0L3cE=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004008422cea9dcf8ae01f7a157888f018a40a66461d3566ec4a4dfc89ecb3c2404be734d329137d630387b012d033221857d5bfb290fa8027640b4063072a3e5b14c860025a219e724b81814901a677a8bee9b716b33b16a5b65f2272956a46b5e8683dc896984309ac79449657a1895c9f62bde99c7f5e24ed2defbc9f8dde35ebd0bddc1",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAhCLOqdz4rgH3oVeIjwGKQKZkYdNW\nbsSk38ieyzwkBL5zTTKRN9YwOHsBLQMyIYV9W/spD6gCdkC0BjByo+WxTIYAJaIZ\n5yS4GBSQGmd6i+6bcWszsWpbZfInKVaka16Gg9yJaYQwmseUSWV6GJXJ9ivemcf1\n4k7S3vvJ+N3jXr0L3cE=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 399,
+          "tcId" : 502,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3081860241433c219024277e7e682fcb288148c282747403279b1ccc06352c6e5505d769be97b3b204da6ef55507aa104a3a35c5af41cf2fa364d60fd967f43e3933ba6d783d024166666666666666666666666666666666666666666666666666666666666666666543814e4d8ca31e157ff599db649b87900bf128581b85a7efbf1657d2e9d81402",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401bc19cf4b94bcd34114ce83c5f1a7e048e2fc4fd457d57e39b3da29f4766acbaef1c10cb13c796a6fffb56d6a392e47b6c74522df7fa02754c33d95b1a9a3c92a1500f5744c2bed308cb4f41b512e632cd01d270ef1a0d3f47ea780e73c6a6c9ea6a996faef4d282896c64fa50f5b04e204c56b504bc122ffba7aea4574d7d7ab6303c0",
-        "wx" : "1bc19cf4b94bcd34114ce83c5f1a7e048e2fc4fd457d57e39b3da29f4766acbaef1c10cb13c796a6fffb56d6a392e47b6c74522df7fa02754c33d95b1a9a3c92a15",
-        "wy" : "0f5744c2bed308cb4f41b512e632cd01d270ef1a0d3f47ea780e73c6a6c9ea6a996faef4d282896c64fa50f5b04e204c56b504bc122ffba7aea4574d7d7ab6303c0"
+        "wx" : "01bc19cf4b94bcd34114ce83c5f1a7e048e2fc4fd457d57e39b3da29f4766acbaef1c10cb13c796a6fffb56d6a392e47b6c74522df7fa02754c33d95b1a9a3c92a15",
+        "wy" : "00f5744c2bed308cb4f41b512e632cd01d270ef1a0d3f47ea780e73c6a6c9ea6a996faef4d282896c64fa50f5b04e204c56b504bc122ffba7aea4574d7d7ab6303c0"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401bc19cf4b94bcd34114ce83c5f1a7e048e2fc4fd457d57e39b3da29f4766acbaef1c10cb13c796a6fffb56d6a392e47b6c74522df7fa02754c33d95b1a9a3c92a1500f5744c2bed308cb4f41b512e632cd01d270ef1a0d3f47ea780e73c6a6c9ea6a996faef4d282896c64fa50f5b04e204c56b504bc122ffba7aea4574d7d7ab6303c0",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBvBnPS5S800EUzoPF8afgSOL8T9RX\n1X45s9op9HZqy67xwQyxPHlqb/+1bWo5Lke2x0Ui33+gJ1TDPZWxqaPJKhUA9XRM\nK+0wjLT0G1EuYyzQHScO8aDT9H6ngOc8amyepqmW+u9NKCiWxk+lD1sE4gTFa1BL\nwSL/unrqRXTX16tjA8A=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401bc19cf4b94bcd34114ce83c5f1a7e048e2fc4fd457d57e39b3da29f4766acbaef1c10cb13c796a6fffb56d6a392e47b6c74522df7fa02754c33d95b1a9a3c92a1500f5744c2bed308cb4f41b512e632cd01d270ef1a0d3f47ea780e73c6a6c9ea6a996faef4d282896c64fa50f5b04e204c56b504bc122ffba7aea4574d7d7ab6303c0",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBvBnPS5S800EUzoPF8afgSOL8T9RX\n1X45s9op9HZqy67xwQyxPHlqb/+1bWo5Lke2x0Ui33+gJ1TDPZWxqaPJKhUA9XRM\nK+0wjLT0G1EuYyzQHScO8aDT9H6ngOc8amyepqmW+u9NKCiWxk+lD1sE4gTFa1BL\nwSL/unrqRXTX16tjA8A=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 400,
+          "tcId" : 503,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3081870241433c219024277e7e682fcb288148c282747403279b1ccc06352c6e5505d769be97b3b204da6ef55507aa104a3a35c5af41cf2fa364d60fd967f43e3933ba6d783d024201b6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db68d82a2b033628ca12ffd36ed0d3bf206957c063c2bf183d7132f20aac7c797a51",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04017b0ebce08b09f21e30d15e0edd9fcdf24ab4831ec8a65a3d1e38f72b15f0115da6ed1885e42fcfae31c0914b71e9df2cd106adc039a82810a92924dd154dc05da300c614d1afc4f63de3803bb5490a34e1e2fab9eb78422b21d377fc0d7f991b938c22f4d7dd665f8dd21fadde43172a55f80d05cc4557b6663f9e7a3fe490d25c5531",
-        "wx" : "17b0ebce08b09f21e30d15e0edd9fcdf24ab4831ec8a65a3d1e38f72b15f0115da6ed1885e42fcfae31c0914b71e9df2cd106adc039a82810a92924dd154dc05da3",
-        "wy" : "0c614d1afc4f63de3803bb5490a34e1e2fab9eb78422b21d377fc0d7f991b938c22f4d7dd665f8dd21fadde43172a55f80d05cc4557b6663f9e7a3fe490d25c5531"
+        "wx" : "017b0ebce08b09f21e30d15e0edd9fcdf24ab4831ec8a65a3d1e38f72b15f0115da6ed1885e42fcfae31c0914b71e9df2cd106adc039a82810a92924dd154dc05da3",
+        "wy" : "00c614d1afc4f63de3803bb5490a34e1e2fab9eb78422b21d377fc0d7f991b938c22f4d7dd665f8dd21fadde43172a55f80d05cc4557b6663f9e7a3fe490d25c5531"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004017b0ebce08b09f21e30d15e0edd9fcdf24ab4831ec8a65a3d1e38f72b15f0115da6ed1885e42fcfae31c0914b71e9df2cd106adc039a82810a92924dd154dc05da300c614d1afc4f63de3803bb5490a34e1e2fab9eb78422b21d377fc0d7f991b938c22f4d7dd665f8dd21fadde43172a55f80d05cc4557b6663f9e7a3fe490d25c5531",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBew684IsJ8h4w0V4O3Z/N8kq0gx7I\nplo9Hjj3KxXwEV2m7RiF5C/PrjHAkUtx6d8s0QatwDmoKBCpKSTdFU3AXaMAxhTR\nr8T2PeOAO7VJCjTh4vq563hCKyHTd/wNf5kbk4wi9NfdZl+N0h+t3kMXKlX4DQXM\nRVe2Zj+eej/kkNJcVTE=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004017b0ebce08b09f21e30d15e0edd9fcdf24ab4831ec8a65a3d1e38f72b15f0115da6ed1885e42fcfae31c0914b71e9df2cd106adc039a82810a92924dd154dc05da300c614d1afc4f63de3803bb5490a34e1e2fab9eb78422b21d377fc0d7f991b938c22f4d7dd665f8dd21fadde43172a55f80d05cc4557b6663f9e7a3fe490d25c5531",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBew684IsJ8h4w0V4O3Z/N8kq0gx7I\nplo9Hjj3KxXwEV2m7RiF5C/PrjHAkUtx6d8s0QatwDmoKBCpKSTdFU3AXaMAxhTR\nr8T2PeOAO7VJCjTh4vq563hCKyHTd/wNf5kbk4wi9NfdZl+N0h+t3kMXKlX4DQXM\nRVe2Zj+eej/kkNJcVTE=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 401,
+          "tcId" : 504,
           "comment" : "extreme value for k",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "3081860241433c219024277e7e682fcb288148c282747403279b1ccc06352c6e5505d769be97b3b204da6ef55507aa104a3a35c5af41cf2fa364d60fd967f43e3933ba6d783d02410eb10e5ab95f2f26a40700b1300fb8c3c8d5384ffbecf1fdb9e11e67cb7fd6a7f503e6e25ac09bb88b6c3983df764d4d72bc2920e233f0f7974a234a21b00bb447",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040004c3ec8d7d23ce74be8b9c7c27be869c23bafc6874ebc44f47e107422ab1e75ed09bebd7cb1ec4626e442bcf512a25c5ddde26eb08ba37506461830cf9241cbe9c0050a1bc08f4ba8da1d641ac3891823ab519facd4159768b1c0738f0e23450f374e4d6de55cceed95722be635c5dc0023a1498862f87bfe61d77e20e592cc20bb2ca",
-        "wx" : "4c3ec8d7d23ce74be8b9c7c27be869c23bafc6874ebc44f47e107422ab1e75ed09bebd7cb1ec4626e442bcf512a25c5ddde26eb08ba37506461830cf9241cbe9c",
+        "wx" : "04c3ec8d7d23ce74be8b9c7c27be869c23bafc6874ebc44f47e107422ab1e75ed09bebd7cb1ec4626e442bcf512a25c5ddde26eb08ba37506461830cf9241cbe9c",
         "wy" : "50a1bc08f4ba8da1d641ac3891823ab519facd4159768b1c0738f0e23450f374e4d6de55cceed95722be635c5dc0023a1498862f87bfe61d77e20e592cc20bb2ca"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040004c3ec8d7d23ce74be8b9c7c27be869c23bafc6874ebc44f47e107422ab1e75ed09bebd7cb1ec4626e442bcf512a25c5ddde26eb08ba37506461830cf9241cbe9c0050a1bc08f4ba8da1d641ac3891823ab519facd4159768b1c0738f0e23450f374e4d6de55cceed95722be635c5dc0023a1498862f87bfe61d77e20e592cc20bb2ca",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQABMPsjX0jznS+i5x8J76GnCO6/Gh0\n68RPR+EHQiqx517Qm+vXyx7EYm5EK89RKiXF3d4m6wi6N1BkYYMM+SQcvpwAUKG8\nCPS6jaHWQaw4kYI6tRn6zUFZdoscBzjw4jRQ83Tk1t5VzO7ZVyK+Y1xdwAI6FJiG\nL4e/5h134g5ZLMILsso=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040004c3ec8d7d23ce74be8b9c7c27be869c23bafc6874ebc44f47e107422ab1e75ed09bebd7cb1ec4626e442bcf512a25c5ddde26eb08ba37506461830cf9241cbe9c0050a1bc08f4ba8da1d641ac3891823ab519facd4159768b1c0738f0e23450f374e4d6de55cceed95722be635c5dc0023a1498862f87bfe61d77e20e592cc20bb2ca",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQABMPsjX0jznS+i5x8J76GnCO6/Gh0\n68RPR+EHQiqx517Qm+vXyx7EYm5EK89RKiXF3d4m6wi6N1BkYYMM+SQcvpwAUKG8\nCPS6jaHWQaw4kYI6tRn6zUFZdoscBzjw4jRQ83Tk1t5VzO7ZVyK+Y1xdwAI6FJiG\nL4e/5h134g5ZLMILsso=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 402,
+          "tcId" : 505,
           "comment" : "extreme value for k and edgecase s",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66024200aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa8c5d782813fba87792a9955c2fd033745693c9892d8896d3a3e7a925f85bd76ad",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400a7c8204f2864dcef089165c3914dcc2c0896075870ca0bc1ce37856f80f23815b0c8f2ec05145c421049e80ec1e7694f9f04174bbef21bc0972e559cf222de7e1a01ff1108c28f01b703820e1c0187912962ab23109618dfcb0c062ccee339002222a3f7dd8dd21675b0e20908fe5855ea876d6a9e02c5f5b793d38fdf79fb83603ea9",
-        "wx" : "0a7c8204f2864dcef089165c3914dcc2c0896075870ca0bc1ce37856f80f23815b0c8f2ec05145c421049e80ec1e7694f9f04174bbef21bc0972e559cf222de7e1a",
-        "wy" : "1ff1108c28f01b703820e1c0187912962ab23109618dfcb0c062ccee339002222a3f7dd8dd21675b0e20908fe5855ea876d6a9e02c5f5b793d38fdf79fb83603ea9"
+        "wx" : "00a7c8204f2864dcef089165c3914dcc2c0896075870ca0bc1ce37856f80f23815b0c8f2ec05145c421049e80ec1e7694f9f04174bbef21bc0972e559cf222de7e1a",
+        "wy" : "01ff1108c28f01b703820e1c0187912962ab23109618dfcb0c062ccee339002222a3f7dd8dd21675b0e20908fe5855ea876d6a9e02c5f5b793d38fdf79fb83603ea9"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400a7c8204f2864dcef089165c3914dcc2c0896075870ca0bc1ce37856f80f23815b0c8f2ec05145c421049e80ec1e7694f9f04174bbef21bc0972e559cf222de7e1a01ff1108c28f01b703820e1c0187912962ab23109618dfcb0c062ccee339002222a3f7dd8dd21675b0e20908fe5855ea876d6a9e02c5f5b793d38fdf79fb83603ea9",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAp8ggTyhk3O8IkWXDkU3MLAiWB1hw\nygvBzjeFb4DyOBWwyPLsBRRcQhBJ6A7B52lPnwQXS77yG8CXLlWc8iLefhoB/xEI\nwo8BtwOCDhwBh5EpYqsjEJYY38sMBizO4zkAIiKj992N0hZ1sOIJCP5YVeqHbWqe\nAsX1t5PTj995+4NgPqk=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400a7c8204f2864dcef089165c3914dcc2c0896075870ca0bc1ce37856f80f23815b0c8f2ec05145c421049e80ec1e7694f9f04174bbef21bc0972e559cf222de7e1a01ff1108c28f01b703820e1c0187912962ab23109618dfcb0c062ccee339002222a3f7dd8dd21675b0e20908fe5855ea876d6a9e02c5f5b793d38fdf79fb83603ea9",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAp8ggTyhk3O8IkWXDkU3MLAiWB1hw\nygvBzjeFb4DyOBWwyPLsBRRcQhBJ6A7B52lPnwQXS77yG8CXLlWc8iLefhoB/xEI\nwo8BtwOCDhwBh5EpYqsjEJYY38sMBizO4zkAIiKj992N0hZ1sOIJCP5YVeqHbWqe\nAsX1t5PTj995+4NgPqk=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 403,
+          "tcId" : 506,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308187024200c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd660241492492492492492492492492492492492492492492492492492492492492492491795c5c808906cc587ff89278234a8566e3f565f5ca840a3d887dac7214bee9b8",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401802fc79fc8e55bce50a581632b51d6eec04a3c74ac2bf4fae16ce6c7efef1701d69f9c00a91ad521d75ac7539d54bf464caeec871456103dc974354460898a19c600722fc1f528506618b1da9f8b2edbdbdaf7eec02e8fb9203d2b277735a1d867911b131f453f52ccc4ced05c3b1bc29e4d20f1e6d34979faa688ce8003f79d8e0c95",
-        "wx" : "1802fc79fc8e55bce50a581632b51d6eec04a3c74ac2bf4fae16ce6c7efef1701d69f9c00a91ad521d75ac7539d54bf464caeec871456103dc974354460898a19c6",
+        "wx" : "01802fc79fc8e55bce50a581632b51d6eec04a3c74ac2bf4fae16ce6c7efef1701d69f9c00a91ad521d75ac7539d54bf464caeec871456103dc974354460898a19c6",
         "wy" : "722fc1f528506618b1da9f8b2edbdbdaf7eec02e8fb9203d2b277735a1d867911b131f453f52ccc4ced05c3b1bc29e4d20f1e6d34979faa688ce8003f79d8e0c95"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401802fc79fc8e55bce50a581632b51d6eec04a3c74ac2bf4fae16ce6c7efef1701d69f9c00a91ad521d75ac7539d54bf464caeec871456103dc974354460898a19c600722fc1f528506618b1da9f8b2edbdbdaf7eec02e8fb9203d2b277735a1d867911b131f453f52ccc4ced05c3b1bc29e4d20f1e6d34979faa688ce8003f79d8e0c95",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBgC/Hn8jlW85QpYFjK1HW7sBKPHSs\nK/T64Wzmx+/vFwHWn5wAqRrVIddax1OdVL9GTK7shxRWED3JdDVEYImKGcYAci/B\n9ShQZhix2p+LLtvb2vfuwC6PuSA9Kyd3NaHYZ5EbEx9FP1LMxM7QXDsbwp5NIPHm\n00l5+qaIzoAD952ODJU=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401802fc79fc8e55bce50a581632b51d6eec04a3c74ac2bf4fae16ce6c7efef1701d69f9c00a91ad521d75ac7539d54bf464caeec871456103dc974354460898a19c600722fc1f528506618b1da9f8b2edbdbdaf7eec02e8fb9203d2b277735a1d867911b131f453f52ccc4ced05c3b1bc29e4d20f1e6d34979faa688ce8003f79d8e0c95",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBgC/Hn8jlW85QpYFjK1HW7sBKPHSs\nK/T64Wzmx+/vFwHWn5wAqRrVIddax1OdVL9GTK7shxRWED3JdDVEYImKGcYAci/B\n9ShQZhix2p+LLtvb2vfuwC6PuSA9Kyd3NaHYZ5EbEx9FP1LMxM7QXDsbwp5NIPHm\n00l5+qaIzoAD952ODJU=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 404,
+          "tcId" : 507,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd660242019999999999999999999999999999999999999999999999999999999999999999950e053936328c7855ffd6676d926e1e402fc4a1606e169fbefc595f4ba7605007",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401beb0b4c2e494226404fca4ad505ebfed13d184b1572683215b16173c29a4475aede47f266e0c9c4143137d3e0001f9f0148b689286a7c64e229458b824ed7658360130205169783ed9ada9f3a193027ae4e21829ad4a71d05d969605c04f3231dabab03beb2fab07dd8323d7132755734f4e6d1fb43fc8a63bfd244160c23efb6c1429",
-        "wx" : "1beb0b4c2e494226404fca4ad505ebfed13d184b1572683215b16173c29a4475aede47f266e0c9c4143137d3e0001f9f0148b689286a7c64e229458b824ed765836",
-        "wy" : "130205169783ed9ada9f3a193027ae4e21829ad4a71d05d969605c04f3231dabab03beb2fab07dd8323d7132755734f4e6d1fb43fc8a63bfd244160c23efb6c1429"
+        "wx" : "01beb0b4c2e494226404fca4ad505ebfed13d184b1572683215b16173c29a4475aede47f266e0c9c4143137d3e0001f9f0148b689286a7c64e229458b824ed765836",
+        "wy" : "0130205169783ed9ada9f3a193027ae4e21829ad4a71d05d969605c04f3231dabab03beb2fab07dd8323d7132755734f4e6d1fb43fc8a63bfd244160c23efb6c1429"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401beb0b4c2e494226404fca4ad505ebfed13d184b1572683215b16173c29a4475aede47f266e0c9c4143137d3e0001f9f0148b689286a7c64e229458b824ed7658360130205169783ed9ada9f3a193027ae4e21829ad4a71d05d969605c04f3231dabab03beb2fab07dd8323d7132755734f4e6d1fb43fc8a63bfd244160c23efb6c1429",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBvrC0wuSUImQE/KStUF6/7RPRhLFX\nJoMhWxYXPCmkR1rt5H8mbgycQUMTfT4AAfnwFItokoanxk4ilFi4JO12WDYBMCBR\naXg+2a2p86GTAnrk4hgprUpx0F2WlgXATzIx2rqwO+svqwfdgyPXEydVc09ObR+0\nP8imO/0kQWDCPvtsFCk=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401beb0b4c2e494226404fca4ad505ebfed13d184b1572683215b16173c29a4475aede47f266e0c9c4143137d3e0001f9f0148b689286a7c64e229458b824ed7658360130205169783ed9ada9f3a193027ae4e21829ad4a71d05d969605c04f3231dabab03beb2fab07dd8323d7132755734f4e6d1fb43fc8a63bfd244160c23efb6c1429",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBvrC0wuSUImQE/KStUF6/7RPRhLFX\nJoMhWxYXPCmkR1rt5H8mbgycQUMTfT4AAfnwFItokoanxk4ilFi4JO12WDYBMCBR\naXg+2a2p86GTAnrk4hgprUpx0F2WlgXATzIx2rqwO+svqwfdgyPXEydVc09ObR+0\nP8imO/0kQWDCPvtsFCk=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 405,
+          "tcId" : 508,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308187024200c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66024166666666666666666666666666666666666666666666666666666666666666666543814e4d8ca31e157ff599db649b87900bf128581b85a7efbf1657d2e9d81402",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040121e59aaf26b8301f4fcc3e0a563c4104ae00b47c55b8945ce749116fdf6761d768bd50ed431e2b51e646fe4fe7dc2985b6aefa7f9441ea11840d2ace2f34293cb1000cf1e1a46d4d637216e28abd124cc641ae7a673445d573856bc2fec58d86e5ed63bc2a7f2049234e335a7bee95bb2724fb1480c97c38cd0d296cbcc113de3f135f",
-        "wx" : "121e59aaf26b8301f4fcc3e0a563c4104ae00b47c55b8945ce749116fdf6761d768bd50ed431e2b51e646fe4fe7dc2985b6aefa7f9441ea11840d2ace2f34293cb1",
+        "wx" : "0121e59aaf26b8301f4fcc3e0a563c4104ae00b47c55b8945ce749116fdf6761d768bd50ed431e2b51e646fe4fe7dc2985b6aefa7f9441ea11840d2ace2f34293cb1",
         "wy" : "0cf1e1a46d4d637216e28abd124cc641ae7a673445d573856bc2fec58d86e5ed63bc2a7f2049234e335a7bee95bb2724fb1480c97c38cd0d296cbcc113de3f135f"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040121e59aaf26b8301f4fcc3e0a563c4104ae00b47c55b8945ce749116fdf6761d768bd50ed431e2b51e646fe4fe7dc2985b6aefa7f9441ea11840d2ace2f34293cb1000cf1e1a46d4d637216e28abd124cc641ae7a673445d573856bc2fec58d86e5ed63bc2a7f2049234e335a7bee95bb2724fb1480c97c38cd0d296cbcc113de3f135f",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBIeWarya4MB9PzD4KVjxBBK4AtHxV\nuJRc50kRb99nYddovVDtQx4rUeZG/k/n3CmFtq76f5RB6hGEDSrOLzQpPLEADPHh\npG1NY3IW4oq9EkzGQa56ZzRF1XOFa8L+xY2G5e1jvCp/IEkjTjNae+6Vuyck+xSA\nyXw4zQ0pbLzBE94/E18=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040121e59aaf26b8301f4fcc3e0a563c4104ae00b47c55b8945ce749116fdf6761d768bd50ed431e2b51e646fe4fe7dc2985b6aefa7f9441ea11840d2ace2f34293cb1000cf1e1a46d4d637216e28abd124cc641ae7a673445d573856bc2fec58d86e5ed63bc2a7f2049234e335a7bee95bb2724fb1480c97c38cd0d296cbcc113de3f135f",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBIeWarya4MB9PzD4KVjxBBK4AtHxV\nuJRc50kRb99nYddovVDtQx4rUeZG/k/n3CmFtq76f5RB6hGEDSrOLzQpPLEADPHh\npG1NY3IW4oq9EkzGQa56ZzRF1XOFa8L+xY2G5e1jvCp/IEkjTjNae+6Vuyck+xSA\nyXw4zQ0pbLzBE94/E18=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 406,
+          "tcId" : 509,
           "comment" : "extreme value for k and s^-1",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308188024200c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66024201b6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db6db68d82a2b033628ca12ffd36ed0d3bf206957c063c2bf183d7132f20aac7c797a51",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "04008e859e66d1237fdc928a4b954954fef565d203a0731d065d9df41a4fd3812b1cc2487053ea19ce839d200845952f80d80698771d83ccc1fc7f236dbee4c76b2bb4005a04b24c88cd40233fb43c59ea5cf2cb9510d16b1168bc126db64aaf9ab07a7453208fde079095966272bf03bc3312c9b9bab8c795ae375e8a0e8dd81c924e7c27",
-        "wx" : "08e859e66d1237fdc928a4b954954fef565d203a0731d065d9df41a4fd3812b1cc2487053ea19ce839d200845952f80d80698771d83ccc1fc7f236dbee4c76b2bb4",
+        "wx" : "008e859e66d1237fdc928a4b954954fef565d203a0731d065d9df41a4fd3812b1cc2487053ea19ce839d200845952f80d80698771d83ccc1fc7f236dbee4c76b2bb4",
         "wy" : "5a04b24c88cd40233fb43c59ea5cf2cb9510d16b1168bc126db64aaf9ab07a7453208fde079095966272bf03bc3312c9b9bab8c795ae375e8a0e8dd81c924e7c27"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004008e859e66d1237fdc928a4b954954fef565d203a0731d065d9df41a4fd3812b1cc2487053ea19ce839d200845952f80d80698771d83ccc1fc7f236dbee4c76b2bb4005a04b24c88cd40233fb43c59ea5cf2cb9510d16b1168bc126db64aaf9ab07a7453208fde079095966272bf03bc3312c9b9bab8c795ae375e8a0e8dd81c924e7c27",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAjoWeZtEjf9ySikuVSVT+9WXSA6Bz\nHQZdnfQaT9OBKxzCSHBT6hnOg50gCEWVL4DYBph3HYPMwfx/I22+5MdrK7QAWgSy\nTIjNQCM/tDxZ6lzyy5UQ0WsRaLwSbbZKr5qwenRTII/eB5CVlmJyvwO8MxLJubq4\nx5WuN16KDo3YHJJOfCc=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b810400230381860004008e859e66d1237fdc928a4b954954fef565d203a0731d065d9df41a4fd3812b1cc2487053ea19ce839d200845952f80d80698771d83ccc1fc7f236dbee4c76b2bb4005a04b24c88cd40233fb43c59ea5cf2cb9510d16b1168bc126db64aaf9ab07a7453208fde079095966272bf03bc3312c9b9bab8c795ae375e8a0e8dd81c924e7c27",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAjoWeZtEjf9ySikuVSVT+9WXSA6Bz\nHQZdnfQaT9OBKxzCSHBT6hnOg50gCEWVL4DYBph3HYPMwfx/I22+5MdrK7QAWgSy\nTIjNQCM/tDxZ6lzyy5UQ0WsRaLwSbbZKr5qwenRTII/eB5CVlmJyvwO8MxLJubq4\nx5WuN16KDo3YHJJOfCc=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 407,
+          "tcId" : 510,
           "comment" : "extreme value for k",
+          "flags" : [
+            "ArithmeticError"
+          ],
           "msg" : "313233343030",
           "sig" : "308187024200c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd6602410eb10e5ab95f2f26a40700b1300fb8c3c8d5384ffbecf1fdb9e11e67cb7fd6a7f503e6e25ac09bb88b6c3983df764d4d72bc2920e233f0f7974a234a21b00bb447",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66011839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650",
-        "wx" : "0c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66",
-        "wy" : "11839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650"
+        "wx" : "00c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66",
+        "wy" : "011839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66011839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAxoWOBrcEBOnNnj7LZiOVtEKcZIE5\nBT+1Ifgor2BrTT26oUted+/nWSj+HcEnov+o3jNIs8GFakKb+X5+McLlvWYBGDkp\naniaO8AEXIpftCx9G9mY9URJV5tEaBevvRcnPmYsl+5ymV70JkDFULkBP60HYTU8\ncIaicsJAiL6Udp/RZlA=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66011839296a789a3bc0045c8a5fb42c7d1bd998f54449579b446817afbd17273e662c97ee72995ef42640c550b9013fad0761353c7086a272c24088be94769fd16650",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAxoWOBrcEBOnNnj7LZiOVtEKcZIE5\nBT+1Ifgor2BrTT26oUted+/nWSj+HcEnov+o3jNIs8GFakKb+X5+McLlvWYBGDkp\naniaO8AEXIpftCx9G9mY9URJV5tEaBevvRcnPmYsl+5ymV70JkDFULkBP60HYTU8\ncIaicsJAiL6Udp/RZlA=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 408,
-          "comment" : "testing point duplication",
+          "tcId" : 511,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "308185024043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b023210281757b30e19218a37cbd612086fbc158caa8b4e1acb2ec00837e5d941f342fb3cc0241492492492492492492492492492492492492492492492492492492492492492491795c5c808906cc587ff89278234a8566e3f565f5ca840a3d887dac7214bee9b8",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 409,
-          "comment" : "testing point duplication",
+          "tcId" : 512,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "308187024201ffbc07ff041506dc73a75086a43252fb43b6327af3c6b2cc7d6acca94fdcdefd78dc0b56a22d16f2eec26ae0c1fb484d059300e80bd6b0472b3d1222ff5d08b03d0241492492492492492492492492492492492492492492492492492492492492492491795c5c808906cc587ff89278234a8566e3f565f5ca840a3d887dac7214bee9b8",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd6600e7c6d6958765c43ffba375a04bd382e426670abbb6a864bb97e85042e8d8c199d368118d66a10bd9bf3aaf46fec052f89ecac38f795d8d3dbf77416b89602e99af",
-        "wx" : "0c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66",
-        "wy" : "0e7c6d6958765c43ffba375a04bd382e426670abbb6a864bb97e85042e8d8c199d368118d66a10bd9bf3aaf46fec052f89ecac38f795d8d3dbf77416b89602e99af"
+        "wx" : "00c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd66",
+        "wy" : "00e7c6d6958765c43ffba375a04bd382e426670abbb6a864bb97e85042e8d8c199d368118d66a10bd9bf3aaf46fec052f89ecac38f795d8d3dbf77416b89602e99af"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd6600e7c6d6958765c43ffba375a04bd382e426670abbb6a864bb97e85042e8d8c199d368118d66a10bd9bf3aaf46fec052f89ecac38f795d8d3dbf77416b89602e99af",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAxoWOBrcEBOnNnj7LZiOVtEKcZIE5\nBT+1Ifgor2BrTT26oUted+/nWSj+HcEnov+o3jNIs8GFakKb+X5+McLlvWYA58bW\nlYdlxD/7o3WgS9OC5CZnCru2qGS7l+hQQujYwZnTaBGNZqEL2b86r0b+wFL4nsrD\nj3ldjT2/d0FriWAuma8=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400c6858e06b70404e9cd9e3ecb662395b4429c648139053fb521f828af606b4d3dbaa14b5e77efe75928fe1dc127a2ffa8de3348b3c1856a429bf97e7e31c2e5bd6600e7c6d6958765c43ffba375a04bd382e426670abbb6a864bb97e85042e8d8c199d368118d66a10bd9bf3aaf46fec052f89ecac38f795d8d3dbf77416b89602e99af",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAxoWOBrcEBOnNnj7LZiOVtEKcZIE5\nBT+1Ifgor2BrTT26oUted+/nWSj+HcEnov+o3jNIs8GFakKb+X5+McLlvWYA58bW\nlYdlxD/7o3WgS9OC5CZnCru2qGS7l+hQQujYwZnTaBGNZqEL2b86r0b+wFL4nsrD\nj3ldjT2/d0FriWAuma8=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 410,
-          "comment" : "testing point duplication",
+          "tcId" : 513,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "308185024043f800fbeaf9238c58af795bcdad04bc49cd850c394d3382953356b023210281757b30e19218a37cbd612086fbc158caa8b4e1acb2ec00837e5d941f342fb3cc0241492492492492492492492492492492492492492492492492492492492492492491795c5c808906cc587ff89278234a8566e3f565f5ca840a3d887dac7214bee9b8",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         },
         {
-          "tcId" : 411,
-          "comment" : "testing point duplication",
+          "tcId" : 514,
+          "comment" : "public key shares x-coordinate with generator",
+          "flags" : [
+            "PointDuplication"
+          ],
           "msg" : "313233343030",
           "sig" : "308187024201ffbc07ff041506dc73a75086a43252fb43b6327af3c6b2cc7d6acca94fdcdefd78dc0b56a22d16f2eec26ae0c1fb484d059300e80bd6b0472b3d1222ff5d08b03d0241492492492492492492492492492492492492492492492492492492492492492491795c5c808906cc587ff89278234a8566e3f565f5ca840a3d887dac7214bee9b8",
-          "result" : "invalid",
-          "flags" : []
+          "result" : "invalid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
-        "uncompressed" : "04012a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8012333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e",
-        "wx" : "12a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8",
-        "wy" : "12333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e"
-      },
-      "keyDer" : "30819b301006072a8648ce3d020106052b810400230381860004012a908bfc5b70e17bdfae74294994808bf2a42dab59af8b0523a026d640a2a3d6d344520b62177e2cfa339ca42fb0883ec425904fbda2833a3b5b0a9a00811365d8012333d532f8f8eb1a623c378a3694651192bbda833e3b8d7b8f90b2bfc9b045f8a55e1b6a5fe1512c400c4bc9c86fd7c699d642f5cee9bb827c8b0abc0da01cef1e",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQBKpCL/Ftw4XvfrnQpSZSAi/KkLatZ\nr4sFI6Am1kCio9bTRFILYhd+LPoznKQvsIg+xCWQT72igzo7WwqaAIETZdgBIzPV\nMvj46xpiPDeKNpRlEZK72oM+O417j5Cyv8mwRfilXhtqX+FRLEAMS8nIb9fGmdZC\n9c7pu4J8iwq8DaAc7x4=\n-----END PUBLIC KEY-----",
-      "sha" : "SHA-512",
-      "type" : "ECDSAVer",
-      "tests" : [
-        {
-          "tcId" : 412,
-          "comment" : "pseudorandom signature",
-          "msg" : "",
-          "sig" : "308188024201625d6115092a8e2ee21b9f8a425aa73814dec8b2335e86150ab4229f5a3421d2e6256d632c7a4365a1ee01dd2a936921bbb4551a512d1d4b5a56c314e4a02534c5024201b792d23f2649862595451055777bda1b02dc6cc8fef23231e44b921b16155cd42257441d75a790371e91819f0a9b1fd0ebd02c90b5b774527746ed9bfe743dbe2f",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 413,
-          "comment" : "pseudorandom signature",
-          "msg" : "4d7367",
-          "sig" : "30818602415adc833cbc1d6141ced457bab2b01b0814054d7a28fa8bb2925d1e7525b7cf7d5c938a17abfb33426dcc05ce8d44db02f53a75ea04017dca51e1fbb14ce3311b1402415f69b2a6de129147a8437b79c72315d35173d88c2d6119085c90dae8ec05c55e067e7dfa4f681035e3dccab099291c0ecf4428332a9cb0736d16e79111ac76d766",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 414,
-          "comment" : "pseudorandom signature",
-          "msg" : "313233343030",
-          "sig" : "3081880242014141e4d94a58c1e747cbd9ee6670a41eac3c26fb4db3248e45d583179076e6b19a8e2003657a108f91f9a103157edff9b37df2b436a77dc112927d907ac9ba258702420108afa91b34bd904c680471e943af336fb90c5fb2b91401a58c9b1f467bf81af8049965dd8b45f12e152f4f7fd3780e3492f31ed2680d4777fbe655fe779ad897ab",
-          "result" : "valid",
-          "flags" : []
-        },
-        {
-          "tcId" : 415,
-          "comment" : "pseudorandom signature",
-          "msg" : "0000000000000000000000000000000000000000",
-          "sig" : "308187024108135d3f1ae9e26fba825643ed8a29d63d7843720e93566aa09db2bdf5aaa69afbcc0c51e5295c298f305ba7b870f0a85bb5699cdf40764aab59418f77c6ffb4520242011d345256887fb351f5700961a7d47572e0d669056cb1d5619345c0c987f3331c2fe2c6df848a5c610422defd6212b64346161aa871ae55b1fe4add5f68836eb181",
-          "result" : "valid",
-          "flags" : []
-        }
-      ]
-    },
-    {
-      "key" : {
-        "curve" : "secp521r1",
-        "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400304b3d071ed1ef302391b566af8c9d1cb7afe9aabc141ac39ab39676c63e48c1b2c6451eb460e452bd573e1fb5f15b8e5f9c03f634d8db6897285064b3ce9bd98a00000000009b98bfd33398c2cf8606fc0ae468b6d617ccb3e704af3b8506642a775d5b4da9d00209364a9f0a4ad77cbac604a015c97e6b5a18844a589a4f1c7d9625",
         "wx" : "304b3d071ed1ef302391b566af8c9d1cb7afe9aabc141ac39ab39676c63e48c1b2c6451eb460e452bd573e1fb5f15b8e5f9c03f634d8db6897285064b3ce9bd98a",
-        "wy" : "09b98bfd33398c2cf8606fc0ae468b6d617ccb3e704af3b8506642a775d5b4da9d00209364a9f0a4ad77cbac604a015c97e6b5a18844a589a4f1c7d9625"
+        "wy" : "009b98bfd33398c2cf8606fc0ae468b6d617ccb3e704af3b8506642a775d5b4da9d00209364a9f0a4ad77cbac604a015c97e6b5a18844a589a4f1c7d9625"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400304b3d071ed1ef302391b566af8c9d1cb7afe9aabc141ac39ab39676c63e48c1b2c6451eb460e452bd573e1fb5f15b8e5f9c03f634d8db6897285064b3ce9bd98a00000000009b98bfd33398c2cf8606fc0ae468b6d617ccb3e704af3b8506642a775d5b4da9d00209364a9f0a4ad77cbac604a015c97e6b5a18844a589a4f1c7d9625",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAMEs9Bx7R7zAjkbVmr4ydHLev6aq8\nFBrDmrOWdsY+SMGyxkUetGDkUr1XPh+18VuOX5wD9jTY22iXKFBks86b2YoAAAAA\nAJuYv9MzmMLPhgb8CuRottYXzLPnBK87hQZkKnddW02p0AIJNkqfCkrXfLrGBKAV\nyX5rWhiESliaTxx9liU=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400304b3d071ed1ef302391b566af8c9d1cb7afe9aabc141ac39ab39676c63e48c1b2c6451eb460e452bd573e1fb5f15b8e5f9c03f634d8db6897285064b3ce9bd98a00000000009b98bfd33398c2cf8606fc0ae468b6d617ccb3e704af3b8506642a775d5b4da9d00209364a9f0a4ad77cbac604a015c97e6b5a18844a589a4f1c7d9625",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAMEs9Bx7R7zAjkbVmr4ydHLev6aq8\nFBrDmrOWdsY+SMGyxkUetGDkUr1XPh+18VuOX5wD9jTY22iXKFBks86b2YoAAAAA\nAJuYv9MzmMLPhgb8CuRottYXzLPnBK87hQZkKnddW02p0AIJNkqfCkrXfLrGBKAV\nyX5rWhiESliaTxx9liU=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 416,
+          "tcId" : 515,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3081870242011c9684af6dc52728410473c63053b01c358d67e81f8a1324ad711c60481a4a86dd3e75de20ca55ce7a9a39b1f82fd5da4fadf26a5bb8edd467af8825efe4746218024134c058aba6488d6943e11e0d1348429449ea17ac5edf8bcaf654106b98b2ddf346c537b8a9a3f9b3174b77637d220ef5318dbbc33d0aac0fe2ddeda17b23cb2de6",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 417,
+          "tcId" : 516,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30818702417c47a668625648cd8a31ac92174cf3d61041f7ad292588def6ed143b1ff9a288fd20cf36f58d4bfe4b2cd4a381d4da50c8eda5674f020449ae1d3dd77e44ed485e024201058e86b327d284e35bab49fc7c335417573f310afa9e1a53566e0fae516e099007965030f6f46b077116353f26cb466d1cf3f35300d744d2d8f883c8a31b43c20d",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 418,
+          "tcId" : 517,
           "comment" : "y-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "308188024201e4e9f3a7b800de63407b8703ac545226541c97a673566711f70e2b9ccb21a145ad4637825b023d1ea9f18e60897413711611a85c1179bff9c107368f1c1b61c24c024201de948ee577c3d4e4122a52ecccac59abb6fa937dfb3e4b988cb243efe98740309452ba013112b225b3b1b1384d5f68796845199a2602a8d4505a331b07d101188e",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400304b3d071ed1ef302391b566af8c9d1cb7afe9aabc141ac39ab39676c63e48c1b2c6451eb460e452bd573e1fb5f15b8e5f9c03f634d8db6897285064b3ce9bd98a01ffffffff6467402ccc673d3079f903f51b974929e8334c18fb50c47af99bd588a2a4b2562ffdf6c9b560f5b528834539fb5fea368194a5e77bb5a765b0e38269da",
         "wx" : "304b3d071ed1ef302391b566af8c9d1cb7afe9aabc141ac39ab39676c63e48c1b2c6451eb460e452bd573e1fb5f15b8e5f9c03f634d8db6897285064b3ce9bd98a",
-        "wy" : "1ffffffff6467402ccc673d3079f903f51b974929e8334c18fb50c47af99bd588a2a4b2562ffdf6c9b560f5b528834539fb5fea368194a5e77bb5a765b0e38269da"
+        "wy" : "01ffffffff6467402ccc673d3079f903f51b974929e8334c18fb50c47af99bd588a2a4b2562ffdf6c9b560f5b528834539fb5fea368194a5e77bb5a765b0e38269da"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400304b3d071ed1ef302391b566af8c9d1cb7afe9aabc141ac39ab39676c63e48c1b2c6451eb460e452bd573e1fb5f15b8e5f9c03f634d8db6897285064b3ce9bd98a01ffffffff6467402ccc673d3079f903f51b974929e8334c18fb50c47af99bd588a2a4b2562ffdf6c9b560f5b528834539fb5fea368194a5e77bb5a765b0e38269da",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAMEs9Bx7R7zAjkbVmr4ydHLev6aq8\nFBrDmrOWdsY+SMGyxkUetGDkUr1XPh+18VuOX5wD9jTY22iXKFBks86b2YoB////\n/2RnQCzMZz0wefkD9RuXSSnoM0wY+1DEevmb1YiipLJWL/32ybVg9bUog0U5+1/q\nNoGUped7tadlsOOCado=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400304b3d071ed1ef302391b566af8c9d1cb7afe9aabc141ac39ab39676c63e48c1b2c6451eb460e452bd573e1fb5f15b8e5f9c03f634d8db6897285064b3ce9bd98a01ffffffff6467402ccc673d3079f903f51b974929e8334c18fb50c47af99bd588a2a4b2562ffdf6c9b560f5b528834539fb5fea368194a5e77bb5a765b0e38269da",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAMEs9Bx7R7zAjkbVmr4ydHLev6aq8\nFBrDmrOWdsY+SMGyxkUetGDkUr1XPh+18VuOX5wD9jTY22iXKFBks86b2YoB////\n/2RnQCzMZz0wefkD9RuXSSnoM0wY+1DEevmb1YiipLJWL/32ybVg9bUog0U5+1/q\nNoGUped7tadlsOOCado=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 419,
+          "tcId" : 518,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "308187024200b6cf64861a2b16e33976095dbf45a592c7c24228c4a1dd727f303d5eeb87e5388ad05c328f824c40abd3e6ce003fef5cd59dee0069ad6348ea6e57f90f6bdc0a820241228181c180366e5451dfef3593ce664804cb42d5a8d5046b816b3daf6602fafd9ac2dc24b8c93a10024480882558b6ad3d9e905923dcd0fd2a11964754a9b46b8f",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 420,
+          "tcId" : 519,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30818802420093c8f766827d6dc15c810fa30433153a5e742859205ee8389fbf695c8840dc917440870acc5b160087ffd0cd9a6081029c60a7c26d5e8aa9a0570f4efdeb13dea20242012ec3bbf75a0ad3df40310266648a36db820217ed7fa94e9c8313e03293ef4f6a40e736fb8f208ad8fb883ca509d48046910523645459c27829d54431463b2548c7",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 421,
+          "tcId" : 520,
           "comment" : "y-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30818802420152388c6da66164b706b41dd4dd48176d6eaf6525f876ef0ff2d147f6966ebfadf1767fa66d04203d3ec9c937a1f0c945aed953e34be444c219fd3b94d3277aa652024201658c1e5b2e563a49d11c883d05c491d628f0a92c3e3dc8db9a4c8d5f0dc846ac22af8b3c5fb5bbe2cfa98614dcffd87de1cee2c5912a5899505a0c5bcaa513e2c6",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "040000000002fba6a061201ea6b1ed4265163568735ebab78600cdf6a71101dc63beaf546d97a214fc6396793b014eb1aa7a728f53deb2ff9999a3808ddfed15e9629b01993852dadc39299a5a45b6bd7c8dc8ec67e7adbb359fa8fa5d44977e15e2e5a9acf0c33645f3f2c68c526e07732fb35043719cfafc16063c8e58850a958436a4e5",
-        "wx" : "2fba6a061201ea6b1ed4265163568735ebab78600cdf6a71101dc63beaf546d97a214fc6396793b014eb1aa7a728f53deb2ff9999a3808ddfed15e9629b",
-        "wy" : "1993852dadc39299a5a45b6bd7c8dc8ec67e7adbb359fa8fa5d44977e15e2e5a9acf0c33645f3f2c68c526e07732fb35043719cfafc16063c8e58850a958436a4e5"
+        "wx" : "02fba6a061201ea6b1ed4265163568735ebab78600cdf6a71101dc63beaf546d97a214fc6396793b014eb1aa7a728f53deb2ff9999a3808ddfed15e9629b",
+        "wy" : "01993852dadc39299a5a45b6bd7c8dc8ec67e7adbb359fa8fa5d44977e15e2e5a9acf0c33645f3f2c68c526e07732fb35043719cfafc16063c8e58850a958436a4e5"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040000000002fba6a061201ea6b1ed4265163568735ebab78600cdf6a71101dc63beaf546d97a214fc6396793b014eb1aa7a728f53deb2ff9999a3808ddfed15e9629b01993852dadc39299a5a45b6bd7c8dc8ec67e7adbb359fa8fa5d44977e15e2e5a9acf0c33645f3f2c68c526e07732fb35043719cfafc16063c8e58850a958436a4e5",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAAAAAAvumoGEgHqax7UJlFjVoc166\nt4YAzfanEQHcY76vVG2XohT8Y5Z5OwFOsap6co9T3rL/mZmjgI3f7RXpYpsBmThS\n2tw5KZpaRba9fI3I7Gfnrbs1n6j6XUSXfhXi5ams8MM2RfPyxoxSbgdzL7NQQ3Gc\n+vwWBjyOWIUKlYQ2pOU=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b8104002303818600040000000002fba6a061201ea6b1ed4265163568735ebab78600cdf6a71101dc63beaf546d97a214fc6396793b014eb1aa7a728f53deb2ff9999a3808ddfed15e9629b01993852dadc39299a5a45b6bd7c8dc8ec67e7adbb359fa8fa5d44977e15e2e5a9acf0c33645f3f2c68c526e07732fb35043719cfafc16063c8e58850a958436a4e5",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAAAAAAvumoGEgHqax7UJlFjVoc166\nt4YAzfanEQHcY76vVG2XohT8Y5Z5OwFOsap6co9T3rL/mZmjgI3f7RXpYpsBmThS\n2tw5KZpaRba9fI3I7Gfnrbs1n6j6XUSXfhXi5ams8MM2RfPyxoxSbgdzL7NQQ3Gc\n+vwWBjyOWIUKlYQ2pOU=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 422,
+          "tcId" : 521,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3081880242010e89470f981d2c7c5c96587121a67323bb96ff2427739d0d885ea277293efa3b25c0bda04d81466198a3cbfc441f1b1b98f6bcdc2589d9d91a17a7899f70d0461e0242017351b0da8c8d0e4aa0974669d190fa2f90aa50227160594dfb55755002365441de17ea42902128a6f81e554177ed509c0cec31fd5053fae03f62ff76579ba92bda",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 423,
+          "tcId" : 522,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "3081880242011094ac23ca46a3e2b4ac3baae6504f1bfb3ddf2db9ab40eda32d8e0a05727998f8552a033bb05241e826a86a1d03014eae3aa5fe1a45caac1db3e8138b9cf5906802420147edb15a5080ee2f929f78b6ac86604aae51b674fa46eaae7fdfd90bf64d6189341155f4eba937eae74c9e480eb4fb7e6aafd4285e7fc503ee6ec20f0b1415be06",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 424,
+          "tcId" : 523,
           "comment" : "x-coordinate of the public key is small",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "308188024201d876ae174da31e128babff9f1d15507660bdc7958750844dc4f4291f75a882a22f177f704be6067bf7ce8f06b8626d971e6ef5dcb666fa975c1e11126e04fccce2024201abb12630a68b669e6ad2d8d62654d75dfbc6b54a8e3a9c915be663e080ddcc348e57a10e2b1dd9f03e1b897796ad889b075e5919dc5bf37a112d92c693456e6457",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0401fffffffe1d5d52b31ca52f8947a35593edf164cd324f833b90935846c64db1454df9f028dc8bc36bb04cb7f0cceceba01a3844097f7c35eeaa81428db0cca6333101b7c70277d0bf78a3c7b62c937f0cb2cad2565f5514f6205ceb1a193d4fdb45ba6e6cec07827bae0b16b8316c3539a15114d0de6d2de407fd7117551a70826eada6",
-        "wx" : "1fffffffe1d5d52b31ca52f8947a35593edf164cd324f833b90935846c64db1454df9f028dc8bc36bb04cb7f0cceceba01a3844097f7c35eeaa81428db0cca63331",
-        "wy" : "1b7c70277d0bf78a3c7b62c937f0cb2cad2565f5514f6205ceb1a193d4fdb45ba6e6cec07827bae0b16b8316c3539a15114d0de6d2de407fd7117551a70826eada6"
+        "wx" : "01fffffffe1d5d52b31ca52f8947a35593edf164cd324f833b90935846c64db1454df9f028dc8bc36bb04cb7f0cceceba01a3844097f7c35eeaa81428db0cca63331",
+        "wy" : "01b7c70277d0bf78a3c7b62c937f0cb2cad2565f5514f6205ceb1a193d4fdb45ba6e6cec07827bae0b16b8316c3539a15114d0de6d2de407fd7117551a70826eada6"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401fffffffe1d5d52b31ca52f8947a35593edf164cd324f833b90935846c64db1454df9f028dc8bc36bb04cb7f0cceceba01a3844097f7c35eeaa81428db0cca6333101b7c70277d0bf78a3c7b62c937f0cb2cad2565f5514f6205ceb1a193d4fdb45ba6e6cec07827bae0b16b8316c3539a15114d0de6d2de407fd7117551a70826eada6",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB/////h1dUrMcpS+JR6NVk+3xZM0y\nT4M7kJNYRsZNsUVN+fAo3IvDa7BMt/DM7OugGjhECX98Ne6qgUKNsMymMzEBt8cC\nd9C/eKPHtiyTfwyyytJWX1UU9iBc6xoZPU/bRbpubOwHgnuuCxa4MWw1OaFRFNDe\nbS3kB/1xF1UacIJuraY=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000401fffffffe1d5d52b31ca52f8947a35593edf164cd324f833b90935846c64db1454df9f028dc8bc36bb04cb7f0cceceba01a3844097f7c35eeaa81428db0cca6333101b7c70277d0bf78a3c7b62c937f0cb2cad2565f5514f6205ceb1a193d4fdb45ba6e6cec07827bae0b16b8316c3539a15114d0de6d2de407fd7117551a70826eada6",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQB/////h1dUrMcpS+JR6NVk+3xZM0y\nT4M7kJNYRsZNsUVN+fAo3IvDa7BMt/DM7OugGjhECX98Ne6qgUKNsMymMzEBt8cC\nd9C/eKPHtiyTfwyyytJWX1UU9iBc6xoZPU/bRbpubOwHgnuuCxa4MWw1OaFRFNDe\nbS3kB/1xF1UacIJuraY=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 425,
+          "tcId" : 524,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30818602414ed692af1ed1b4bd5cea3aa8ddc6f3f15d8a6ee0016fa0e8eb958580e7421832ecc0e387c34aafac6380bac419ea45c42ae6426af503847f22c49c2f456338c1a702417aceadde02ace1668bc1a3360d34e125afde230f536c154d91e6c876bee1d34ae06edcbbca0c7cd17646840913164740b12e2e224fe3ef3dec6fd84a81b581c188",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 426,
+          "tcId" : 525,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "308188024200e01094048fcf7a1e2ec66faedffc40f48c9c93514325bde6b4958d80f0413efde7eec1dc6de65f96009c069397e51da2eb1729efa287afd5552b25a9e427a6d836024201489e7e124f66942e642de992e60b3a86fcce576767719390c3a312fcdeaa560a7fbb0cabb35e05a6d6f3499160fd2dba12d29b613b16dec7494c950d65fdf11fa3",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 427,
+          "tcId" : 526,
           "comment" : "x-coordinate of the public key is large",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "308188024201d296292213380de133dc66eceb8bd857a5c468afe855c05da9db937373b51f9020ca11353415da76bb6af997a486d2370e31adcc0a4531952a3b59428678ee59430242015979a3c609c2c2099ae1b290da3d613b248e3a10de7ad770dffc82fb33e74fc3207533f97285cf4557a6407e9a775e59efeaee4264b2634933a6baf8c406f0c4a9",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     },
     {
-      "key" : {
+      "type" : "EcdsaVerify",
+      "publicKey" : {
+        "type" : "EcPublicKey",
         "curve" : "secp521r1",
         "keySize" : 521,
-        "type" : "ECPublicKey",
         "uncompressed" : "0400c7c8817bf2f0652a4a4b5140c773e261080a0a111395856e8a3350f5eb5612bd63b367b965e92e9538ea3b7908aef1ade4b68e17f9f9148495c167d1c4dd4913490008bf0be2979abb8111fd0d768adcad774113a822c1bb60887053b5cf8c9563e76705a391ece154b5dfb114b20e351df4014bec19fa87720845801cf06b7fffffff",
-        "wx" : "0c7c8817bf2f0652a4a4b5140c773e261080a0a111395856e8a3350f5eb5612bd63b367b965e92e9538ea3b7908aef1ade4b68e17f9f9148495c167d1c4dd491349",
+        "wx" : "00c7c8817bf2f0652a4a4b5140c773e261080a0a111395856e8a3350f5eb5612bd63b367b965e92e9538ea3b7908aef1ade4b68e17f9f9148495c167d1c4dd491349",
         "wy" : "08bf0be2979abb8111fd0d768adcad774113a822c1bb60887053b5cf8c9563e76705a391ece154b5dfb114b20e351df4014bec19fa87720845801cf06b7fffffff"
       },
-      "keyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400c7c8817bf2f0652a4a4b5140c773e261080a0a111395856e8a3350f5eb5612bd63b367b965e92e9538ea3b7908aef1ade4b68e17f9f9148495c167d1c4dd4913490008bf0be2979abb8111fd0d768adcad774113a822c1bb60887053b5cf8c9563e76705a391ece154b5dfb114b20e351df4014bec19fa87720845801cf06b7fffffff",
-      "keyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAx8iBe/LwZSpKS1FAx3PiYQgKChET\nlYVuijNQ9etWEr1js2e5ZekulTjqO3kIrvGt5LaOF/n5FISVwWfRxN1JE0kACL8L\n4peau4ER/Q12itytd0ETqCLBu2CIcFO1z4yVY+dnBaOR7OFUtd+xFLIONR30AUvs\nGfqHcghFgBzwa3////8=\n-----END PUBLIC KEY-----",
+      "publicKeyDer" : "30819b301006072a8648ce3d020106052b81040023038186000400c7c8817bf2f0652a4a4b5140c773e261080a0a111395856e8a3350f5eb5612bd63b367b965e92e9538ea3b7908aef1ade4b68e17f9f9148495c167d1c4dd4913490008bf0be2979abb8111fd0d768adcad774113a822c1bb60887053b5cf8c9563e76705a391ece154b5dfb114b20e351df4014bec19fa87720845801cf06b7fffffff",
+      "publicKeyPem" : "-----BEGIN PUBLIC KEY-----\nMIGbMBAGByqGSM49AgEGBSuBBAAjA4GGAAQAx8iBe/LwZSpKS1FAx3PiYQgKChET\nlYVuijNQ9etWEr1js2e5ZekulTjqO3kIrvGt5LaOF/n5FISVwWfRxN1JE0kACL8L\n4peau4ER/Q12itytd0ETqCLBu2CIcFO1z4yVY+dnBaOR7OFUtd+xFLIONR30AUvs\nGfqHcghFgBzwa3////8=\n-----END PUBLIC KEY-----\n",
       "sha" : "SHA-512",
-      "type" : "ECDSAVer",
       "tests" : [
         {
-          "tcId" : 428,
+          "tcId" : 527,
           "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "308188024201ef8f785c51a25ae2cd93487b5c848d4af133217a91f51359c966e7538e68743578122df5830002f96f6fadb5bc44480e3b3b2c804e4c51cf95d059d5646c5cef21024201ba2276cc003e87bea37c3724e58a0ab885f56d09b8b5718f674f9c70f3b5ecfb4ad1f3417b420ec40810e08826efa7d8ad6ca7c6a7840348097f92b2de8d6e080b",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 429,
+          "tcId" : 528,
           "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "30818802420155978adc4b570d897511f5ecfb65a31947e6e989da17dea716625bb3fa7b92b853623eb0cd9ce2a5e2b4d8c1c2a90ec04fe79d012576ec728a45c5ce47c6d500c0024200f79fa8b94ee282a3d1815892cbf15d7ebdf62cb042c76bb3c710c23e32b75992cc249d84072198e4ed63d72435a07d2ed76f278d7399f61a5b5c997f45692fed22",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         },
         {
-          "tcId" : 430,
+          "tcId" : 529,
           "comment" : "y-coordinate of the public key has many trailing 1's",
+          "flags" : [
+            "EdgeCasePublicKey"
+          ],
           "msg" : "4d657373616765",
           "sig" : "308188024201a2af29c58184ca861e7cd931f39cea064b199eee563f241cd5ecf6ebb2ade728f1be23cf007ebe8ef0c42d99f9f5190f6815446afc3043a820d7daf27e86b83b8a024201a2acd1822eb539383defff8769aad8bacd50cd24ca7aa6670671418110177808c3f4fbe6041b9cb898359ee61e04824adedd62b39fe5791907a20586333bd3c76d",
-          "result" : "valid",
-          "flags" : []
+          "result" : "valid"
         }
       ]
     }


### PR DESCRIPTION
Update Wycheproof ECDSA test vectors to v1. This PR updates one single unit test file: `ECDSASignatureTests` which contains tests for `P256`, `P383` and `P521` with different Hash Function versions. Since all curves with HashFunctions are put in the same unit test file I had to update all vectors simultaneously.

@Lukasa let me know if you prefer it I break out the each test vector file into seperate unit test files, and do one PR per test vector file.

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

We ought to use as many and as up to date test vectors as possible. Wycheproofs v0 were created 4 years ago and were due some upgrade.

### Modifications:
The following Wycheproof test vectors have been updated:
* `ecdsa_secp256r1_sha256_test.json`
* `ecdsa_secp256r1_sha512_test.json`
* `ecdsa_secp384r1_sha384_test.json`
* `ecdsa_secp384r1_sha512_test.json`
* `ecdsa_secp521r1_sha512_test.json`

The following unit test file have been updated `ECDSASignatureTests.swift`, with a trivial JSON key change: `key` -> `publicKey`.

### Result:

Many more tests are run.