### PR TITLE
Add Sendable annotations to Crypto Extras

### DIFF
--- a/Sources/_CryptoExtras/AES/AES_GCM_SIV.swift
+++ b/Sources/_CryptoExtras/AES/AES_GCM_SIV.swift
@@ -16,7 +16,11 @@ import Crypto
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 @_implementationOnly import CryptoBoringWrapper
+#if canImport(Darwin) || swift(>=5.9.1)
 import Foundation
+#else
+@preconcurrency import Foundation
+#endif
 
 /// Types associated with the AES GCM SIV algorithm
 extension AES.GCM {
@@ -81,7 +85,7 @@ extension AES.GCM {
 }
 
 extension AES.GCM._SIV {
-    public struct Nonce: ContiguousBytes, Sequence {
+    public struct Nonce: Sendable, ContiguousBytes, Sequence {
         let bytes: Data
 
         /// Generates a fresh random Nonce. Unless required by a specification to provide a specific Nonce, this is the recommended initializer.
@@ -115,7 +119,7 @@ extension AES.GCM._SIV {
 }
 
 extension AES.GCM._SIV {
-    public struct SealedBox {
+    public struct SealedBox: Sendable {
         /// The combined representation ( nonce || ciphertext || tag)
         public let combined: Data
         /// The authentication tag

--- a/Sources/_CryptoExtras/ChaCha20CTR/ChaCha20CTR.swift
+++ b/Sources/_CryptoExtras/ChaCha20CTR/ChaCha20CTR.swift
@@ -16,7 +16,11 @@
 @_implementationOnly import CCryptoBoringSSLShims
 import Crypto
 @_implementationOnly import CryptoBoringWrapper
+#if canImport(Darwin) || swift(>=5.9.1)
 import Foundation
+#else
+@preconcurrency import Foundation
+#endif
 
 typealias ChaCha20CTRImpl = OpenSSLChaCha20CTRImpl
 
@@ -51,7 +55,7 @@ extension Insecure {
 }
 
 extension Insecure.ChaCha20CTR {
-    public struct Nonce: ContiguousBytes, Sequence {
+    public struct Nonce: Sendable, ContiguousBytes, Sequence {
         let bytes: Data
 
         /// Generates a fresh random Nonce. Unless required by a specification to provide a specific Nonce, this is the recommended initializer.
@@ -83,7 +87,7 @@ extension Insecure.ChaCha20CTR {
         }
     }
 
-    public struct Counter: ContiguousBytes {
+    public struct Counter: Sendable, ContiguousBytes {
         let counter: UInt32
 
         /// Generates a fresh Counter set to 0. Unless required by a specification to provide a specific Counter, this is the recommended initializer.

--- a/Sources/_CryptoExtras/RSA/RSA.swift
+++ b/Sources/_CryptoExtras/RSA/RSA.swift
@@ -159,7 +159,7 @@ extension _RSA.Signing {
 }
 
 extension _RSA.Signing {
-    public struct RSASignature: ContiguousBytes {
+    public struct RSASignature: Sendable, ContiguousBytes {
         public var rawRepresentation: Data
 
         public init<D: DataProtocol>(rawRepresentation: D) {
@@ -177,7 +177,7 @@ extension _RSA.Signing {
 }
 
 extension _RSA.Signing {
-    public struct Padding {
+    public struct Padding: Sendable {
         internal enum Backing {
             case pkcs1v1_5
             case pss
@@ -305,7 +305,7 @@ extension _RSA.Signing.PublicKey {
 }
 
 extension _RSA.Signing {
-    public struct KeySize {
+    public struct KeySize: Sendable {
         public let bitCount: Int
 
         /// RSA key size of 2048 bits
@@ -399,7 +399,7 @@ extension _RSA.Encryption {
 }
 
 extension _RSA.Encryption {
-    public struct Padding {
+    public struct Padding: Sendable {
         internal enum Backing {
             case pkcs1_oaep(Digest)
         }


### PR DESCRIPTION
### Motivation

Add Sendable annotations to Crypto Extras to reflect current sandability so that downstream packages can implement sendable conformance.

### Modifications

* Add Sendable conformance to appropriate public symbols.
* RSA public and private keys are notable omissions, this is because they are backed by SecKey from security framework and we have no guarantees about their sendability

### Result

* Accurate Sendable annotations