### PR TITLE
Update to CryptoKit 2023 final API

### DIFF
--- a/Sources/Crypto/HPKE/Ciphersuite/HPKE-KexKeyDerivation.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/HPKE-KexKeyDerivation.swift
@@ -24,8 +24,13 @@ extension HPKE {
                                      pkRm: Data, pkSm: Data? = nil, kem: HPKE.KEM, kdf: HPKE.KDF) -> SymmetricKey {
             var suiteID = suiteIDLabel
             suiteID.append(kem.identifier)
+            #if !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
+            return CryptoKit.ExtractAndExpand(zz: dh, kemContext: kemContext(enc: enc, pkRm: pkRm, pkSm: pkSm),
+                                                     suiteID: suiteID, kem: kem, kdf: kdf)
+            #else
             return Crypto.ExtractAndExpand(zz: dh, kemContext: kemContext(enc: enc, pkRm: pkRm, pkSm: pkSm),
                                                      suiteID: suiteID, kem: kem, kdf: kdf)
+            #endif
         }
         
         static func kemContext(enc: Data, pkRm: Data, pkSm: Data? = nil) -> Data {

--- a/Sources/Crypto/HPKE/Ciphersuite/HPKE-LabeledExtract.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/HPKE-LabeledExtract.swift
@@ -41,12 +41,12 @@ internal func LabeledExtract(salt: Data?, label: Data, ikm: ContiguousBytes?, su
     return kdf.extract(salt: salt ?? Data(), ikm: SymmetricKey(data: labeled_ikm))
 }
 
-internal func LabeledExpand(prk: SymmetricKey, label: Data, info: Data, outputByteCount: UInt16, suiteID: Data, kdf: HPKE.KDF) -> SymmetricKey {
+internal func LabeledExpand<Info: DataProtocol>(prk: SymmetricKey, label: Data, info: Info, outputByteCount: UInt16, suiteID: Data, kdf: HPKE.KDF) -> SymmetricKey {
     var labeled_info = I2OSP(value: Int(outputByteCount), outputByteCount: 2)
     labeled_info.append(protocolLabel)
     labeled_info.append(suiteID)
     labeled_info.append(label)
-    labeled_info.append(info)
+    labeled_info.append(contentsOf: info)
     return kdf.expand(prk: prk, info: labeled_info, outputByteCount: Int(outputByteCount))
 }
 

--- a/Sources/Crypto/HPKE/Ciphersuite/KEM/Conformances/DHKEM.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/KEM/Conformances/DHKEM.swift
@@ -56,6 +56,12 @@ extension HPKE {
             let kem: HPKE.KEM
             let key: DHPK
 
+            #if !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
+            typealias EncapsulationResult = CryptoKit.KEM.EncapsulationResult
+            #else
+            typealias EncapsulationResult = Crypto.KEM.EncapsulationResult
+            #endif
+
             init(_ publicKey: DHPK, kem: HPKE.KEM) throws {
                 // TODO: Validate Ciphersuite Mismatches
                 _ = try publicKey.hpkeRepresentation(kem: kem)
@@ -63,14 +69,14 @@ extension HPKE {
                 self.kem = kem
             }
             
-            func encapsulate() throws -> Crypto.KEM.EncapsulationResult {
+            func encapsulate() throws -> EncapsulationResult {
                 let ephemeralKeys = DHPK.EphemeralPrivateKey()
                 let dh =
                 try ephemeralKeys.sharedSecretFromKeyAgreement(with: key)
                 
                 let enc = try! ephemeralKeys.publicKey.hpkeRepresentation(kem: kem)
                 let selfRepresentation = try self.key.hpkeRepresentation(kem: kem)
-                return Crypto.KEM.EncapsulationResult(sharedSecret: HPKE.KexUtils.ExtractAndExpand(dh: dh,
+                return EncapsulationResult(sharedSecret: HPKE.KexUtils.ExtractAndExpand(dh: dh,
                                                                                             enc: enc,
                                                                                             pkRm: selfRepresentation,
                                                                                             kem: kem,

--- a/Sources/Crypto/Util/SecureBytes.swift
+++ b/Sources/Crypto/Util/SecureBytes.swift
@@ -170,7 +170,7 @@ extension SecureBytes: RangeReplaceableCollection {
 
     // The default implementation of this from RangeReplaceableCollection can't take advantage of `ContiguousBytes`, so we override it here
     @inlinable
-    public mutating func append(contentsOf newElements: some Sequence<UInt8>) {
+    public mutating func append<Elements: Sequence>(contentsOf newElements: Elements) where Elements.Element == UInt8 {
         let done:Void? = newElements.withContiguousStorageIfAvailable {
             replaceSubrange(endIndex..<endIndex, with: $0)
         }


### PR DESCRIPTION
Motivation

This patch brings us up-to-date with CryptoKit's final 2023 API form.

Modifications

Slight tweak to exporter secrets for HPKE to match final spec. New representation for SecureBytes when empty.

Result

We're ready for the future
