### PR TITLE
Add more Sendable annotations to Crypto Extras

### DIFF
--- a/Sources/_CryptoExtras/AES/AES_CBC.swift
+++ b/Sources/_CryptoExtras/AES/AES_CBC.swift
@@ -18,7 +18,7 @@ import Foundation
 extension AES {
     /// The Advanced Encryption Standard (AES) Cipher Block Chaining (CBC) cipher
     /// suite.
-    public enum _CBC {
+    public enum _CBC: Sendable {
         private static var blockSize: Int { 16 }
 
         private static func encryptBlockInPlace(
@@ -143,7 +143,7 @@ extension AES {
 
 extension AES._CBC {
     /// An initialization vector.
-    public struct IV {
+    public struct IV: Sendable {
         // AES CBC uses a 128-bit IV.
         var ivBytes: (
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,

--- a/Sources/_CryptoExtras/AES/AES_CBC.swift
+++ b/Sources/_CryptoExtras/AES/AES_CBC.swift
@@ -18,7 +18,7 @@ import Foundation
 extension AES {
     /// The Advanced Encryption Standard (AES) Cipher Block Chaining (CBC) cipher
     /// suite.
-    public enum _CBC: Sendable {
+    public enum _CBC {
         private static var blockSize: Int { 16 }
 
         private static func encryptBlockInPlace(

--- a/Sources/_CryptoExtras/AES/AES_GCM_SIV.swift
+++ b/Sources/_CryptoExtras/AES/AES_GCM_SIV.swift
@@ -25,7 +25,7 @@ import Foundation
 /// Types associated with the AES GCM SIV algorithm
 extension AES.GCM {
     /// AES in GCM SIV mode with 128-bit tags.
-    public enum _SIV: Sendable {
+    public enum _SIV {
         static let tagByteCount = 16
         static let nonceByteCount = 12
 

--- a/Sources/_CryptoExtras/AES/AES_GCM_SIV.swift
+++ b/Sources/_CryptoExtras/AES/AES_GCM_SIV.swift
@@ -25,7 +25,7 @@ import Foundation
 /// Types associated with the AES GCM SIV algorithm
 extension AES.GCM {
     /// AES in GCM SIV mode with 128-bit tags.
-    public enum _SIV {
+    public enum _SIV: Sendable {
         static let tagByteCount = 16
         static let nonceByteCount = 12
 

--- a/Sources/_CryptoExtras/RSA/RSA.swift
+++ b/Sources/_CryptoExtras/RSA/RSA.swift
@@ -44,7 +44,7 @@ extension _RSA {
 }
 
 extension _RSA.Signing {
-    public struct PublicKey {
+    public struct PublicKey: Sendable {
         private var backing: BackingPublicKey
 
         /// Construct an RSA public key from a PEM representation.
@@ -98,7 +98,7 @@ extension _RSA.Signing {
 }
 
 extension _RSA.Signing {
-    public struct PrivateKey {
+    public struct PrivateKey: Sendable {
         private var backing: BackingPrivateKey
 
         /// Construct an RSA private key from a PEM representation.

--- a/Sources/_CryptoExtras/RSA/RSA_boring.swift
+++ b/Sources/_CryptoExtras/RSA/RSA_boring.swift
@@ -20,7 +20,7 @@ import Crypto
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 
-internal struct BoringSSLRSAPublicKey {
+internal struct BoringSSLRSAPublicKey: Sendable {
     private var backing: Backing
 
     init(pemRepresentation: String) throws {
@@ -57,7 +57,7 @@ internal struct BoringSSLRSAPublicKey {
 }
 
 
-internal struct BoringSSLRSAPrivateKey {
+internal struct BoringSSLRSAPrivateKey: Sendable {
     private var backing: Backing
 
     init(pemRepresentation: String) throws {

--- a/Sources/_CryptoExtras/RSA/RSA_security.swift
+++ b/Sources/_CryptoExtras/RSA/RSA_security.swift
@@ -17,7 +17,8 @@ import Crypto
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_implementationOnly import Security
 
-internal struct SecurityRSAPublicKey {
+// unchecked sendable until `SecKey` gets sendable annotations
+internal struct SecurityRSAPublicKey: @unchecked Sendable {
     private var backing: SecKey
 
     init(pemRepresentation: String) throws {
@@ -69,8 +70,8 @@ internal struct SecurityRSAPublicKey {
     }
 }
 
-
-internal struct SecurityRSAPrivateKey {
+// unchecked sendable until `SecKey` gets sendable annotations
+internal struct SecurityRSAPrivateKey: @unchecked Sendable {
     private var backing: SecKey
 
     init(pemRepresentation: String) throws {


### PR DESCRIPTION
### Motivation

Add Sendable annotations to Crypto Extras to reflect current sandability so that downstream packages can implement sendable conformance.

### Modifications

* Add Sendable conformance to some missed public symbols.
* RSA public and private keys are now marked sendable with their backing storage on darwin OS marked unchecked sendable until SecKey from security framework has sendability annotations

### Result

* More accurate Sendable annotations