### PR TITLE
Add extern C markers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ DerivedData
 
 .*.sw[nop]
 
+.vscode

--- a/Sources/CCryptoBoringSSLShims/include/CCryptoBoringSSLShims.h
+++ b/Sources/CCryptoBoringSSLShims/include/CCryptoBoringSSLShims.h
@@ -22,6 +22,10 @@
 #include <CCryptoBoringSSL.h>
 #endif
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 // MARK:- Pointer type shims
 // This section of the code handles shims that change uint8_t* pointers to
 // void *s. This is done because Swift does not have the rule that C does, that
@@ -119,5 +123,9 @@ int CCryptoBoringSSLShims_RSA_public_encrypt(int flen, const void *from, void *t
 
 int CCryptoBoringSSLShims_RSA_private_decrypt(int flen, const void *from, void *to,
                                               RSA *rsa, int padding);
+
+#if defined(__cplusplus)
+}
+#endif // defined(__cplusplus)
 
 #endif  // C_CRYPTO_BORINGSSL_SHIMS_H

--- a/Sources/CCryptoBoringSSLShims/shims.c
+++ b/Sources/CCryptoBoringSSLShims/shims.c
@@ -13,6 +13,10 @@
 //===----------------------------------------------------------------------===//
 #include <CCryptoBoringSSLShims.h>
 
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
 // MARK:- Pointer type shims
 // This section of the code handles shims that change uint8_t* pointers to
 // void *s. This is done because Swift does not have the rule that C does, that
@@ -152,3 +156,7 @@ int CCryptoBoringSSLShims_RSA_private_decrypt(int flen, const void *from, void *
                                               RSA *rsa, int padding) {
     return CCryptoBoringSSL_RSA_private_decrypt(flen, from, to, rsa, padding);
 }
+
+#if defined(__cplusplus)
+}
+#endif

--- a/Sources/CCryptoBoringSSLShims/shims.c
+++ b/Sources/CCryptoBoringSSLShims/shims.c
@@ -13,10 +13,6 @@
 //===----------------------------------------------------------------------===//
 #include <CCryptoBoringSSLShims.h>
 
-#if defined(__cplusplus)
-extern "C" {
-#endif
-
 // MARK:- Pointer type shims
 // This section of the code handles shims that change uint8_t* pointers to
 // void *s. This is done because Swift does not have the rule that C does, that
@@ -156,7 +152,3 @@ int CCryptoBoringSSLShims_RSA_private_decrypt(int flen, const void *from, void *
                                               RSA *rsa, int padding) {
     return CCryptoBoringSSL_RSA_private_decrypt(flen, from, to, rsa, padding);
 }
-
-#if defined(__cplusplus)
-}
-#endif


### PR DESCRIPTION
Ensure C linkage for shims to allow for usage in C++ interop environments.

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [x] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

This library when consumed from a swift package that has C++ interop enabled fails to successfully link since the symbols seem to get mangled.

### Modifications:

I've added conditional `extern "C"` markers in the shims file if and only iff C++ is detected.

### Result:

You should be able to consume and link this library in a target that has C++ interop enabled.