### PR TITLE
Set CRYPTO_IN_SWIFTPM

### DIFF
--- a/Sources/Crypto/CMakeLists.txt
+++ b/Sources/Crypto/CMakeLists.txt
@@ -82,7 +82,7 @@ add_library(Crypto
   "Util/Zeroization.swift")
 
 target_compile_definitions(Crypto PRIVATE
-  CRYPTO_IN_SWIFTPM_FORCE_BUILD_API)
+  "$<$<COMPILE_LANGUAGE:Swift>:CRYPTO_IN_SWIFTPM>")
 target_include_directories(Crypto PRIVATE
   $<TARGET_PROPERTY:CCryptoBoringSSL,INCLUDE_DIRECTORIES>
   $<TARGET_PROPERTY:CCryptoBoringSSLShims,INCLUDE_DIRECTORIES>


### PR DESCRIPTION
Needed to expose SecureEncalve through SwiftCrypto when building for Swift-Certificates. CRYPTO_IN_SWIFTPM is set all of the time in package.swift, while CRYPTO_IN_SWIFTPM_FORCE_BUILD_API is only set in development. Lets enable the one that's on all of the time, and remove the one that isn't so that we get our declarations.

Since `CRYPTO_IN_SWIFTPM` is enabled all of the time, would it make sense to not have it? Or what exactly is it used for?