### PR TITLE
Make Curve25519 `PublicKey`s conform to `Equatable`

### DIFF
--- a/Sources/Crypto/Keys/EC/Ed25519.swift
+++ b/Sources/Crypto/Keys/EC/Ed25519.swift
@@ -57,7 +57,7 @@ extension Curve25519 {
             }
         }
 
-        public struct PublicKey {
+		public struct PublicKey: Equatable {
             private var baseKey: Curve25519.Signing.Curve25519PublicKeyImpl
 
             public init<D: ContiguousBytes>(rawRepresentation: D) throws {
@@ -75,6 +75,10 @@ extension Curve25519 {
             var keyBytes: [UInt8] {
                 return self.baseKey.keyBytes
             }
+			
+			public static func ==(lhs: Self, rhs: Self) -> Bool {
+				lhs.rawRepresentation == rhs.rawRepresentation
+			}
         }
     }
 }

--- a/Sources/Crypto/Keys/EC/X25519Keys.swift
+++ b/Sources/Crypto/Keys/EC/X25519Keys.swift
@@ -26,7 +26,7 @@ extension Curve25519 {
         typealias Curve25519PublicKeyImpl = Curve25519.KeyAgreement.OpenSSLCurve25519PublicKeyImpl
         #endif
 
-        public struct PublicKey: ECPublicKey {
+        public struct PublicKey: ECPublicKey, Equatable {
             fileprivate var baseKey: Curve25519PublicKeyImpl
 
             /// Initializes a Curve25519 Key for Key Agreement.
@@ -54,6 +54,10 @@ extension Curve25519 {
             private func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
                 return try self.baseKey.keyBytes.withUnsafeBytes(body)
             }
+			
+			public static func ==(lhs: Self, rhs: Self) -> Bool {
+				lhs.rawRepresentation == rhs.rawRepresentation
+			}
         }
 
         public struct PrivateKey: ECPrivateKey, DiffieHellmanKeyAgreement {

--- a/Tests/CryptoTests/Signatures/EdDSA/EdDSATests.swift
+++ b/Tests/CryptoTests/Signatures/EdDSA/EdDSATests.swift
@@ -75,4 +75,38 @@ class EdDSATests: XCTestCase {
         // This signature should be invalid
         XCTAssertFalse(privateKey.publicKey.isValidSignature(DispatchData.empty, for: DispatchData.empty))
     }
+	
+	func testCurve25519SigningPublicKeyEquatable() throws {
+		// Inequality
+		
+		// The probability of this inequality check loop
+		// accidentally failing is... 1/(2^246), i.e. low.
+		for _ in 0..<1024 {
+			XCTAssertNotEqual(
+				Curve25519.Signing.PrivateKey().publicKey,
+				Curve25519.Signing.PrivateKey().publicKey
+			)
+		}
+		
+		// Equality
+		let publicKey = Curve25519.Signing.PrivateKey().publicKey
+		XCTAssertEqual(publicKey, publicKey)
+	}
+	
+	func testCurve25519KeyAgreementPublicKeyEquatable() throws {
+		// Inequality
+		
+		// The probability of this inequality check loop
+		// accidentally failing is... 1/(2^246), i.e. low.
+		for _ in 0..<1024 {
+			XCTAssertNotEqual(
+				Curve25519.KeyAgreement.PrivateKey().publicKey,
+				Curve25519.KeyAgreement.PrivateKey().publicKey
+			)
+		}
+		
+		// Equality
+		let publicKey = Curve25519.KeyAgreement.PrivateKey().publicKey
+		XCTAssertEqual(publicKey, publicKey)
+	}
 }


### PR DESCRIPTION
Make Curve25519 PublicKeys conform to `Equatable`

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

When PublicKey's are used in `struct`'s that are marked `Equatable` those structs cannot be auto-synthetized conform to `Equatable` since these PublicKeys before this PR do not conform to `Equatable`. This is rather annoying. And during the 5 years I've been working in the crypto industry I have added my own conformance to CryptoKit's PublicKeys to be `Equatable` probably more than 10 times!

There exists no security risk in making PublicKeys conform to `Equatable`, the current implementation does not use `safeCompare`, it could, but I deem it not necessary.

There is really no drawback in adding `Equatable` conformance.

### Modifications:

1. Make `Curve25519.Signing.PublicKey` be `Equatable`
2. Make `Curve25519.KeyAgreement.PublicKey` be `Equatable`
3. Add tests for these. 

### Result:

`Curve25519.Signing.PublicKey` and `Curve25519.KeyAgreement.PublicKey` now conform to `Equatable`.