### PR TITLE
Add cxx interop build pipeline

### DIFF
--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -19,8 +19,6 @@ services:
     
   cxx-interop-build:
     image: swift-crypto:22.04-5.10
-    environment:
-      - CXX_INTEROP_BUILD_PACKAGE_NAME=code
 
   shell:
     image: swift-crypto:22.04-5.10

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -19,6 +19,8 @@ services:
     
   cxx-interop-build:
     image: swift-crypto:22.04-5.10
+    environment:
+      - CXX_INTEROP_BUILD_PACKAGE_NAME=code
 
   shell:
     image: swift-crypto:22.04-5.10

--- a/docker/docker-compose.2204.510.yaml
+++ b/docker/docker-compose.2204.510.yaml
@@ -16,6 +16,9 @@ services:
 
   cmake:
     image: swift-crypto:22.04-5.10
+    
+  cxx-interop-build:
+    image: swift-crypto:22.04-5.10
 
   shell:
     image: swift-crypto:22.04-5.10

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -20,6 +20,8 @@ services:
 
   cxx-interop-build:
     image: swift-crypto:22.04-5.9
+    environment:
+      - CXX_INTEROP_BUILD_PACKAGE_NAME=code
 
   shell:
     image: swift-crypto:22.04-5.9

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -18,5 +18,8 @@ services:
   cmake:
     image: swift-crypto:22.04-5.9
 
+  cxx-interop-build:
+    image: swift-crypto:22.04-5.9
+
   shell:
     image: swift-crypto:22.04-5.9

--- a/docker/docker-compose.2204.59.yaml
+++ b/docker/docker-compose.2204.59.yaml
@@ -20,8 +20,6 @@ services:
 
   cxx-interop-build:
     image: swift-crypto:22.04-5.9
-    environment:
-      - CXX_INTEROP_BUILD_PACKAGE_NAME=code
 
   shell:
     image: swift-crypto:22.04-5.9

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -16,8 +16,8 @@ services:
     depends_on: [runtime-setup]
     volumes:
       - ~/.ssh:/root/.ssh
-      - ..:/code:z
-    working_dir: /code
+      - ..:/swift-crypto:z
+    working_dir: /swift-crypto
     cap_drop:
       - CAP_NET_RAW
       - CAP_NET_BIND_SERVICE

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -35,6 +35,10 @@ services:
   cmake:
     <<: *common
     command: /bin/bash -xcl "cmake -G Ninja -D CMAKE_BUILD_TYPE=Release -B out -S . && ninja -C out"
+    
+  cxx-interop-build:
+    <<: *common
+    command: /bin/bash -xcl "swift build -Xswiftc -cxx-interoperability-mode=default"
 
   # util
 

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
     
   cxx-interop-build:
     <<: *common
-    command: /bin/bash -xcl "swift build -Xswiftc -cxx-interoperability-mode=default"
+    command: /bin/bash -xcl "./scripts/cxx-interop-compatibility.sh"
 
   # util
 

--- a/scripts/cxx-interop-compatibility.sh
+++ b/scripts/cxx-interop-compatibility.sh
@@ -18,7 +18,6 @@ set -eu
 sourcedir=$(dirname "$(readlink -f $0)")/..
 workingdir=$(mktemp -d)
 projectname=$(basename $workingdir)
-packagename=${CXX_INTEROP_BUILD_PACKAGE_NAME:-swift-crypto}
 
 cd $workingdir
 swift package init
@@ -46,16 +45,11 @@ let package = Package(
             // Depend on all products of swift-crypto to make sure they're all
             // compatible with cxx interop.
             dependencies: [
-                .product(name: "Crypto", package: "$packagename"),
-                .product(name: "_CryptoExtras", package: "$packagename")
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "_CryptoExtras", package: "swift-crypto")
             ],
             swiftSettings: [.interoperabilityMode(.Cxx)]
-        ),
-        .testTarget(
-            name: "interopTests",
-            dependencies: ["interop"],
-            swiftSettings: [.interoperabilityMode(.Cxx)]
-        ),
+        )
     ]
 )
 EOF

--- a/scripts/cxx-interop-compatibility.sh
+++ b/scripts/cxx-interop-compatibility.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+##===----------------------------------------------------------------------===##
+##
+## This source file is part of the SwiftCrypto open source project
+##
+## Copyright (c) 2023 Apple Inc. and the SwiftCrypto project authors
+## Licensed under Apache License v2.0
+##
+## See LICENSE.txt for license information
+## See CONTRIBUTORS.md for the list of SwiftCrypto project authors
+##
+## SPDX-License-Identifier: Apache-2.0
+##
+##===----------------------------------------------------------------------===##
+
+set -eu
+
+sourcedir=$(pwd)
+workingdir=$(mktemp -d)
+projectname=$(basename $workingdir)
+
+cd $workingdir
+swift package init
+
+cat << EOF > Package.swift
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "interop",
+        platforms: [
+        .macOS(.v10_15),
+        .iOS(.v13),
+        .watchOS(.v6),
+        .tvOS(.v13),
+    ],
+    products: [
+        .library(
+            name: "interop",
+            targets: ["interop"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "$sourcedir")
+    ],
+    targets: [
+        .target(
+            name: "interop",
+            // Depend on all products of swift-crypto to make sure they're all
+            // compatible with cxx interop.
+            dependencies: [
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "_CryptoExtras", package: "swift-crypto")
+            ],
+            swiftSettings: [.interoperabilityMode(.Cxx)]
+        ),
+        .testTarget(
+            name: "interopTests",
+            dependencies: ["interop"],
+            swiftSettings: [.interoperabilityMode(.Cxx)]
+        ),
+    ]
+)
+EOF
+
+cat << EOF > Sources/$projectname/$(echo $projectname | tr . _).swift
+import Crypto
+import _CryptoExtras
+EOF
+
+swift build

--- a/scripts/cxx-interop-compatibility.sh
+++ b/scripts/cxx-interop-compatibility.sh
@@ -15,9 +15,10 @@
 
 set -eu
 
-sourcedir=$(pwd)
+sourcedir=$(dirname "$(readlink -f $0)")/..
 workingdir=$(mktemp -d)
 projectname=$(basename $workingdir)
+packagename=${CXX_INTEROP_BUILD_PACKAGE_NAME:-swift-crypto}
 
 cd $workingdir
 swift package init
@@ -29,12 +30,7 @@ import PackageDescription
 
 let package = Package(
     name: "interop",
-        platforms: [
-        .macOS(.v10_15),
-        .iOS(.v13),
-        .watchOS(.v6),
-        .tvOS(.v13),
-    ],
+    platforms: [.macOS(.v10_15)],
     products: [
         .library(
             name: "interop",
@@ -50,8 +46,8 @@ let package = Package(
             // Depend on all products of swift-crypto to make sure they're all
             // compatible with cxx interop.
             dependencies: [
-                .product(name: "Crypto", package: "swift-crypto"),
-                .product(name: "_CryptoExtras", package: "swift-crypto")
+                .product(name: "Crypto", package: "$packagename"),
+                .product(name: "_CryptoExtras", package: "$packagename")
             ],
             swiftSettings: [.interoperabilityMode(.Cxx)]
         ),


### PR DESCRIPTION
This PR adds a new target to `docker-compose` that builds this project with C++ interoperability enabled, with the goal of adding a new CI pipeline that performs this check.

### Motivation:

To make sure that C++ interoperability can be used on projects that depend on `swift-crypto`.

### Modifications:

- Added a new target to docker-compose that builds this project with C++ interoperability enabled.
- Will request a new CI pipeline that runs this new target.

### Result:

We will ensure this projects builds properly with C++ interoperability enabled.