### PR TITLE
Fix up flags used for Docker

### DIFF
--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -101,7 +101,7 @@ function mangle_symbols {
         )
 
         # Now cross compile for our targets.
-        docker run --rm -v$(pwd):/src -w/src --platform linux/arm64 swift5.8-jammy \
+        docker run --rm -v$(pwd):/src -w/src --platform linux/arm64 swift:5.8-jammy \
             swift build --product CCryptoBoringSSL
         docker run --rm -v$(pwd):/src -w/src --platform linux/amd64 swift:5.8-jammy \
             swift build --product CCryptoBoringSSL

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -101,9 +101,9 @@ function mangle_symbols {
         )
 
         # Now cross compile for our targets.
-        docker run -t -i --rm --privileged -v$(pwd):/src -w/src --platform linux/arm64 swift:5.8-jammy \
+        docker run --rm -v$(pwd):/src -w/src --platform linux/arm64 swift:$(swift package --version | cut -c31-) \
             swift build --product CCryptoBoringSSL
-        docker run -t -i --rm --privileged -v$(pwd):/src -w/src --platform linux/amd64 swift:5.8-jammy \
+        docker run --rm -v$(pwd):/src -w/src --platform linux/amd64 swift:$(swift package --version | cut -c31-) \
             swift build --product CCryptoBoringSSL
 
         # Now we need to generate symbol mangles for Linux. We can do this in

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -101,9 +101,9 @@ function mangle_symbols {
         )
 
         # Now cross compile for our targets.
-        docker run --rm -v$(pwd):/src -w/src --platform linux/arm64 swift:$(swift package --version | cut -c31-) \
+        docker run --rm -v$(pwd):/src -w/src --platform linux/arm64 swift5.8-jammy \
             swift build --product CCryptoBoringSSL
-        docker run --rm -v$(pwd):/src -w/src --platform linux/amd64 swift:$(swift package --version | cut -c31-) \
+        docker run --rm -v$(pwd):/src -w/src --platform linux/amd64 swift:5.8-jammy \
             swift build --product CCryptoBoringSSL
 
         # Now we need to generate symbol mangles for Linux. We can do this in


### PR DESCRIPTION
The `-t`, `-I`, and `--privileged` flags for `docker run` are not necessary here. Also adds logic to use the same version of Swift as the macOS installation (note: breaks use with beta versions of Xcode, as the Docker tag for such Swift versions won't exist yet).