### PR TITLE
Use `SecKeyGetBlockSize` instead of `kSecAttrKeySizeInBits`

### DIFF
--- a/Sources/_CryptoExtras/RSA/RSA.swift
+++ b/Sources/_CryptoExtras/RSA/RSA.swift
@@ -54,7 +54,7 @@ extension _RSA.Signing {
         public init(pemRepresentation: String) throws {
             self.backing = try BackingPublicKey(pemRepresentation: pemRepresentation)
 
-            if self.keySizeInBits < 1024 || self.keySizeInBits % 8 != 0 {
+            guard self.keySizeInBits >= 1024 else {
                 throw CryptoKitError.incorrectParameterSize
             }
         }
@@ -66,7 +66,7 @@ extension _RSA.Signing {
         public init<Bytes: DataProtocol>(derRepresentation: Bytes) throws {
             self.backing = try BackingPublicKey(derRepresentation: derRepresentation)
 
-            if self.keySizeInBits < 1024 || self.keySizeInBits % 8 != 0 {
+            guard self.keySizeInBits >= 1024 else {
                 throw CryptoKitError.incorrectParameterSize
             }
         }
@@ -108,7 +108,7 @@ extension _RSA.Signing {
         public init(pemRepresentation: String) throws {
             self.backing = try BackingPrivateKey(pemRepresentation: pemRepresentation)
 
-            if self.keySizeInBits < 1024 || self.keySizeInBits % 8 != 0 {
+            guard self.keySizeInBits >= 1024 else {
                 throw CryptoKitError.incorrectParameterSize
             }
         }
@@ -120,7 +120,7 @@ extension _RSA.Signing {
         public init<Bytes: DataProtocol>(derRepresentation: Bytes) throws {
             self.backing = try BackingPrivateKey(derRepresentation: derRepresentation)
 
-            if self.keySizeInBits < 1024 || self.keySizeInBits % 8 != 0 {
+            guard self.keySizeInBits >= 1024 else {
                 throw CryptoKitError.incorrectParameterSize
             }
         }

--- a/Sources/_CryptoExtras/RSA/RSA_security.swift
+++ b/Sources/_CryptoExtras/RSA/RSA_security.swift
@@ -61,8 +61,7 @@ internal struct SecurityRSAPublicKey {
     }
 
     var keySizeInBits: Int {
-        let attributes = SecKeyCopyAttributes(self.backing)! as NSDictionary
-        return (attributes[kSecAttrKeySizeInBits]! as! NSNumber).intValue
+        SecKeyGetBlockSize(self.backing) * 8
     }
 
     fileprivate init(_ backing: SecKey) {
@@ -146,8 +145,7 @@ internal struct SecurityRSAPrivateKey {
     }
 
     var keySizeInBits: Int {
-        let attributes = SecKeyCopyAttributes(self.backing)! as NSDictionary
-        return (attributes[kSecAttrKeySizeInBits]! as! NSNumber).intValue
+        SecKeyGetBlockSize(self.backing) * 8
     }
 
     var publicKey: SecurityRSAPublicKey {


### PR DESCRIPTION
<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:
Security.framework has change to return the exact bit count of the key size instead of the block size in bytes in macOS 14 beta and aligned releases. However, BoringSSL and the previous implementation relyed on that.
`SecKeyCopyAttributes ` is also rather expensive to call and `keySizeInBits` is accessed immediately (twice) after initialisation. 

### Modifications:

call `SecKeyGetBlockSize(_:)`` instead of looking up the `kSecAttrKeySizeInBits` in the attributes dictionary.

### Result:

test pass again and allocations are reduced.