### PR TITLE
Update availability annotations in tests

### DIFF
--- a/Tests/CryptoTests/Digests/DigestsTests.swift
+++ b/Tests/CryptoTests/Digests/DigestsTests.swift
@@ -113,6 +113,7 @@ class DigestsTests: XCTestCase {
         try orFail { try testHashFunctionImplementsCoW(hf: SHA512.self) }
     }
     
+    @available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
     func testBlockSizes() {
         XCTAssertEqual(Insecure.MD5.blockByteCount, 64)
         XCTAssertEqual(Insecure.SHA1.blockByteCount, 64)

--- a/Tests/_CryptoExtrasTests/Utils/BytesUtil.swift
+++ b/Tests/_CryptoExtrasTests/Utils/BytesUtil.swift
@@ -60,7 +60,7 @@ extension DataProtocol {
     var hexString: String {
         get {
             let hexLen = self.count * 2
-            return String.init(unsafeUninitializedCapacity: hexLen) { buf in
+            let bytes = Array(unsafeUninitializedCapacity: hexLen) { buf, count in
                 var offset = 0
 
                 self.regions.forEach { (_) in
@@ -70,8 +70,9 @@ extension DataProtocol {
                         offset += 1
                     }
                 }
-                return offset
+                count = offset
             }
+            return String(decoding: bytes, as: UTF8.self)
         }
     }
 }


### PR DESCRIPTION
### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### ~If you've made changes to `gyb` files~
- [ ] ~I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request~

### Motivation:

When building the tests for iOS and tvOS, the build fails because we are using APIs that aren't available on all platform versions. E.g.:

```
Tests/CryptoTests/Digests/DigestsTests.swift:117:37: error: 'blockByteCount' is only available in iOS 13.2 or newer
        XCTAssertEqual(Insecure.MD5.blockByteCount, 64)
```

### Modifications:

- Add `@available` guard to test that uses `blockByteCount` API.
- Update `DataProtocol.hexString` to not use `String.init(unsafeUninitializedCapacity:initializingUTF8With:)`, which is only available on iOS 14+, and instead use `Array.init(unsafeUninitializedCapacity:initializingWith:)`, which is available on older platforms.
 
### Result:

Tests can now build for and run on iOS and tvOS.