### PR TITLE
Add inequality operator ( != ) for digest and DataProtocol comparison

### DIFF
--- a/Sources/Crypto/Digests/Digest.swift
+++ b/Sources/Crypto/Digests/Digest.swift
@@ -11,10 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import Foundation
+
 #if (os(macOS) || os(iOS) || os(watchOS) || os(tvOS)) && CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import Foundation
 
 /// A protocol defining requirements for digests
 public protocol Digest: Hashable, ContiguousBytes, CustomStringConvertible, Sequence where Element == UInt8 {
@@ -52,7 +53,7 @@ extension Digest {
 extension Digest {
     public static func == (lhs: Self, rhs: Self) -> Bool {
         return safeCompare(lhs, rhs)
-	}
+    }
     
     public static func == <D: DataProtocol>(lhs: Self, rhs: D) -> Bool {
         if rhs.regions.count != 1 {
@@ -62,9 +63,24 @@ extension Digest {
             return safeCompare(lhs, rhs.regions.first!)
         }
     }
-
+    
     public var description: String {
         return "\(Self.self): \(Array(self).hexString)"
     }
 }
 #endif // Linux or !SwiftPM
+
+extension Digest {
+    
+    /// Determines whether a digest is not equal to a collection of contiguous bytes.
+    ///
+    /// - Parameters:
+    ///   - lhs: A digest to compare.
+    ///   - rhs: A collection of contiguous bytes to compare.
+    ///
+    /// - Returns: A Boolean value that’s `true` if the digest is not equal to the collection of binary data.
+    public static func != <D: DataProtocol>(lhs: Self, rhs: D) -> Bool {
+        return !(lhs == rhs)
+    }
+    
+}

--- a/Tests/CryptoTests/Digests/DigestsTests.swift
+++ b/Tests/CryptoTests/Digests/DigestsTests.swift
@@ -121,4 +121,11 @@ class DigestsTests: XCTestCase {
         XCTAssertEqual(SHA384.blockByteCount, 128)
         XCTAssertEqual(SHA512.blockByteCount, 128)
     }
+    
+    func testComparisonOperators() {
+        XCTAssertTrue(SHA256.hash(data: [1, 2, 3, 4]) == SHA256.hash(data: [1, 2, 3, 4]))
+        XCTAssertTrue(SHA256.hash(data: [1, 2, 3, 4]) != SHA256.hash(data: [5, 6, 7, 8]))
+        XCTAssertTrue(SHA256.hash(data: [1, 2, 3, 4]) == Data(SHA256.hash(data: [1, 2, 3, 4])))
+        XCTAssertTrue(SHA256.hash(data: [1, 2, 3, 4]) != Data(SHA256.hash(data: [5, 6, 7, 8])))
+    }
 }


### PR DESCRIPTION
Add an inequality comparison operator to determine whether a digest is not equal to a collection of contiguous bytes.

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

### Motivation:

The equal ( == ) and not equal ( != ) operators are available for comparing two digests. However, only the equal operator is available for the comparison between a digest and a collection of contiguous bytes.

This modification adds the missing inequality operator ( != ) for digest and DataProtocol comparison.

### Modifications:

The following static method has been added to **_Digest.swift_** as an extension to **Digest**.

`public static func != <D: DataProtocol>(lhs: Self, rhs: D) -> Bool`

A corresponding test case has also been added to **_DigestsTests.swift_**.

### Result:

Instead of checking `if !(digest == someDataBytes) {...}`, we can now write `if digest != someDataBytes {...}`.