### PR TITLE
Make NIST `PublicKey`s conform to `Equatable`

### DIFF
--- a/Sources/Crypto/Key Agreement/ECDH.swift
+++ b/Sources/Crypto/Key Agreement/ECDH.swift
@@ -88,6 +88,10 @@ extension P256 {
                 let pemDocument = ASN1.PEMDocument(type: "PUBLIC KEY", derBytes: self.derRepresentation)
                 return pemDocument.pemString
             }
+			
+			public static func ==(lhs: Self, rhs: Self) -> Bool {
+				lhs.rawRepresentation == rhs.rawRepresentation
+			}
         }
 
         public struct PrivateKey: NISTECPrivateKey {
@@ -222,6 +226,10 @@ extension P256 {
                 let pemDocument = ASN1.PEMDocument(type: "PUBLIC KEY", derBytes: self.derRepresentation)
                 return pemDocument.pemString
             }
+			
+			public static func ==(lhs: Self, rhs: Self) -> Bool {
+				lhs.rawRepresentation == rhs.rawRepresentation
+			}
         }
 
         public struct PrivateKey: NISTECPrivateKey {
@@ -356,6 +364,10 @@ extension P384 {
                 let pemDocument = ASN1.PEMDocument(type: "PUBLIC KEY", derBytes: self.derRepresentation)
                 return pemDocument.pemString
             }
+			
+			public static func ==(lhs: Self, rhs: Self) -> Bool {
+				lhs.rawRepresentation == rhs.rawRepresentation
+			}
         }
 
         public struct PrivateKey: NISTECPrivateKey {
@@ -490,6 +502,10 @@ extension P384 {
                 let pemDocument = ASN1.PEMDocument(type: "PUBLIC KEY", derBytes: self.derRepresentation)
                 return pemDocument.pemString
             }
+			
+			public static func ==(lhs: Self, rhs: Self) -> Bool {
+				lhs.rawRepresentation == rhs.rawRepresentation
+			}
         }
 
         public struct PrivateKey: NISTECPrivateKey {
@@ -624,6 +640,10 @@ extension P521 {
                 let pemDocument = ASN1.PEMDocument(type: "PUBLIC KEY", derBytes: self.derRepresentation)
                 return pemDocument.pemString
             }
+			
+			public static func ==(lhs: Self, rhs: Self) -> Bool {
+				lhs.rawRepresentation == rhs.rawRepresentation
+			}
         }
 
         public struct PrivateKey: NISTECPrivateKey {
@@ -758,6 +778,10 @@ extension P521 {
                 let pemDocument = ASN1.PEMDocument(type: "PUBLIC KEY", derBytes: self.derRepresentation)
                 return pemDocument.pemString
             }
+			
+			public static func ==(lhs: Self, rhs: Self) -> Bool {
+				lhs.rawRepresentation == rhs.rawRepresentation
+			}
         }
 
         public struct PrivateKey: NISTECPrivateKey {

--- a/Sources/Crypto/Key Agreement/ECDH.swift.gyb
+++ b/Sources/Crypto/Key Agreement/ECDH.swift.gyb
@@ -94,6 +94,10 @@ extension ${CURVE} {
                 let pemDocument = ASN1.PEMDocument(type: "PUBLIC KEY", derBytes: self.derRepresentation)
                 return pemDocument.pemString
             }
+			
+			public static func ==(lhs: Self, rhs: Self) -> Bool {
+				lhs.rawRepresentation == rhs.rawRepresentation
+			}
         }
 
         public struct PrivateKey: NISTECPrivateKey {

--- a/Sources/Crypto/Keys/EC/NISTCurvesKeys.swift
+++ b/Sources/Crypto/Keys/EC/NISTCurvesKeys.swift
@@ -32,7 +32,7 @@ protocol ECPrivateKey {
     var publicKey: PublicKey { get }
 }
 
-protocol NISTECPublicKey: ECPublicKey {
+protocol NISTECPublicKey: ECPublicKey, Equatable {
     init<Bytes: ContiguousBytes>(compactRepresentation: Bytes) throws
     init<Bytes: ContiguousBytes>(compressedRepresentation: Bytes) throws
     init<Bytes: ContiguousBytes>(x963Representation: Bytes) throws

--- a/Tests/CryptoTests/Signatures/ECDSA/ECDSASignatureTests.swift
+++ b/Tests/CryptoTests/Signatures/ECDSA/ECDSASignatureTests.swift
@@ -453,6 +453,89 @@ class SignatureTests: XCTestCase {
         let compressedX963Positive = Data(base64Encoded: "A+QHCXtGd5WWSQgp37FBPXMy+nnSwFK79QQD0ZeNMv7L")!
         XCTAssertThrowsError(try P256.Signing.PublicKey(x963Representation: compressedX963Positive))
     }
-    
+	
+	func testP256SigningPublicKeyEquatable() throws {
+		// Equality
+		let publicKey = P256.Signing.PrivateKey().publicKey
+		XCTAssertEqual(publicKey, publicKey)
+
+		// Inequality
+		for _ in 0..<32 {
+			XCTAssertNotEqual(
+				publicKey,
+				P256.Signing.PrivateKey().publicKey
+			)
+		}
+	}
+
+	func testP256KeyAgreementPublicKeyEquatable() throws {
+		// Equality
+		let publicKey = P256.KeyAgreement.PrivateKey().publicKey
+		XCTAssertEqual(publicKey, publicKey)
+
+		// Inequality
+		for _ in 0..<32 {
+			XCTAssertNotEqual(
+				publicKey,
+				P256.KeyAgreement.PrivateKey().publicKey
+			)
+		}
+	}
+	
+	func testP384SigningPublicKeyEquatable() throws {
+		// Equality
+		let publicKey = P384.Signing.PrivateKey().publicKey
+		XCTAssertEqual(publicKey, publicKey)
+
+		// Inequality
+		for _ in 0..<32 {
+			XCTAssertNotEqual(
+				publicKey,
+				P384.Signing.PrivateKey().publicKey
+			)
+		}
+	}
+
+	func testP384KeyAgreementPublicKeyEquatable() throws {
+		// Equality
+		let publicKey = P384.KeyAgreement.PrivateKey().publicKey
+		XCTAssertEqual(publicKey, publicKey)
+
+		// Inequality
+		for _ in 0..<32 {
+			XCTAssertNotEqual(
+				publicKey,
+				P384.KeyAgreement.PrivateKey().publicKey
+			)
+		}
+	}
+	
+	func testP521SigningPublicKeyEquatable() throws {
+		// Equality
+		let publicKey = P521.Signing.PrivateKey().publicKey
+		XCTAssertEqual(publicKey, publicKey)
+
+		// Inequality
+		for _ in 0..<32 {
+			XCTAssertNotEqual(
+				publicKey,
+				P521.Signing.PrivateKey().publicKey
+			)
+		}
+	}
+
+	func testP521KeyAgreementPublicKeyEquatable() throws {
+		// Equality
+		let publicKey = P521.KeyAgreement.PrivateKey().publicKey
+		XCTAssertEqual(publicKey, publicKey)
+
+		// Inequality
+		for _ in 0..<32 {
+			XCTAssertNotEqual(
+				publicKey,
+				P521.KeyAgreement.PrivateKey().publicKey
+			)
+		}
+	}
 }
 #endif // (os(macOS) || os(iOS) || os(watchOS) || os(tvOS)) && CRYPTO_IN_SWIFTPM


### PR DESCRIPTION
Make NIST PublicKey's (`P256`, `P384` and `P521`) conform to `Equatable`

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [x] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

There is really no drawback in adding `Equatable` conformance, as argued in #173

### Modifications:

1. Make `P256`, `P384` and `P521`'s _Signing_ and _KeyAgreement_ `PublicKey` be `Equatable`, by...
2. ... marking `NISTECPublicKey` to be `Equatable` and adding equals function in `ECDH.swift.gyb`
3. Add tests for these. 

### Result:

ALL NIST PublicKey's now conform to `Equatable`