### PR TITLE
pkcs8PEMRepresenation for RSA private keys

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -130,7 +130,8 @@ let package = Package(
             ],
             exclude: [
                 "CMakeLists.txt",
-            ]
+            ],
+            swiftSettings: swiftSettings
         ),
         .target(
             name: "CryptoBoringWrapper",

--- a/Sources/_CryptoExtras/RSA/RSA.swift
+++ b/Sources/_CryptoExtras/RSA/RSA.swift
@@ -144,6 +144,10 @@ extension _RSA.Signing {
             self.backing.pemRepresentation
         }
 
+        public var pkcs8PEMRepresentation: String {
+            self.backing.pkcs8PEMRepresentation
+        }
+
         public var keySizeInBits: Int {
             self.backing.keySizeInBits
         }
@@ -388,6 +392,7 @@ extension _RSA.Encryption {
         
         public var derRepresentation: Data { self.backing.derRepresentation }
         public var pemRepresentation: String { self.backing.pemRepresentation }
+        public var pkcs8PEMRepresentation: String { self.backing.pkcs8PEMRepresentation }
         public var keySizeInBits: Int { self.backing.keySizeInBits }
         public var publicKey: _RSA.Encryption.PublicKey { .init(self.backing.publicKey) }
     }

--- a/Sources/_CryptoExtras/RSA/RSA.swift
+++ b/Sources/_CryptoExtras/RSA/RSA.swift
@@ -14,7 +14,7 @@
 import Foundation
 import Crypto
 
-#if canImport(Security)
+#if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 fileprivate typealias BackingPublicKey = SecurityRSAPublicKey
 fileprivate typealias BackingPrivateKey = SecurityRSAPrivateKey
 #else

--- a/Sources/_CryptoExtras/RSA/RSA_boring.swift
+++ b/Sources/_CryptoExtras/RSA/RSA_boring.swift
@@ -14,7 +14,9 @@
 import Foundation
 import Crypto
 
-#if !canImport(Security)
+#if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
+// Nothing; this is implemented in RSA_security
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 

--- a/Sources/_CryptoExtras/RSA/RSA_security.swift
+++ b/Sources/_CryptoExtras/RSA/RSA_security.swift
@@ -14,7 +14,7 @@
 import Foundation
 import Crypto
 
-#if canImport(Security)
+#if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_implementationOnly import Security
 
 internal struct SecurityRSAPublicKey {

--- a/Sources/_CryptoExtras/Util/BoringSSLHelpers.swift
+++ b/Sources/_CryptoExtras/Util/BoringSSLHelpers.swift
@@ -12,7 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if !canImport(Security)
+#if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
+// This is only used when bulding with BoringSSL.
+#else
 @_implementationOnly import CCryptoBoringSSL
 import Foundation
 import Crypto

--- a/Sources/_CryptoExtras/Util/DigestType.swift
+++ b/Sources/_CryptoExtras/Util/DigestType.swift
@@ -11,7 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if !canImport(Security)
+#if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
+// Nothing to do in this case
+#else
 @_implementationOnly import CCryptoBoringSSL
 import Crypto
 

--- a/Tests/_CryptoExtrasTests/TestRSASigning.swift
+++ b/Tests/_CryptoExtrasTests/TestRSASigning.swift
@@ -638,6 +638,43 @@ final class TestRSASigning: XCTestCase {
         XCTAssertEqual(pemKey, key.pemRepresentation)
     }
 
+    func testParsingPKCS8PrivateKeyPEM() throws {
+        let pemKey = """
+        -----BEGIN PRIVATE KEY-----
+        MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQCmKCB/22l/q8ny
+        ernraohemEndZ3+RFWpeXZcGpBiWmoUqmrlJOYEzYNwvMP3y2VKPRStWHzuVN/mc
+        /QTytLNec7HbgJqUpHZSh1XrviysJjBaWkVrOVAOmeXLnyImbCBsvhjxTHECjner
+        tnNRjuoPdSRhYU5+9filh/iQxVMTAZFeGAKwS5fSXh6nB7s9sEztJ01rFQ6myp7c
+        xteyhRgNAKRIYoxjgOSrzalH5PWJZ94fS3J8xPzUF9WILojXUKAagHoA8nTD1bfF
+        Jz2tFojnjbfBE8S4FUxiiflybtjlH1sZz7EqEATcu1ny/pludcfoKmHHFuuCA0q7
+        XOHWtptfAgMBAAECggEAZB/iFaneFPUsKFYUGuyDaJ1URXrMwFyrUFoNXA8eUgKj
+        JF1AMgPY+2DuzfEz1ldnDLadurPvb6ffXt6JUMfbHpuRHbiNbez88BZljD15JfON
+        R6UGF+rddy797oniRkz57Q1Qcneh0eyP6IV1UDxShyYL2jKM3qzSPM2G15ZQzS43
+        3xCTFEFFTxFdmDWxC4iV7LHgdwub/9+FX2M05GeVzZ2t35PtabJ/FVqbj29ANcdg
+        Q7UAIFgAWfwfQSA1qXbx0LyChwuEEyef2h3ENnveJm8E9t03h6RGJky9IQVMP3B6
+        0SzUmSGlEX0rXpq/dRNrC+3bBDyQB4ZagVGk41IB4QKBgQDXq1keSNi3o2a/c9Io
+        007+Fqo3PRj1035/yq+qqm6J158q9WIIJS+b71ZQ62UR7yxWtm7DiFE0mXvP+aF/
+        e767O6cOf9qrdMX+G8SpDRtmQzXVOsIv1J26cJezpdDeud6V5odUX6EdcErQqzcv
+        uhTSOVWQbrq4SAAcAoWCsvYruwKBgQDFOnuQ2sEK3GPbFHzX7I+BKIe8bq2JkcBN
+        cHgs9NHNd93pddbeITm1lp/XPv/uJiZU2nneMHpP04mT89WRlFNA5UpmD99Ra5yN
+        wIeKaDuDf7k6NJNL/ubLkbrdjVV4feKN9c57tjGeaYwEB/qpaf6v1WiElLNLfvFo
+        ZBPTEDVKrQKBgQCRHwCZq0UA1Nf3rfTVedLmkNO61cbs64JsdTOdcI9u+4NkAbgU
+        aQlPMU5wpuTcm4bHVnzT3+9cqIaynHQ6d0cRcANqc0fuJWZxJbhAVMyCFGmt8Jro
+        WnZEFS1POh2BMasATR30/WBJkd0V6o/48oq+JsxXotrL088XCe9S0h9prwKBgQCt
+        jacKctUIf6OHN2Ich9hH6ah4ElS3CADWpC+8L7snOWGXfNCVK1ujBWamfJOttvho
+        FtDCypn3AMjB3wGCV6ljI+HyKelztmRPAKrFCq/EKXKPW5B6gVYKsLRlHWem3e+s
+        yC7pAgxrv6ksKvFSfylVBVAxysBzoMNB/z7KriqXCQKBgD735odQUJdsPZ3Swnbv
+        Iq/roNK1tzFxb52IHS2r2WM9TX4OlQE1VSPTTs0f84wTS+XZAnDRGubN5GYBkmWp
+        K8TpFCFPBP/Yv1Kngovn4O1MskoxTQraRBDjfC6O7OfcSCSMuVgB0Oofcp9iQjLA
+        HV3KOnbYqvzmFv7OWnAszkTh
+        -----END PRIVATE KEY-----
+        
+        """
+
+        let key = try _RSA.Signing.PrivateKey(pemRepresentation: pemKey)
+        XCTAssertEqual(pemKey, key.pkcs8PEMRepresentation)
+    }
+
     private func testPKCS1Group(_ group: RSAPKCS1TestGroup) throws {
         let derKey = try _RSA.Signing.PublicKey(derRepresentation: group.keyDerBytes)
         let pemKey = try _RSA.Signing.PublicKey(pemRepresentation: group.keyPem)


### PR DESCRIPTION
This PR adds a `pkcs8PEMRepresentation` property to RSA public keys.

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] ~~I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request~~

### Motivation:

There are two widely-used formats for public and private keys. [PKCS#1](https://www.rfc-editor.org/rfc/rfc3447#appendix-A.1) defines the format for RSA keys, which begin with `BEGIN RSA {PUBLIC/PRIVATE KEY}` 

Later, as additional key types were implemented, more general containers were introduced. [X.509](https://www.rfc-editor.org/rfc/rfc3280#section-4.1) introduces `SubjectPublicKeyInfo` (SPKI), which defines a general structure for containing _any_ type of public key (RSA or otherwise). [PKCS#8](https://www.rfc-editor.org/rfc/rfc5208#page-3) does the same for private keys. `privateKey.pemRepresentation` gives the PKCS#1 representation, but there's no equivalent for getting the PCKS8 representation.

Our implementation of RSA keys included a way to get both the new and old format of public keys (via `publicKey.pemRepresentation` and `publicKey.pkcs1PEMRepresentation`), but we didn't have a way to get both the new and old formats of _private_ keys.

This PR introduces `_RSA.PrivateKey.pkcs8PEMRepresentation` to fill that gap.


### Modifications:

- `_RSA`'s backing private key types have gained a new `pkcs8PEMRepresentation` property.
- I adjusted the package file to pass the `CRYPTO_IN_SWIFTPM` and `CRYPTO_IN_SWIFTPM_FORCE_BUILD_API` flags to the `_CryptoExtras` target as well. 
- I updated the implementation of `_CryptoExtras` to check for those flags, rather than checking for `#if canImport(Security)`. This made it easier to test the RSA changes when building on macOS.

Note that the BoringSSL implementation of `pkcs8PEMRepresentation` includes a trailing newline. The naive implementation using Security.framework would not have that trailing newline, but for consistency between the two implementations, I have added it to both.

I'm open to instead stripping off the trailing new line on the BoringSSL implementation, but I was less sure of how to implement that.

### Result:

RSA private keys now have `pkcs8PEMRepresentation`.