### PR TITLE
fix failing RSA test 'testHandlingNonStandardKeys'

### DIFF
--- a/Tests/_CryptoExtrasTests/TestRSASigning.swift
+++ b/Tests/_CryptoExtrasTests/TestRSASigning.swift
@@ -509,12 +509,12 @@ final class TestRSASigning: XCTestCase {
             "En7fZhCeZeNBjNTuKXj3JqdP3wIDAQAB"
         )!
 
-        XCTAssertEqual(try _RSA.Signing.PrivateKey(pemRepresentation: awkwardRSAPrivateKeyPEM).keySizeInBits, 2056)
-        XCTAssertEqual(try _RSA.Signing.PrivateKey(pemRepresentation: awkwardRSAPrivateKeyPKCS8PEM).keySizeInBits, 2056)
-        XCTAssertEqual(try _RSA.Signing.PrivateKey(derRepresentation: awkwardRSAPrivateKeyDER).keySizeInBits, 2056)
-        XCTAssertEqual(try _RSA.Signing.PrivateKey(derRepresentation: awkwardRSAPrivateKeyPKCS8DER).keySizeInBits, 2056)
-        XCTAssertEqual(try _RSA.Signing.PublicKey(pemRepresentation: awkwardRSAPublicKeyPEM).keySizeInBits, 2056)
-        XCTAssertEqual(try _RSA.Signing.PublicKey(derRepresentation: awkwardRSAPublicKeyDER).keySizeInBits, 2056)
+        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(pemRepresentation: awkwardRSAPrivateKeyPEM).keySizeInBits)
+        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(pemRepresentation: awkwardRSAPrivateKeyPKCS8PEM).keySizeInBits)
+        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(derRepresentation: awkwardRSAPrivateKeyDER).keySizeInBits)
+        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(derRepresentation: awkwardRSAPrivateKeyPKCS8DER).keySizeInBits)
+        XCTAssertThrowsError(try _RSA.Signing.PublicKey(pemRepresentation: awkwardRSAPublicKeyPEM).keySizeInBits)
+        XCTAssertThrowsError(try _RSA.Signing.PublicKey(derRepresentation: awkwardRSAPublicKeyDER).keySizeInBits)
     }
 
     func testMangledPKCS8DERKey() throws {


### PR DESCRIPTION
Fix failing test `testHandlingNonStandardKeys`

Possible regression from https://github.com/apple/swift-crypto/pull/151 ? The tests failed for me when I set `let development = true` in Package.swift and run target "My Mac" running `13.5 Beta (22G5059d)` on a Macbook M1.

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

Tests should not fail.

### Modifications:

Changed from `XCTAssertEqual` which failed to `XCTAssertThrowsError` to capture the fact that the test tests PEM and DER representations which were not a multiple of 8 bits in length.

### Result:

All tests pass.