### PR TITLE
Add an inequality operator ( != ) for digest and DataProtocol comparison.

### DIFF
--- a/Sources/Crypto/ASN1/ASN1.swift
+++ b/Sources/Crypto/ASN1/ASN1.swift
@@ -637,7 +637,7 @@ extension ArraySlice where Element == UInt8 {
             let requiredBits = UInt.bitWidth - length.leadingZeroBitCount
             switch requiredBits {
             case 0...7:
-                // For 0 to 7 bits, the long form is unnacceptable and we require the short.
+                // For 0 to 7 bits, the long form is unacceptable and we require the short.
                 throw CryptoKitASN1Error.unsupportedFieldLength
             case 8...:
                 // For 8 or more bits, fieldLength should be the minimum required.

--- a/Sources/Crypto/CryptoKitErrors.swift
+++ b/Sources/Crypto/CryptoKitErrors.swift
@@ -18,7 +18,7 @@
 /// - incorrectKeySize: A key is being deserialized with an incorrect key size.
 /// - incorrectParameterSize: The number of bytes passed for a given argument is incorrect.
 /// - authenticationFailure: The authentication tag or signature is incorrect.
-/// - underlyingCoreCryptoError: An unexpected error at a lower-level occured.
+/// - underlyingCoreCryptoError: An unexpected error at a lower-level occurred.
 /// - wrapFailure: Failed to wrap key
 /// - unwrapFailure: Failed to unwrap key
 public enum CryptoKitError: Error {

--- a/Sources/Crypto/Digests/Digest.swift
+++ b/Sources/Crypto/Digests/Digest.swift
@@ -11,10 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import Foundation
+
 #if (os(macOS) || os(iOS) || os(watchOS) || os(tvOS)) && CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import Foundation
 
 /// A protocol defining requirements for digests
 public protocol Digest: Hashable, ContiguousBytes, CustomStringConvertible, Sequence where Element == UInt8 {
@@ -52,7 +53,7 @@ extension Digest {
 extension Digest {
     public static func == (lhs: Self, rhs: Self) -> Bool {
         return safeCompare(lhs, rhs)
-	}
+    }
     
     public static func == <D: DataProtocol>(lhs: Self, rhs: D) -> Bool {
         if rhs.regions.count != 1 {
@@ -62,9 +63,24 @@ extension Digest {
             return safeCompare(lhs, rhs.regions.first!)
         }
     }
-
+    
     public var description: String {
         return "\(Self.self): \(Array(self).hexString)"
     }
 }
 #endif // Linux or !SwiftPM
+
+extension Digest {
+    
+    /// Determines whether a digest is not equal to a collection of contiguous bytes.
+    ///
+    /// - Parameters:
+    ///   - lhs: A digest to compare.
+    ///   - rhs: A collection of contiguous bytes to compare.
+    ///
+    /// - Returns: A Boolean value that’s `true` if the digest is not equal to the collection of binary data.
+    public static func != <D: DataProtocol>(lhs: Self, rhs: D) -> Bool {
+        return !(lhs == rhs)
+    }
+    
+}

--- a/Sources/Crypto/Key Agreement/ECDH.swift
+++ b/Sources/Crypto/Key Agreement/ECDH.swift
@@ -123,7 +123,7 @@ extension P256 {
             public init<Bytes: RandomAccessCollection>(derRepresentation: Bytes) throws where Bytes.Element == UInt8 {
                 let bytes = Array(derRepresentation)
 
-                // We have to try to parse this twice because we have no informaton about what kind of key this is.
+                // We have to try to parse this twice because we have no information about what kind of key this is.
                 // We try with PKCS#8 first, and then fall back to SEC.1.
 
                 do {
@@ -257,7 +257,7 @@ extension P256 {
             public init<Bytes: RandomAccessCollection>(derRepresentation: Bytes) throws where Bytes.Element == UInt8 {
                 let bytes = Array(derRepresentation)
 
-                // We have to try to parse this twice because we have no informaton about what kind of key this is.
+                // We have to try to parse this twice because we have no information about what kind of key this is.
                 // We try with PKCS#8 first, and then fall back to SEC.1.
 
                 do {
@@ -391,7 +391,7 @@ extension P384 {
             public init<Bytes: RandomAccessCollection>(derRepresentation: Bytes) throws where Bytes.Element == UInt8 {
                 let bytes = Array(derRepresentation)
 
-                // We have to try to parse this twice because we have no informaton about what kind of key this is.
+                // We have to try to parse this twice because we have no information about what kind of key this is.
                 // We try with PKCS#8 first, and then fall back to SEC.1.
 
                 do {
@@ -525,7 +525,7 @@ extension P384 {
             public init<Bytes: RandomAccessCollection>(derRepresentation: Bytes) throws where Bytes.Element == UInt8 {
                 let bytes = Array(derRepresentation)
 
-                // We have to try to parse this twice because we have no informaton about what kind of key this is.
+                // We have to try to parse this twice because we have no information about what kind of key this is.
                 // We try with PKCS#8 first, and then fall back to SEC.1.
 
                 do {
@@ -659,7 +659,7 @@ extension P521 {
             public init<Bytes: RandomAccessCollection>(derRepresentation: Bytes) throws where Bytes.Element == UInt8 {
                 let bytes = Array(derRepresentation)
 
-                // We have to try to parse this twice because we have no informaton about what kind of key this is.
+                // We have to try to parse this twice because we have no information about what kind of key this is.
                 // We try with PKCS#8 first, and then fall back to SEC.1.
 
                 do {
@@ -793,7 +793,7 @@ extension P521 {
             public init<Bytes: RandomAccessCollection>(derRepresentation: Bytes) throws where Bytes.Element == UInt8 {
                 let bytes = Array(derRepresentation)
 
-                // We have to try to parse this twice because we have no informaton about what kind of key this is.
+                // We have to try to parse this twice because we have no information about what kind of key this is.
                 // We try with PKCS#8 first, and then fall back to SEC.1.
 
                 do {

--- a/Sources/Crypto/Key Agreement/ECDH.swift.gyb
+++ b/Sources/Crypto/Key Agreement/ECDH.swift.gyb
@@ -129,7 +129,7 @@ extension ${CURVE} {
             public init<Bytes: RandomAccessCollection>(derRepresentation: Bytes) throws where Bytes.Element == UInt8 {
                 let bytes = Array(derRepresentation)
 
-                // We have to try to parse this twice because we have no informaton about what kind of key this is.
+                // We have to try to parse this twice because we have no information about what kind of key this is.
                 // We try with PKCS#8 first, and then fall back to SEC.1.
 
                 do {

--- a/Sources/_CryptoExtras/ChaCha20CTR/ChaCha20CTR.swift
+++ b/Sources/_CryptoExtras/ChaCha20CTR/ChaCha20CTR.swift
@@ -36,7 +36,7 @@ extension Insecure {
         ///   - nonce: A 12 byte nonce for ChaCha20 encryption. The nonce must be unique for every use of the key to seal data.
         /// - Returns: The encrypted ciphertext
         /// - Throws: CipherError errors
-        /// - Warning: You most likely want to use the ChaChaPoly implemention with AuthenticatedData available at `Crypto.ChaChaPoly`
+        /// - Warning: You most likely want to use the ChaChaPoly implementation with AuthenticatedData available at `Crypto.ChaChaPoly`
         public static func encrypt<
             Plaintext: DataProtocol
         >(

--- a/Tests/CryptoTests/Digests/DigestsTests.swift
+++ b/Tests/CryptoTests/Digests/DigestsTests.swift
@@ -121,4 +121,11 @@ class DigestsTests: XCTestCase {
         XCTAssertEqual(SHA384.blockByteCount, 128)
         XCTAssertEqual(SHA512.blockByteCount, 128)
     }
+    
+    func testComparisonOperators() {
+        XCTAssertTrue(SHA256.hash(data: [1, 2, 3, 4]) == SHA256.hash(data: [1, 2, 3, 4]))
+        XCTAssertTrue(SHA256.hash(data: [1, 2, 3, 4]) != SHA256.hash(data: [5, 6, 7, 8]))
+        XCTAssertTrue(SHA256.hash(data: [1, 2, 3, 4]) == Data(SHA256.hash(data: [1, 2, 3, 4])))
+        XCTAssertTrue(SHA256.hash(data: [1, 2, 3, 4]) != Data(SHA256.hash(data: [5, 6, 7, 8])))
+    }
 }

--- a/Tests/CryptoTests/Utils/XCTestUtils.swift
+++ b/Tests/CryptoTests/Utils/XCTestUtils.swift
@@ -42,7 +42,7 @@ extension XCTestCase {
     /// Unwraps the given optional value, or if it is nil, throws an error and
     /// registers an XCTest failure. Meant to be used in a test method that has
     /// been marked as `throws`.
-    /// - Note: this is a replacement for `XCTUnwrap`, which is not availble
+    /// - Note: this is a replacement for `XCTUnwrap`, which is not available
     /// in SPM command line builds as of this writing: <https://bugs.swift.org/browse/SR-11501>
     func unwrap<T>(_ optional: T?, file: StaticString = (#file), line: UInt = #line) throws -> T {
         guard let wrapped = optional else {


### PR DESCRIPTION
Add an inequality comparison operator to determine whether a digest is not equal to a collection of contiguous bytes.

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

### Motivation:

The equal ( == ) and not equal ( != ) operators are available for comparing two digests. However, only the equal operator is available for the comparison between a digest and a collection of contiguous bytes.

This modification adds the missing inequality operator ( != ) for digest and DataProtocol comparison.

### Modifications:

The following static method has been added to `Digest.swift` as an extension to **Digest.**

`public static func != <D: DataProtocol>(lhs: Self, rhs: D) -> Bool`

A corresponding test case has also been added to `DigestsTests.swift`.

### Result:

Instead of checking `if !(digest == someDataBytes) {...}`, we can now write `if digest != someDataBytes {...}`