### PR TITLE
Add support for AES-CBC in `_CryptoExtras`

### DIFF
--- a/Sources/_CryptoExtras/AES/AES_CBC.swift
+++ b/Sources/_CryptoExtras/AES/AES_CBC.swift
@@ -1,0 +1,179 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+import Foundation
+
+extension AES {
+    /// The Advanced Encryption Standard (AES) Cipher Block Chaining (CBC) cipher
+    /// suite.
+    public enum _CBC {
+        private static var blockSize: Int { 16 }
+
+        private static func encryptBlockInPlace(
+            _ plaintext: inout Block,
+            priorCiphertextBlock: Block,
+            using key: SymmetricKey
+        ) throws {
+            assert([128, 192, 256].contains(key.bitCount))
+
+            plaintext ^= priorCiphertextBlock
+            try AES.permute(&plaintext, key: key)
+        }
+
+        /// Encrypts data using AES-CBC.
+        ///
+        /// - Parameters:
+        ///   - plaintext: The message to encrypt.
+        ///   - key: A encryption key.
+        ///   - iv: The initialization vector.
+        /// - Returns: The encrypted ciphertext.
+        public static func encrypt<Plaintext: DataProtocol>(_ plaintext: Plaintext, using key: SymmetricKey, iv: AES._CBC.IV) throws -> Data {
+            guard [128, 192, 256].contains(key.bitCount) else {
+                throw CryptoKitError.incorrectKeySize
+            }
+
+            let requiresFullPaddingBlock = (plaintext.count % AES._CBC.blockSize) == 0
+
+            var ciphertext = Data()
+            ciphertext.reserveCapacity(plaintext.count + Self.blockSize)  // Room for padding.
+
+            var previousBlock = Block(iv)
+            var plaintext = plaintext[...]
+
+            while plaintext.count > 0 {
+                var block = Block(blockBytes: plaintext.prefix(Self.blockSize))
+                try Self.encryptBlockInPlace(&block, priorCiphertextBlock: previousBlock, using: key)
+                ciphertext.append(contentsOf: block)
+                previousBlock = block
+                plaintext = plaintext.dropFirst(Self.blockSize)
+            }
+
+            if requiresFullPaddingBlock {
+                var block = Block.paddingBlock
+                try Self.encryptBlockInPlace(&block, priorCiphertextBlock: previousBlock, using: key)
+                ciphertext.append(contentsOf: block)
+            }
+
+            return ciphertext
+        }
+
+        private static func decryptBlockInPlace(_ ciphertext: inout Block, priorCiphertextBlock: Block, using key: SymmetricKey) throws {
+            assert([128, 192, 256].contains(key.bitCount))
+
+            try AES.inversePermute(&ciphertext, key: key)
+            ciphertext ^= priorCiphertextBlock
+        }
+
+        /// Decrypts data using AES-CBC.
+        ///
+        /// - Parameters:
+        ///   - ciphertext: The encrypted ciphertext.
+        ///   - key: A decryption key.
+        ///   - iv: The initialization vector.
+        /// - Returns: The decrypted message.
+        public static func decrypt<Ciphertext: DataProtocol>(_ ciphertext: Ciphertext, using key: SymmetricKey, iv: AES._CBC.IV) throws -> Data {
+            guard [128, 192, 256].contains(key.bitCount) else {
+                throw CryptoKitError.incorrectKeySize
+            }
+
+            var plaintext = Data()
+            plaintext.reserveCapacity(ciphertext.count)
+
+            var previousBlock = Block(iv)
+            var ciphertext = ciphertext[...]
+
+            while ciphertext.count > 0 {
+                let ctBlock = Block(blockBytes: ciphertext.prefix(Self.blockSize))
+                var block = ctBlock
+                try Self.decryptBlockInPlace(&block, priorCiphertextBlock: previousBlock, using: key)
+                plaintext.append(contentsOf: block)
+                previousBlock = ctBlock
+                ciphertext = ciphertext.dropFirst(Self.blockSize)
+            }
+
+            try plaintext.trimPadding()
+            return plaintext
+        }
+    }
+}
+
+extension AES._CBC {
+    /// An initialization vector.
+    public struct IV {
+        // AES CBC uses a 128-bit IV.
+        var ivBytes: (
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
+            UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
+        )
+
+        public init() {
+            var rng = SystemRandomNumberGenerator()
+            let (first, second) = (rng.next(), rng.next())
+
+            self.ivBytes = (
+                UInt8(truncatingIfNeeded: first),
+                UInt8(truncatingIfNeeded: first >> 8),
+                UInt8(truncatingIfNeeded: first >> 16),
+                UInt8(truncatingIfNeeded: first >> 24),
+                UInt8(truncatingIfNeeded: first >> 32),
+                UInt8(truncatingIfNeeded: first >> 40),
+                UInt8(truncatingIfNeeded: first >> 48),
+                UInt8(truncatingIfNeeded: first >> 56),
+                UInt8(truncatingIfNeeded: second),
+                UInt8(truncatingIfNeeded: second >> 8),
+                UInt8(truncatingIfNeeded: second >> 16),
+                UInt8(truncatingIfNeeded: second >> 24),
+                UInt8(truncatingIfNeeded: second >> 32),
+                UInt8(truncatingIfNeeded: second >> 40),
+                UInt8(truncatingIfNeeded: second >> 48),
+                UInt8(truncatingIfNeeded: second >> 56)
+            )
+        }
+
+        public init<IVBytes: Collection>(ivBytes: IVBytes) throws where IVBytes.Element == UInt8 {
+            // We support a 128-bit IV.
+            guard ivBytes.count == 16 else {
+                throw CryptoKitError.incorrectKeySize
+            }
+
+            self.ivBytes = (
+                0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 0, 0, 0, 0, 0
+            )
+
+            withUnsafeMutableBytes(of: &self.ivBytes) { bytesPtr in
+                bytesPtr.copyBytes(from: ivBytes)
+            }
+        }
+    }
+}
+
+extension Data {
+    fileprivate mutating func trimPadding() throws {
+        guard let paddingBytes = self.last else {
+            // Degenerate case, empty string. This is forbidden:
+            // we must always pad.
+            throw CryptoKitError.incorrectParameterSize
+        }
+
+        guard paddingBytes > 0 &&
+              self.count >= paddingBytes &&
+              self.suffix(Int(paddingBytes)).allSatisfy({ $0 == paddingBytes }) else {
+            throw CryptoKitError.incorrectParameterSize
+        }
+
+        self = self.dropLast(Int(paddingBytes))
+    }
+}

--- a/Tests/_CryptoExtrasTests/AES-GCM-SIV-Runner.swift
+++ b/Tests/_CryptoExtrasTests/AES-GCM-SIV-Runner.swift
@@ -34,7 +34,7 @@ struct AESGCMTestVector: Codable {
     let result: String
 }
 
-class AESGCMSIVTests: XCTestCase {
+final class AESGCMSIVTests: XCTestCase {
     func testPropertiesStayTheSameAfterFailedOpening() throws {
         let message = Data("this is a message".utf8)
         let sealed = try AES.GCM._SIV.seal(message, using: SymmetricKey(size: .bits128))

--- a/Tests/_CryptoExtrasTests/AES_CBCTests.swift
+++ b/Tests/_CryptoExtrasTests/AES_CBCTests.swift
@@ -1,0 +1,107 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2023 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+import Foundation
+import _CryptoExtras
+import XCTest
+
+final class CBCTests: XCTestCase {
+    func testWycheproofDecrypt() throws {
+        try wycheproofTest(
+            jsonName: "aes_cbc_pkcs5_test",
+            testFunction: { (group: AESCBCTestGroup) in
+                for test in group.tests {
+                    do {
+                        let decrypted = try AES._CBC.decrypt(
+                            test.computedCt, using: test.computedKey, iv: test.computedIv
+                        )
+
+                        switch test.result {
+                        case "valid":
+                            XCTAssertTrue(decrypted == test.computedMsg, "Unexpected invalid test \(test.tcId) (\(test.comment))")
+                        case "invalid":
+                            XCTAssertFalse(decrypted != test.computedMsg, "Unexpected valid test \(test.tcId) (\(test.comment))")
+                        default:
+                            fatalError("Unexpected result type")
+                        }
+                    } catch {
+                        XCTAssertTrue(test.result == "invalid", "Unexpected invalid test \(test.tcId) (\(test.comment))")
+                    }
+                }
+            })
+    }
+
+    func testWycheproofEncrypt() throws {
+        try wycheproofTest(
+            jsonName: "aes_cbc_pkcs5_test",
+            testFunction: { (group: AESCBCTestGroup) in
+                for test in group.tests {
+                    if test.result == "invalid" { continue }
+
+                    do {
+                        let encrypted = try AES._CBC.encrypt(
+                            test.computedMsg, using: test.computedKey, iv: test.computedIv
+                        )
+                        XCTAssertEqual(encrypted, test.computedCt, "Unexpected invalid test \(test.tcId) (\(test.comment))")
+                    } catch {
+                        XCTFail("Unexpected invalid test \(test.tcId) (\(test.comment))")
+                    }
+                }
+            }
+        )
+    }
+}
+
+
+struct AESCBCTestGroup: Codable {
+    var keySize: Int
+    var ivSize: Int
+    var type: String
+    var tests: [AESCBCTest]
+}
+
+struct AESCBCTest: Codable {
+    var tcId: Int
+    var comment: String
+    var key: String
+    var msg: String
+    var iv: String
+    var ct: String
+    var result: String
+    var flags: [String]
+
+    var computedKey: SymmetricKey {
+        SymmetricKey(hexEncoded: self.key)
+    }
+
+    var computedMsg: Data {
+        try! Data(hexString: self.msg)
+    }
+
+    var computedIv: AES._CBC.IV {
+        try! AES._CBC.IV(ivBytes: Array(hexString: self.iv))
+    }
+
+    var computedCt: Data {
+        try! Data(hexString: self.ct)
+    }
+}
+
+extension SymmetricKey {
+    init(hexEncoded: String) {
+        let keyBytes = try! Array(hexString: hexEncoded)
+        self = SymmetricKey(data: keyBytes)
+    }
+}

--- a/Tests/_CryptoExtrasVectors/aes_cbc_pkcs5_test.json
+++ b/Tests/_CryptoExtrasVectors/aes_cbc_pkcs5_test.json
@@ -1,0 +1,2088 @@
+{
+  "algorithm" : "AES-CBC-PKCS5",
+  "generatorVersion" : "0.8r12",
+  "numberOfTests" : 183,
+  "header" : [
+    "Test vectors of type IndCpaTest are intended for test that verify",
+    "encryption and decryption of symmetric ciphers without authentication."
+  ],
+  "notes" : {
+    "BadPadding" : "The ciphertext in this test vector is the message encrypted with an invalid or unexpected padding. This allows to find implementations that are not properly checking the padding during decryption."
+  },
+  "schema" : "ind_cpa_test_schema.json",
+  "testGroups" : [
+    {
+      "ivSize" : 128,
+      "keySize" : 128,
+      "type" : "IndCpaTest",
+      "tests" : [
+        {
+          "tcId" : 1,
+          "comment" : "empty message",
+          "key" : "e34f15c7bd819930fe9d66e0c166e61c",
+          "iv" : "da9520f7d3520277035173299388bee2",
+          "msg" : "",
+          "ct" : "b10ab60153276941361000414aed0a9d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 2,
+          "comment" : "message size divisible by block size",
+          "key" : "e09eaa5a3f5e56d279d5e7a03373f6ea",
+          "iv" : "c9ee3cd746bf208c65ca9e72a266d54f",
+          "msg" : "ef4eab37181f98423e53e947e7050fd0",
+          "ct" : "d1fa697f3e2e04d64f1a0da203813ca5bc226a0b1d42287b2a5b994a66eaf14a",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 3,
+          "comment" : "message size divisible by block size",
+          "key" : "9bd3902ed0996c869b572272e76f3889",
+          "iv" : "8b2e86a9a185cfa6f51c7cc595b822bc",
+          "msg" : "a7ba19d49ee1ea02f098aa8e30c740d893a4456ccc294040484ed8a00a55f93e",
+          "ct" : "514cbc69aced506926deacdeb0cc0a5a07d540f65d825b65c7db0075cf930a06e0124ae598461cab0b3251baa853e377",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 4,
+          "comment" : "message size divisible by block size",
+          "key" : "75ce184447cada672e02290310d224f7",
+          "iv" : "2717d10eb2eea3b39ec257e43307a260",
+          "msg" : "c774810a31a6421ad8eaafd5c22fa2455e2c167fee4a0b73ff927b2d96c69da1e939407b86b1c19bcfc69c434c3cf8a2",
+          "ct" : "137c824d7f7dc36f24216dde37c2e1c10cee533f6453de92e44b898fc3037d2e9e19d67a96387136dd9717a56e28614a5c177158f402ce2936fd98d1feb6a817",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 5,
+          "comment" : "small plaintext size",
+          "key" : "e1e726677f4893890f8c027f9d8ef80d",
+          "iv" : "155fd397579b0b5d991d42607f2cc9ad",
+          "msg" : "3f",
+          "ct" : "599d77aca16910b42d8b4ac9560efe1b",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 6,
+          "comment" : "small plaintext size",
+          "key" : "b151f491c4c006d1f28214aa3da9a985",
+          "iv" : "4eb836be6808db264cb1111a3283b394",
+          "msg" : "27d9",
+          "ct" : "74e20bf03a0ad4b49edc86a1b19c3d1d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 7,
+          "comment" : "small plaintext size",
+          "key" : "c36ff15f72777ee21deec07b63c1a0cd",
+          "iv" : "a8446c27ea9068d8d924d5c4eac91157",
+          "msg" : "50b428",
+          "ct" : "3f7a26558ba51cf352219d34c46907ae",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 8,
+          "comment" : "small plaintext size",
+          "key" : "32b9c5c78c3a0689a86052420fa1e8fc",
+          "iv" : "ef026d27da3702d7bb72e5e364a8f8f2",
+          "msg" : "0b9262ec",
+          "ct" : "c29d1463baccc558fd720c897da5bb98",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 9,
+          "comment" : "small plaintext size",
+          "key" : "43151bbaef367277ebfc97509d0aa49c",
+          "iv" : "c9defd3929dcd6c355c144e9750dd869",
+          "msg" : "eaa91273e7",
+          "ct" : "e24a717914f9cc8eaa1dc96f7840d6af",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 10,
+          "comment" : "small plaintext size",
+          "key" : "481440298525cc261f8159159aedf62d",
+          "iv" : "ce91e0454b0123f1ead0f158826459e9",
+          "msg" : "6123c556c5cc",
+          "ct" : "f080e487f4e5b7aed793ea95ffe4bb30",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 11,
+          "comment" : "small plaintext size",
+          "key" : "9ca26eb88731efbf7f810d5d95e196ac",
+          "iv" : "1cb7bc8fe00523e7743d3cd9f483d6fe",
+          "msg" : "7e48f06183aa40",
+          "ct" : "27cadee413ed901f51c9366d731d95f6",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 12,
+          "comment" : "small plaintext size",
+          "key" : "48f0d03e41cc55c4b58f737b5acdea32",
+          "iv" : "a345f084229dbfe0ceab6c6939571532",
+          "msg" : "f4a133aa6d5985a0",
+          "ct" : "59bf12427b51a3aee0c9d3c540d04d24",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 13,
+          "comment" : "small plaintext size",
+          "key" : "1c958849f31996b28939ce513087d1be",
+          "iv" : "e5b6f73f132355b7be7d977bea068dfc",
+          "msg" : "b0d2fee11b8e2f86b7",
+          "ct" : "1a0a18355f8ca4e6e2cf31da18d070da",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 14,
+          "comment" : "small plaintext size",
+          "key" : "39de0ebea97c09b2301a90009a423253",
+          "iv" : "c7cd10ca949ea03e7d4ba204b69e09b8",
+          "msg" : "81e5c33b4c620852f044",
+          "ct" : "cef498ea61715a27f400418d1d5bfbf0",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 15,
+          "comment" : "small plaintext size",
+          "key" : "91656d8fc0aced60ddb1c4006d0dde53",
+          "iv" : "bb8c9af30821dfeb7124392a554d9f01",
+          "msg" : "7b3e440fe566790064b2ec",
+          "ct" : "7ab43ddc45835ce40d2280bcea6a63f2",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 16,
+          "comment" : "small plaintext size",
+          "key" : "af7d5134720b5386158d51ea126e7cf9",
+          "iv" : "54c3b90ca6e933f9094334d0263d3775",
+          "msg" : "7cc6fcc925c20f3c83b5567c",
+          "ct" : "c70b457c945ad40895cf4c8be3ce7c66",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 17,
+          "comment" : "small plaintext size",
+          "key" : "4ed56753de6f75a032ebabca3ce27971",
+          "iv" : "9a2c5e91d4f0b9b9da64b46c5c2c8cb2",
+          "msg" : "0c8c0f5619d9f8da5339281285",
+          "ct" : "f9900afee2acfe63f8f15d81bbf64c39",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 18,
+          "comment" : "small plaintext size",
+          "key" : "beba50c936b696c15e25046dffb23a64",
+          "iv" : "cf7951501104e1434309e6b936ec1742",
+          "msg" : "821ea8532fbabffb6e3d212e9b46",
+          "ct" : "da4137bd8ac78e75a700b3de806f2d6f",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 19,
+          "comment" : "small plaintext size",
+          "key" : "501d81ebf912ddb87fbe3b7aac1437bc",
+          "iv" : "90f5cf4fbfd2e2a1ab8eef402617bd5c",
+          "msg" : "2368e3c3636b5e8e94d2081adbf798",
+          "ct" : "fed05321d11d978e2ec32527ecfce06c",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 20,
+          "comment" : "plaintext size > 16",
+          "key" : "831e664c9e3f0c3094c0b27b9d908eb2",
+          "iv" : "54f2459e40e002763144f4752cde2fb5",
+          "msg" : "26603bb76dd0a0180791c4ed4d3b058807",
+          "ct" : "8d55dc10584e243f55d2bdbb5758b7fabcd58c8d3785f01c7e3640b2a1dadcd9",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 21,
+          "comment" : "plaintext size > 16",
+          "key" : "cbffc6c8c7f76f46349c32d666f4efb0",
+          "iv" : "088e01c2c65b26e7ad6af7b92ea09d73",
+          "msg" : "6df067add738195fd55ac2e76b476971b9a0e6d8",
+          "ct" : "e9199842355ea0c3dbf1b2a94fef1c802a95d024df9e407883cf5bf1f02c3cdc",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 22,
+          "comment" : "plaintext size > 16",
+          "key" : "fda6a01194beb462953d7e6c49b32dac",
+          "iv" : "d9c9468796a2f5741b84d2d41430c5d3",
+          "msg" : "f60ae3b036abcab78c98fc1d4b67970c0955cb6fe24483f8907fd73319679b",
+          "ct" : "19beb4db2be0f3aff0083583038b2281a77c85b5f345ba4d2bc7f742a14f9247",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 23,
+          "comment" : "plaintext size > 16",
+          "key" : "efd9caa8ac68e9e29acdae57e93bcea8",
+          "iv" : "c98b47808add45c0c891983ec4b09846",
+          "msg" : "3e1d2001f1e475b972738936443a5f51eedaf802a66fadf2406cfaadb0549149fcb9f485e534dc2d",
+          "ct" : "84904fc92bd2e7590aa268e667370327b9446f41067dd40d3e5091a63a0d5687e4926e00cc3cb461c3b85d80ee2da818",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 24,
+          "comment" : "plaintext size > 16",
+          "key" : "37e4dbdc436258d5a9adb9f205c77cf3",
+          "iv" : "08e9410de244d3f40607ebae38fa74e7",
+          "msg" : "24a874aec067116ad22eb55846ded3f5e86919a135585c929a86d92b2958fed110e52e33804887243584a6a94402cc9a105e0c940ec335bd2890f16dcce3fc8bd02873c80ade6f1ac08683130bcca454",
+          "ct" : "1d1391593a336be4b207295ad0542bc4ef2f39053066e12c38f71603f377fd42f4f0b2b5a42cdfeaee2af039f06fcf347abe171af3157ff07f3cdd3b33e11a60caecf9890325c132eeb66ab847278d165c26bca7c30486bb2fd83b63c5ff7ae0",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 25,
+          "comment" : "zero padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "",
+          "ct" : "aa62606a287476777b92d8e4c4e53028",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 26,
+          "comment" : "zero padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "6162636465666768",
+          "ct" : "ada437b682c92384b6c23ec10a21b3d8",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 27,
+          "comment" : "zero padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "26c5b3e540ee3dd6b52d14afd01a44f8",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 28,
+          "comment" : "zero padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecbc0deb417e98aba3ee12fea2921f8ae51",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 29,
+          "comment" : "zero padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecb1188ff22f6563f6173440547d1e0dfd8",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 30,
+          "comment" : "padding with 0xff",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "",
+          "ct" : "726570a34cea08139d9f836579102a0e",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 31,
+          "comment" : "padding with 0xff",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "6162636465666768",
+          "ct" : "c8ef7ac3fd659ce7157d72a25f0a5048",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 32,
+          "comment" : "padding with 0xff",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "6123c889bbc766acd4bca4cb982f9978",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 33,
+          "comment" : "padding with 0xff",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecb442cd16f7410fca70924b573f7967e84",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 34,
+          "comment" : "padding with 0xff",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecbb20f899b0e7c1d65b931af94b5c44c25",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 35,
+          "comment" : "bit padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "",
+          "ct" : "50aeed98a820c5a037a5aa4d4ef3090b",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 36,
+          "comment" : "bit padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "6162636465666768",
+          "ct" : "25ee339006f948f42713543c62467ef9",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 37,
+          "comment" : "bit padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "97914574676ed5b8db0b6f3931195b3f",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 38,
+          "comment" : "bit padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecb2874a1e2d28dd18e5573df9fd59fd789",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 39,
+          "comment" : "bit padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecbb547c4fddbdcd3e02f438a2e48587594",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 40,
+          "comment" : "padding longer than 1 block",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "",
+          "ct" : "d17ccbb26f0aa95f397b20063547349bac24c5429cbea591e96595cccc11451b",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 41,
+          "comment" : "padding longer than 1 block",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "6162636465666768",
+          "ct" : "fc07025e81d43efa85f92afdf8781b1e88598e12d6812df43733e93414b9e901",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 42,
+          "comment" : "padding longer than 1 block",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "deb1746f4e9e0be4a21825b071b6e93303031651e0c59091e2ae0fbcce11b987",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 43,
+          "comment" : "padding longer than 1 block",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecb563d35096fde10ccb6f768438c9eb4ec90f399b76924c716e9f94143263306c6",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 44,
+          "comment" : "padding longer than 1 block",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecbc8fd2e2c5362acf5212bd47859aa827d8469b87b0e6adafe3dba98c1885b6345",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 45,
+          "comment" : "ANSI X.923 padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "",
+          "ct" : "ca5dd2d09bd56eec9e8acaeca20af68e",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 46,
+          "comment" : "ANSI X.923 padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "6162636465666768",
+          "ct" : "01e53a5ec9b0957c45f79ed0f4b2b982",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 47,
+          "comment" : "ANSI X.923 padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecbd3909bb3457e5b946ff709be9a2ed84d",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 48,
+          "comment" : "ANSI X.923 padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecbc5ab3ab637166a6a067b82b5672c08f8",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 49,
+          "comment" : "ISO 10126 padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "",
+          "ct" : "ba0726bd6dea11382b19c842e2ddead2",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 50,
+          "comment" : "ISO 10126 padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "6162636465666768",
+          "ct" : "22f18b85c729903744fb8db5ed2840d4",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 51,
+          "comment" : "ISO 10126 padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecb6b103fbe43519a18880b7e6d9153e1c2",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 52,
+          "comment" : "ISO 10126 padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecbe00bdb15b8a61285447498700d35e0c6",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 53,
+          "comment" : "padding longer than message",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "",
+          "ct" : "d17ccbb26f0aa95f397b20063547349b",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 54,
+          "comment" : "padding longer than message",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "6162636465666768",
+          "ct" : "2056dfa339fa00be6836999411a98c76",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 55,
+          "comment" : "padding longer than message",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "f92628f6418d8d9c9afac233861b3835",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 56,
+          "comment" : "padding longer than message",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecbc0c41093b495a7d5a080d976493fd0e7",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 57,
+          "comment" : "padding longer than message",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecb6770446a5ccaa26f7d4f970cc5834eba",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 58,
+          "comment" : " invalid padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "",
+          "ct" : "4ff3e623fdd432608c183f40864177af",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 59,
+          "comment" : " invalid padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "6162636465666768",
+          "ct" : "6a1ef1e6ae6a788777aabd9ccf3cf43a",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 60,
+          "comment" : " invalid padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecbee1345cd513161b241f4ae2799b0327f",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 61,
+          "comment" : " invalid padding",
+          "key" : "db4f3e5e3795cc09a073fa6a81e5a6bc",
+          "iv" : "23468aa734f5f0f19827316ff168e94f",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "fbcbdfdaaf17980be939c0b243266ecbe0d539beef6f2d4f7cda4fd9f4f05570",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        }
+      ]
+    },
+    {
+      "ivSize" : 128,
+      "keySize" : 192,
+      "type" : "IndCpaTest",
+      "tests" : [
+        {
+          "tcId" : 62,
+          "comment" : "empty message",
+          "key" : "3d6bf9edae6d881eade0ff8c7076a4835b71320c1f36b631",
+          "iv" : "db20f9a6f4d6b4e478f1a4b9d4051d34",
+          "msg" : "",
+          "ct" : "ff0c315873b4b1872abef2353b792ef0",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 63,
+          "comment" : "message size divisible by block size",
+          "key" : "f4bfa5aa4f0f4d62cf736cd2969c43d580fdb92f2753bedb",
+          "iv" : "69a76dc4da64d89c580eb75ae975ec39",
+          "msg" : "0e239f239705b282ce2200fe20de1165",
+          "ct" : "7dbd573e4db58a318edfe29f199d8cda538a49f36486337c2711163e55fd5d0b",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 64,
+          "comment" : "message size divisible by block size",
+          "key" : "9d11abc1fcb248a436598e695be12c3c2ed90a18ba09d62c",
+          "iv" : "6525667350930fb945dd1895a3abfcd1",
+          "msg" : "aa5182cae2a8fb068c0b3fb2be3e57ae523d13dffd1a944587707c2b67447f3f",
+          "ct" : "bd0258909e5b72438d95ca4b29c8a79c6228fd06a3b2fa06f7659654c7b24610f23f2fb16313b7d3614cb0cd16fabb8e",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 65,
+          "comment" : "message size divisible by block size",
+          "key" : "7e41d83181659a2c38da5ead353cdb04c2b4d4a3cfe58e25",
+          "iv" : "3943d8fddd5bb2a59772df31a31a8fff",
+          "msg" : "8a32d11c7a11aa72e13381632b1310f4fd90fc209a6a350e61c069a561871214f9c04fc1df7354cbe4d8d639c525d324",
+          "ct" : "6cbeacf8de25d7dd9dcdc087bf2f80873b1eb335400589076f8d2bf81e294c5d72b85eb8ac9558b0de9e9fbee4b18716e5220c507fbb9d319a08f67816765ca6",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 66,
+          "comment" : "small plaintext size",
+          "key" : "915429743435c28997a33b33b6574a953d81dae0e7032e6a",
+          "iv" : "1379d48493f743e6a149deb3b9bab31e",
+          "msg" : "58",
+          "ct" : "519925956d32e4fa350b1144f088e4e8",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 67,
+          "comment" : "small plaintext size",
+          "key" : "f0c288ba26b284f9fb321b444a6517b3cdda1a799d55fdff",
+          "iv" : "48c7f44b43a1279d820733e6cb30617a",
+          "msg" : "0f7e",
+          "ct" : "bfb90aa7de1bdeed5bdc5703bdfd9630",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 68,
+          "comment" : "small plaintext size",
+          "key" : "6b55e4d4fd6847a80a6bfb0dcc0aa93f9fd797fc5c50292e",
+          "iv" : "2c287b38cc30c8c351b087b91a6a97ba",
+          "msg" : "33f530",
+          "ct" : "b1a25816908c086f26037d10b7be9ad9",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 69,
+          "comment" : "small plaintext size",
+          "key" : "1eb21a9e995a8e45c9e71ecbd6fe615b3e0318007c64b644",
+          "iv" : "61f6060919c9c09ef06be28f39c344aa",
+          "msg" : "3aa73c48",
+          "ct" : "74dbdecbfa94b71d2d6ef03200c7d095",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 70,
+          "comment" : "small plaintext size",
+          "key" : "710e2d5d4a9f0bc7e50796655e046a18cc5769d7764355da",
+          "iv" : "7682005907bfef3ce00196a17ad2246d",
+          "msg" : "7e4c690a88",
+          "ct" : "10c860aaee23c3c3c1b9306b189dd80d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 71,
+          "comment" : "small plaintext size",
+          "key" : "d8c09ea400779b63e774bdacd0cb7b5dd6f736ca23d52acf",
+          "iv" : "1f6c912997ce007701e5fdf407c6b421",
+          "msg" : "e9520280973b",
+          "ct" : "673dcd444386930a0cc577fab4501e5c",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 72,
+          "comment" : "small plaintext size",
+          "key" : "8e67e9a0863b55bed408866f1cbc05357abe3f9d79f406f2",
+          "iv" : "5854033ae50de090678432781a168b6c",
+          "msg" : "4880b412287a0b",
+          "ct" : "059e5f72a81d8820add8eae8fabcdd42",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 73,
+          "comment" : "small plaintext size",
+          "key" : "28d8da67806410e5565bcc5a9d7ab9fb357413fa0158378c",
+          "iv" : "003b2d86d8b636c58cf664565572d5e6",
+          "msg" : "004e3f4a4e6db955",
+          "ct" : "c412159fd5ae20d771b7d2e734124d6a",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 74,
+          "comment" : "small plaintext size",
+          "key" : "dc968dd89fd602bb7eca6f3a8a13e4f59c08d02a514b1934",
+          "iv" : "3f22b50f888ab9424ba871d15aac55b7",
+          "msg" : "41a25354efeb1bc3b8",
+          "ct" : "4aba571c2c5ab9a6140f16efc68c8ec1",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 75,
+          "comment" : "small plaintext size",
+          "key" : "7658951c0f620d82afd92756cc2d7983b79da3e56fdd1b78",
+          "iv" : "e4b8dde04b49fa6b88bfccd8d70c21d1",
+          "msg" : "f0e82fb5c5666f4af49f",
+          "ct" : "66d1b9152a8cd1a88eab341c775070b4",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 76,
+          "comment" : "small plaintext size",
+          "key" : "d9574c3a221b986690931faac5258d9d3c52362b2cb9b054",
+          "iv" : "7753f616cd8796c9b8a3bbfbe6cb1e7f",
+          "msg" : "178ea8404ba54ee4e4522c",
+          "ct" : "d9377788e2881a48f9347786db7df51f",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 77,
+          "comment" : "small plaintext size",
+          "key" : "704409bab28085c44981f28f75dd143a4f747106f63f262e",
+          "iv" : "eae9ee19ccb7f8b087675709c4d35f73",
+          "msg" : "cda5709e7f115624e74ab031",
+          "ct" : "db825f4434ea3bb53576fa7385fb7dfe",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 78,
+          "comment" : "small plaintext size",
+          "key" : "d8d06ef6a53bbff5c8f12d791b8f4c67e574bf440736d1cc",
+          "iv" : "a6aaff339a729d30a7ec1328db36d23e",
+          "msg" : "a1171eae1979f48345dd9485a0",
+          "ct" : "3e7287df2a5ed9de4d817e352bd47ea7",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 79,
+          "comment" : "small plaintext size",
+          "key" : "71129e781613f39d9ac39fbde2628b44c250c14deb5ef9e2",
+          "iv" : "92fda71e88c70d18ed71b992735a2150",
+          "msg" : "967593cc64bcbf7f3c58d04cb82b",
+          "ct" : "17c3ade4b469ae614760039a8fa6250e",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 80,
+          "comment" : "small plaintext size",
+          "key" : "850fc859e9f7b89a367611dee6698f33962d8245ca8dc331",
+          "iv" : "ed6596c86b98123ad2f3c573e974d051",
+          "msg" : "586f4f171af116519061a8e0e77940",
+          "ct" : "9cafecff2a28d02f732573f65a2cadca",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 81,
+          "comment" : "plaintext size > 16",
+          "key" : "cfd3f68873d81a27d2bfce876c79f6e609074dec39e34614",
+          "iv" : "c45b52a240eba3bdde5dfd57f3d474fb",
+          "msg" : "b1973cb25aa87ef9d1a8888b0a0f5c04c6",
+          "ct" : "401ad889bdb9d38816c782e00b168ccccde9bf75f4be868ceb91237e8b37b750",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 82,
+          "comment" : "plaintext size > 16",
+          "key" : "b7f165bced1613da5e747fdf9255832d30c07f2deeb5a326",
+          "iv" : "07ece5fe02266e073499fd4d66929034",
+          "msg" : "289647ea8d0ff31375a82aa1c620903048bb1d0e",
+          "ct" : "455d516e87851e6c894578a0f7126e0acbc7cfbb1d80296647ab89a79dfa6f71",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 83,
+          "comment" : "plaintext size > 16",
+          "key" : "9bbe6e004fb260dadb02b68b78954f1da5e6a2d02e0aeefe",
+          "iv" : "d799157bc1f77c182027be918b30783a",
+          "msg" : "665423092ce95b927e98b8082030f58e33f3ec1b0c29532c2f421855f00f97",
+          "ct" : "cbf541330a5a9bda24984976b0cf96ba08ef521fa2cdb3df839128570e222ac4",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 84,
+          "comment" : "plaintext size > 16",
+          "key" : "1381fbd5e79045d40f29790fc1a436c95b040a046ebf0b0f",
+          "iv" : "fdf97645e4192ba84728bbf6683f79de",
+          "msg" : "d575dce596dd0a2cd1c18dab7eb0948fafb8669969a48b6314493bfb8daf8acacd51382f9bb5b357",
+          "ct" : "03225f08592efca14ad8ecf822465e8be4157465d0be150dd3d645b6fef1b19ca7bbaa5940b2a7895fa2b0ee55b0d4ec",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 85,
+          "comment" : "plaintext size > 16",
+          "key" : "1bb4ed0e8435e20729f48c1b7e3af6e69e4cebf0731131cf",
+          "iv" : "059685f59247eea5d3f2a1532cb9d6b2",
+          "msg" : "6d29dab6a0568c961ab3c825e0d89940cef06c63ade7e557cd3e92792eaf23c8cd5a0f029c63b1cdce4754ccfad7a73c7c9e50ffe081e9136f5e9a424077339de12ea43572afe1b034e833e5887763aa",
+          "ct" : "27ad00313f328f0d3e6c3238ab560cb7243a9f54f7dff79b5a7a879439993d458017f09e8d3f694098bc19e61fe54085138664abb51a5b328cf2c9ce5d59726fff5e1b7553c143d9e0493c51cab23ff2ecdad91bd72bb12b32f3b611f9a4225d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 86,
+          "comment" : "zero padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "",
+          "ct" : "2c010faa25c68c3b30b8c1491c316d5f",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 87,
+          "comment" : "zero padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "6162636465666768",
+          "ct" : "818454d433154a8e00e8f590b8a1c38c",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 88,
+          "comment" : "zero padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "0a7423fae3f4c8d4633f839d36f2e9ff",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 89,
+          "comment" : "zero padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b61432e83f6e522c371e6e71bde539595b70b7",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 90,
+          "comment" : "zero padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b6143254d15f47701fa54f5957828f386e1d97",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 91,
+          "comment" : "padding with 0xff",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "",
+          "ct" : "6ded36cc7603e514014dfb7199900676",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 92,
+          "comment" : "padding with 0xff",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "6162636465666768",
+          "ct" : "839f772f8e5f50afdc02f954094869fe",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 93,
+          "comment" : "padding with 0xff",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "eefe3553c099c187929b287e54f95726",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 94,
+          "comment" : "padding with 0xff",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b61432d0531a2641d40467353542d79ce20ea8",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 95,
+          "comment" : "padding with 0xff",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b61432aaf08a090ecf66167ba5958100be7950",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 96,
+          "comment" : "bit padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "",
+          "ct" : "c0e402c8bbdda18c8ddd86470bd4b244",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 97,
+          "comment" : "bit padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "6162636465666768",
+          "ct" : "dc185d4572565e01131e471ec4c48125",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 98,
+          "comment" : "bit padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "3ad1ddf3c3b320398785e6ec6544e9a2",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 99,
+          "comment" : "bit padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b614325876f90cfbbdbcd85e8252d37c44c638",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 100,
+          "comment" : "bit padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b61432d18f57216b0e6426d911998a0e44156b",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 101,
+          "comment" : "padding longer than 1 block",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "",
+          "ct" : "f1605abb4e6628347c616da350fe243043a8d7b6aea244ca013f45241d802213",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 102,
+          "comment" : "padding longer than 1 block",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "6162636465666768",
+          "ct" : "a5f027fb9514ec8844534d452c940feb2c1807f57ed628156cf753f2ab698356",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 103,
+          "comment" : "padding longer than 1 block",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "f346fbc9744d723c42bbb2a4c934cdd4f1019e58c226cb2491fed621271a38f3",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 104,
+          "comment" : "padding longer than 1 block",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b6143263eb325d36e13aa1d3dd1d7e071700104c7eb3e22e0859aa06296bc3194bb909",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 105,
+          "comment" : "padding longer than 1 block",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b61432219485d41584bd110a6d7a9cad472815d93921c48d4bcb509fdf2e63d7627c37",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 106,
+          "comment" : "ANSI X.923 padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "",
+          "ct" : "215571a18a70140f3a0fd4c1b2dd6316",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 107,
+          "comment" : "ANSI X.923 padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "6162636465666768",
+          "ct" : "2529985ec0ec3cf4bd22746e00d7bdc6",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 108,
+          "comment" : "ANSI X.923 padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b614329a8058657ac4a150e995cf83efccf051",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 109,
+          "comment" : "ANSI X.923 padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b614328a068626780ba600f880bd5323f8ac15",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 110,
+          "comment" : "ISO 10126 padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "",
+          "ct" : "13e75f9ffe2afa81b9a2e7faf74aab6d",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 111,
+          "comment" : "ISO 10126 padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "6162636465666768",
+          "ct" : "a382197fe491f5c3f91b629dc47c3d58",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 112,
+          "comment" : "ISO 10126 padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b614320b842e5d6e32660263ff814a0277659f",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 113,
+          "comment" : "ISO 10126 padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b614321d2f736515cfe17921800eb392e0139d",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 114,
+          "comment" : "padding longer than message",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "",
+          "ct" : "f1605abb4e6628347c616da350fe2430",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 115,
+          "comment" : "padding longer than message",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "6162636465666768",
+          "ct" : "b3602ff0f797cbbdde35105d27e55b94",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 116,
+          "comment" : "padding longer than message",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "0334c1bc34b597f60a639e74d8b45c4e",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 117,
+          "comment" : "padding longer than message",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b61432c3f9fe42d9715035bcda97d27405ced7",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 118,
+          "comment" : "padding longer than message",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b61432362b014a9abdaf25ae1f6dfb99d03d9d",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 119,
+          "comment" : " invalid padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "",
+          "ct" : "97ab405b86c388f144cf74fbb9358493",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 120,
+          "comment" : " invalid padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "6162636465666768",
+          "ct" : "691f6009802f0fb4920928db7eca1349",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 121,
+          "comment" : " invalid padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b61432a99fc96a6fa0c9fcb18de1672d74914d",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 122,
+          "comment" : " invalid padding",
+          "key" : "9e20311eaf2eaf3e3a04bc52564e67313c84940a2996e3f2",
+          "iv" : "a3fe6f76e8f582830bbe83574a7bb729",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "a7cfcdabcc5a2736a2708c1cb0b61432dd1bb2e98102322fb1aa92c979d4c7c3",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        }
+      ]
+    },
+    {
+      "ivSize" : 128,
+      "keySize" : 256,
+      "type" : "IndCpaTest",
+      "tests" : [
+        {
+          "tcId" : 123,
+          "comment" : "empty message",
+          "key" : "7bf9e536b66a215c22233fe2daaa743a898b9acb9f7802de70b40e3d6e43ef97",
+          "iv" : "eb38ef61717e1324ae064e86f1c3e797",
+          "msg" : "",
+          "ct" : "e7c166554d1bb32792c981fa674cc4d8",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 124,
+          "comment" : "message size divisible by block size",
+          "key" : "612e837843ceae7f61d49625faa7e7494f9253e20cb3adcea686512b043936cd",
+          "iv" : "9ec7b863ac845cad5e4673da21f5b6a9",
+          "msg" : "cc37fae15f745a2f40e2c8b192f2b38d",
+          "ct" : "299295be47e9f5441fe83a7a811c4aeb2650333e681e69fa6b767d28a6ccf282",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 125,
+          "comment" : "message size divisible by block size",
+          "key" : "96e1e4896fb2cd05f133a6a100bc5609a7ac3ca6d81721e922dadd69ad07a892",
+          "iv" : "e70d83a77a2ce722ac214c00837acedf",
+          "msg" : "91a17e4dfcc3166a1add26ff0e7c12056e8a654f28a6de24f4ba739ceb5b5b18",
+          "ct" : "a615a39ff8f59f82cf72ed13e1b01e32459700561be112412961365c7a0b58aa7a16d68c065e77ebe504999051476bd7",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 126,
+          "comment" : "message size divisible by block size",
+          "key" : "649e373e681ef52e3c10ac265484750932a9918f28fb824f7cb50adab39781fe",
+          "iv" : "bd003c0a9d804c29f053a77cb380cb47",
+          "msg" : "39b447bd3a01983c1cb761b456d69000948ceb870562a536126a0d18a8e7e49b16de8fe672f13d0808d8b7d957899917",
+          "ct" : "ed3ed8ecdbabc0a8c06259e913f3ab9a1f1dc6d05e5dfdd9c80e1008f3423064d540681291bbd3e159820fee3ff190a68fe506d8ab9e62c8e7b3816093336dbc",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 127,
+          "comment" : "small plaintext size",
+          "key" : "e754076ceab3fdaf4f9bcab7d4f0df0cbbafbc87731b8f9b7cd2166472e8eebc",
+          "iv" : "014d2e13dfbcb969ba3bb91442d52eca",
+          "msg" : "40",
+          "ct" : "42c0b89a706ed2606cd94f9cb361fa51",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 128,
+          "comment" : "small plaintext size",
+          "key" : "ea3b016bdd387dd64d837c71683808f335dbdc53598a4ea8c5f952473fafaf5f",
+          "iv" : "fae3e2054113f6b3b904aadbfe59655c",
+          "msg" : "6601",
+          "ct" : "b90c326b72eb222ddb4dae47f2bc223c",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 129,
+          "comment" : "small plaintext size",
+          "key" : "73d4709637857dafab6ad8b2b0a51b06524717fedf100296644f7cfdaae1805b",
+          "iv" : "203cd3e0068e43d38b6f2e48a188f252",
+          "msg" : "f1d300",
+          "ct" : "567c45c5e6d570bef583d21cac43757d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 130,
+          "comment" : "small plaintext size",
+          "key" : "d5c81b399d4c0d1583a13da56de6d2dc45a66e7b47c24ab1192e246dc961dd77",
+          "iv" : "abcf220eede012279c3a2d33295ff273",
+          "msg" : "2ae63cbf",
+          "ct" : "c45afe62fc9351ad0fc9b03bc2f3a91f",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 131,
+          "comment" : "small plaintext size",
+          "key" : "2521203fa0dddf59d837b2830f87b1aa61f958155df3ca4d1df2457cb4284dc8",
+          "iv" : "01373953578902909ae4f6cb0a72587c",
+          "msg" : "af3a015ea1",
+          "ct" : "281fa533d0740cc6cdf94dd1a5f7402d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 132,
+          "comment" : "small plaintext size",
+          "key" : "665a02bc265a66d01775091da56726b6668bfd903cb7af66fb1b78a8a062e43c",
+          "iv" : "3fb0d5ecd06c71150748b599595833cb",
+          "msg" : "3f56935def3f",
+          "ct" : "3f3f39697bd7e88d85a14132be1cbc48",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 133,
+          "comment" : "small plaintext size",
+          "key" : "facd75b22221380047305bc981f570e2a1af38928ea7e2059e3af5fc6b82b493",
+          "iv" : "27a2db6114ece34fb6c23302d9ba07c6",
+          "msg" : "57bb86beed156f",
+          "ct" : "379990d91557614836381d5026fa04a0",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 134,
+          "comment" : "small plaintext size",
+          "key" : "505aa98819809ef63b9a368a1e8bc2e922da45b03ce02d9a7966b15006dba2d5",
+          "iv" : "9b2b631e3f24bdc814a14abb3416059e",
+          "msg" : "2e4e7ef728fe11af",
+          "ct" : "7ecefe24caa78a68f4031d40fdb9a43a",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 135,
+          "comment" : "small plaintext size",
+          "key" : "f942093842808ba47f64e427f7351dde6b9546e66de4e7d60aa6f328182712cf",
+          "iv" : "92cfc4eb146b18b73fc76483fc5e1229",
+          "msg" : "852a21d92848e627c7",
+          "ct" : "ffe4ec8baf4af40ab2e7f4d6193fae9c",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 136,
+          "comment" : "small plaintext size",
+          "key" : "64be162b39c6e5f1fed9c32d9f674d9a8cde6eaa2443214d86bd4a1fb53b81b4",
+          "iv" : "4ceed8dcb75b6259dad737bdef96f099",
+          "msg" : "195a3b292f93baff0a2c",
+          "ct" : "ef96215e7950e7be8aae78b9ec8aaf39",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 137,
+          "comment" : "small plaintext size",
+          "key" : "b259a555d44b8a20c5489e2f38392ddaa6be9e35b9833b67e1b5fdf6cb3e4c6c",
+          "iv" : "2d4cead3f1120a2b4b59419d04951e20",
+          "msg" : "afd73117330c6e8528a6e4",
+          "ct" : "4ed0eac75b05868078303875f82fb4f0",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 138,
+          "comment" : "small plaintext size",
+          "key" : "2c6fc62daa77ba8c6881b3dd6989898fef646663cc7b0a3db8228a707b85f2dc",
+          "iv" : "a10392634143c2a3332fa0fb3f72200a",
+          "msg" : "0ff54d6b6759120c2e8a51e3",
+          "ct" : "f4d298caea7c390fc8c7f558f584f852",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 139,
+          "comment" : "small plaintext size",
+          "key" : "abab815d51df29f740e4e2079fb798e0152836e6ab57d1536ae8929e52c06eb8",
+          "iv" : "38b916a7ad3a9251ae3bd8865ca3a688",
+          "msg" : "f0058d412a104e53d820b95a7f",
+          "ct" : "5e1c00e2ec829f92b87c6adf5c25262d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 140,
+          "comment" : "small plaintext size",
+          "key" : "3d5da1af83f7287458bff7a7651ea5d8db72259401333f6b82096996dd7eaf19",
+          "iv" : "bfcc3ac44d12e42d780c1188ac64b57f",
+          "msg" : "aacc36972f183057919ff57b49e1",
+          "ct" : "bf3a04ddb2dbfe7c6dc9e15aa67be25d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 141,
+          "comment" : "small plaintext size",
+          "key" : "c19bdf314c6cf64381425467f42aefa17c1cc9358be16ce31b1d214859ce86aa",
+          "iv" : "35bc82e3503b95044c6406a8b2c2ecff",
+          "msg" : "5d066a92c300e9b6ddd63a7c13ae33",
+          "ct" : "fdcfa77f5bd09326b4c11f9281b72474",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 142,
+          "comment" : "plaintext size > 16",
+          "key" : "73216fafd0022d0d6ee27198b2272578fa8f04dd9f44467fbb6437aa45641bf7",
+          "iv" : "4b74bd981ea9d074757c3e2ef515e5fb",
+          "msg" : "d5247b8f6c3edcbfb1d591d13ece23d2f5",
+          "ct" : "fbea776fb1653635f88e2937ed2450ba4e9063e96d7cdba04928f01cb85492fe",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 143,
+          "comment" : "plaintext size > 16",
+          "key" : "c2039f0d05951aa8d9fbdf68be58a37cf99bd1afcedda286a9db470c3729ca92",
+          "iv" : "9a1d8ccc24c5e4d3995480af236be103",
+          "msg" : "ed5b5e28e9703bdf5c7b3b080f2690a605fcd0d9",
+          "ct" : "3a79bb6084c7116b58afe52d7181a0aacee1caa11df959090e2e7b0073d74817",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 144,
+          "comment" : "plaintext size > 16",
+          "key" : "4f097858a1aec62cf18f0966b2b120783aa4ae9149d3213109740506ae47adfe",
+          "iv" : "400aab92803bcbb44a96ef789655b34e",
+          "msg" : "ee53d8e5039e82d9fcca114e375a014febfea117a7e709d9008d43858e3660",
+          "ct" : "642b11efb79b49e5d038bc7aa29b8c6c3ce0bf11c3a69670eb565799908be66d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 145,
+          "comment" : "plaintext size > 16",
+          "key" : "5f99f7d60653d79f088dd07ef306b65e057d36e053fa1c9f6854425c019fd4df",
+          "iv" : "6eedf45753ffe38f2407fbc28ab5959c",
+          "msg" : "fcc9212c23675c5d69a1266c77389bc955e453daba20034aabbcd502a1b73e05af30f8b7622abdbc",
+          "ct" : "a9b051354f0cf61f11921b330e60f996de796aeb68140a0f9c5962e1f48e4805262fb6f53b26d9bb2fa0e359efe14734",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 146,
+          "comment" : "plaintext size > 16",
+          "key" : "95aaa5df4ccb529e9b2dc929e770c1f419f8e8933bfb36f632f532b3dcad2ba6",
+          "iv" : "f88551c6aa197f9ad80251c2e32d7663",
+          "msg" : "f5735567b7c8312f116517788b091cc6cb1d474b010a77910154fd11c3b2f0cd19f713b63d66492e8cc7ee8ad714783f46c305a26416e11ff4b99ec5ce2550593cc5ec1b86ba6a66d10f82bdff827055",
+          "ct" : "5074f46f1a6d0eeff070d623172eb15bbfc83e7d16466a00c9da5f4545eecf44adbf60cf9ac9aa1a3ec5eca22d4a34a7b21ca44d214c9d04ab1cb0b2c07001de9adb46f3c12f8f48436b516a409bf6cbdf1871dee3115d5cbb7943558b68867e",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 147,
+          "comment" : "zero padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "",
+          "ct" : "e07558d746574528fb813f34e3fb7719",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 148,
+          "comment" : "zero padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "6162636465666768",
+          "ct" : "c01af61276368818a8295f7d4b5bb2fd",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 149,
+          "comment" : "zero padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "97dd9716f06be49160399a5b212250ae",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 150,
+          "comment" : "zero padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7ce783bb4b4e18d7c646f38e0bb8ff92896",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 151,
+          "comment" : "zero padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7ce64679a46621b792f643542a735f0bbbf",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 152,
+          "comment" : "padding with 0xff",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "",
+          "ct" : "c007ddffb76b95208505fe7f3be96172",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 153,
+          "comment" : "padding with 0xff",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "6162636465666768",
+          "ct" : "e9b7719c4c2b9fa6b94cb50e87b28156",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 154,
+          "comment" : "padding with 0xff",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "77b31f474c4bd489dbadd532643d1fa5",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 155,
+          "comment" : "padding with 0xff",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7cea0166e9e1c0122cb2e2983fc0fac7176",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 156,
+          "comment" : "padding with 0xff",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7ce6f0effa789cbb0b875cc53cc8f7b3caf",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 157,
+          "comment" : "bit padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "",
+          "ct" : "4dd5f910c94700235c9ed239160e34e2",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 158,
+          "comment" : "bit padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "6162636465666768",
+          "ct" : "94d18b5923f8f3608ae7ad494fbb517e",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 159,
+          "comment" : "bit padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "0c92886dbcb030b873123a25d224da42",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 160,
+          "comment" : "bit padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7ce851be67798a2937cd6681165da6dce03",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 161,
+          "comment" : "bit padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7ce45658a37aaebc51098866b0894007e8e",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 162,
+          "comment" : "padding longer than 1 block",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "",
+          "ct" : "524236e25956e950713bec0d3d579068f34e4d18c4ccab081317dae526fe7fca",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 163,
+          "comment" : "padding longer than 1 block",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "6162636465666768",
+          "ct" : "d29eb845640c3a8878f51bc50e290aa4a65a34a93728fe8f82fdb8d3d2b7c648",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 164,
+          "comment" : "padding longer than 1 block",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "c34563be2952277c0f5c67ae1d6f847118730dd7f6a502ceef3c4bce5999f7aa",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 165,
+          "comment" : "padding longer than 1 block",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7cec0f74a1aa92fd9c96f9d15d193d1695c1eb33486e269277612f90f509f0535c2",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 166,
+          "comment" : "padding longer than 1 block",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7ce151ade309ec5200bacdd83b57ce794cd2b3bf9f8957def829e8465f7db266f9e",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 167,
+          "comment" : "ANSI X.923 padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "",
+          "ct" : "fb38cbef13f1d5be9c0ac7ed9cbe023c",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 168,
+          "comment" : "ANSI X.923 padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "6162636465666768",
+          "ct" : "18cf8988abe9a2463a3a75db1fac8bcc",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 169,
+          "comment" : "ANSI X.923 padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7cee16d6fc4b4d3cdf6f915996e437fd4cc",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 170,
+          "comment" : "ANSI X.923 padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7cea8f41f61ead6e9936cbe7ee5a1163b9b",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 171,
+          "comment" : "ISO 10126 padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "",
+          "ct" : "a05c14da0109093c195b4998812fe150",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 172,
+          "comment" : "ISO 10126 padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "6162636465666768",
+          "ct" : "c477877250c8e4ca2869f35c4757cdb4",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 173,
+          "comment" : "ISO 10126 padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7ce69f57c6e99c7b9df7d4879ccd15caf3d",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 174,
+          "comment" : "ISO 10126 padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7ce77f89a247c928f147748ce6bc8fc4b67",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 175,
+          "comment" : "padding longer than message",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "",
+          "ct" : "524236e25956e950713bec0d3d579068",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 176,
+          "comment" : "padding longer than message",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "6162636465666768",
+          "ct" : "e03b6f2ae1c963b6dfa40b42d34314b7",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 177,
+          "comment" : "padding longer than message",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "303132333435363738396162636465",
+          "ct" : "df14f4cbbccca57b9727d68270a1b6c1",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 178,
+          "comment" : "padding longer than message",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7ceea228bf1edd41c390e2eef140142bc00",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 179,
+          "comment" : "padding longer than message",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7ce3937e0e9abf7f672a34a500ba8e9099a",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 180,
+          "comment" : " invalid padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "",
+          "ct" : "32ac6057df2a5d1e2e5131348c6ebc4e",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 181,
+          "comment" : " invalid padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "6162636465666768",
+          "ct" : "df4a7c3b9f4756d30fca0d18e9b28960",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 182,
+          "comment" : " invalid padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "30313233343536373839414243444546",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7ceae2855c47c7988873d57f901e049494b",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        },
+        {
+          "tcId" : 183,
+          "comment" : " invalid padding",
+          "key" : "7c78f34dbce8f0557d43630266f59babd1cb92ba624bd1a8f45a2a91c84a804a",
+          "iv" : "f010f61c31c9aa8fa0d5be5f6b0f2f70",
+          "msg" : "3031323334353637383941424344454647",
+          "ct" : "8881e9e02fa9e3037b397957ba1fb7ce0714c8de200b27ac91d9257fc93c13be",
+          "result" : "invalid",
+          "flags" : [
+            "BadPadding"
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
# Motivation
We want to support AES-CBC for encryption and decryption purposes.

# Modification
This PR adds support AES-CBC. Furthermore, it adds wycheproof tests for it.
