### PR TITLE
Add support for AES CTR mode in _CryptoExtras

### DIFF
--- a/Sources/_CryptoExtras/AES/AES_CTR.swift
+++ b/Sources/_CryptoExtras/AES/AES_CTR.swift
@@ -1,0 +1,136 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+import Foundation
+
+extension AES {
+    public enum _CTR {
+        private static func encryptInPlace(
+            _ plaintext: UnsafeMutableRawBufferPointer,
+            using key: SymmetricKey,
+            nonce: AES._CTR.Nonce
+        ) throws {
+            precondition(MemoryLayout<AES._CTR.Nonce>.size == 16)
+
+            guard [128, 192, 256].contains(key.bitCount) else {
+                throw CryptoKitError.incorrectKeySize
+            }
+
+            var nonce = nonce
+
+            for offset in stride(from: 0, to: plaintext.count, by: MemoryLayout<AES._CTR.Nonce>.size) {
+                var nonceCopy = nonce
+
+                try nonceCopy.withUnsafeMutableBytes { noncePtr in
+                    var noncePtr = noncePtr
+                    try AES.permute(&noncePtr, key: key)
+                    let remainingPlaintextBytes = plaintext.count &- offset
+
+                    for i in 0..<min(remainingPlaintextBytes, MemoryLayout<AES._CTR.Nonce>.size) {
+                        plaintext[offset &+ i] ^= noncePtr[i]
+                    }
+                }
+
+                nonce.incrementCounter()
+            }
+        }
+
+        public static func encrypt<Plaintext: DataProtocol>(
+            _ plaintext: Plaintext,
+            using key: SymmetricKey,
+            nonce: AES._CTR.Nonce
+        ) throws -> Data {
+            var flattenedPlaintext = Data(plaintext)
+            try flattenedPlaintext.withUnsafeMutableBytes {
+                try Self.encryptInPlace($0, using: key, nonce: nonce)
+            }
+            return flattenedPlaintext
+        }
+
+        private static func decryptInPlace(
+            _ ciphertext: UnsafeMutableRawBufferPointer,
+            using key: SymmetricKey,
+            nonce: AES._CTR.Nonce
+        ) throws {
+            // Surprise, CTR mode is symmetric in encryption/decryption!
+            try Self.encryptInPlace(ciphertext, using: key, nonce: nonce)
+        }
+
+        public static func decrypt<Ciphertext: DataProtocol>(
+            _ ciphertext: Ciphertext,
+            using key: SymmetricKey,
+            nonce: AES._CTR.Nonce
+        ) throws -> Data {
+            var flattenedCiphertext = Data(ciphertext)
+            try flattenedCiphertext.withUnsafeMutableBytes {
+                try Self.decryptInPlace($0, using: key, nonce: nonce)
+            }
+            return flattenedCiphertext
+        }
+    }
+}
+
+extension AES._CTR {
+    public struct Nonce: Sendable {
+        // AES CTR uses a 128-bit counter. It's most usual to use a 96-bit nonce
+        // and a 32-bit counter at the end, so we support that specific mode of
+        // operation here.
+        private var nonceBytes: (
+            UInt64, UInt32, UInt32
+        )
+
+        public init() {
+            var rng = SystemRandomNumberGenerator()
+            self.nonceBytes = (
+                rng.next(), rng.next(), rng.next()
+            )
+        }
+
+        public init<NonceBytes: Collection>(nonceBytes: NonceBytes) throws where NonceBytes.Element == UInt8 {
+            // We support a 96-bit nonce (with a 32-bit counter, initialized to 0) or a full 128-bit
+            // expression.
+            guard nonceBytes.count == 12 || nonceBytes.count == 16 else {
+                throw CryptoKitError.incorrectParameterSize
+            }
+
+            self.nonceBytes = (
+                0, 0, 0
+            )
+
+            Swift.withUnsafeMutableBytes(of: &self.nonceBytes) { bytesPtr in
+                bytesPtr.copyBytes(from: nonceBytes)
+            }
+        }
+
+        mutating func incrementCounter() {
+            var (newValue, overflow) = UInt32(bigEndian: self.nonceBytes.2).addingReportingOverflow(1)
+            self.nonceBytes.2 = newValue.bigEndian
+
+            if overflow {
+                (newValue, overflow) = UInt32(bigEndian: self.nonceBytes.1).addingReportingOverflow(1)
+                self.nonceBytes.1 = newValue.bigEndian
+            }
+
+            if overflow {
+                // If this overflows that's fine: we'll have overflowed everything and gone back to 0.
+                self.nonceBytes.0 = (UInt64(bigEndian: self.nonceBytes.0) &+ 1).bigEndian
+            }
+        }
+
+        mutating func withUnsafeMutableBytes<ReturnType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ReturnType) rethrows -> ReturnType {
+            return try Swift.withUnsafeMutableBytes(of: &self.nonceBytes, body)
+        }
+    }
+}

--- a/Tests/_CryptoExtrasTests/AES_CTRTests.swift
+++ b/Tests/_CryptoExtrasTests/AES_CTRTests.swift
@@ -1,0 +1,220 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.md for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crypto
+import Foundation
+@testable import _CryptoExtras
+import XCTest
+
+final class AESCTRTests: XCTestCase {
+    /// This plaintext is the plaintext for the NIST test vectors from
+    /// NIST Special Publication 800-38A.
+    static let plaintext = """
+    6bc1bee22e409f96e93d7e117393172a\
+    ae2d8a571e03ac9c9eb76fac45af8e51\
+    30c81c46a35ce411e5fbc1191a0a52ef\
+    f69f2445df4f9b17ad2b417be66c3710
+    """
+
+    static let plaintextBytes: Data = try! Data(Array(hexString: plaintext))
+
+    func testEncryptionVectorF51() throws {
+        let hexKey = "2b7e151628aed2a6abf7158809cf4f3c"
+        let key = SymmetricKey(hexEncoded: hexKey)
+
+        let hexNonce = "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+        let nonce = try AES._CTR.Nonce(nonceBytes: Array(hexString: hexNonce))
+
+        let plaintext = Self.plaintextBytes
+        let encryptedBytes = try AES._CTR.encrypt(plaintext, using: key, nonce: nonce)
+
+        let ciphertext = """
+        874d6191b620e3261bef6864990db6ce\
+        9806f66b7970fdff8617187bb9fffdff\
+        5ae4df3edbd5d35e5b4f09020db03eab\
+        1e031dda2fbe03d1792170a0f3009cee
+        """
+        let ciphertextBytes = try Data(hexString: ciphertext)
+        XCTAssertEqual(encryptedBytes, ciphertextBytes)
+    }
+
+    func testDecryptionVectorF52() throws {
+        let hexKey = "2b7e151628aed2a6abf7158809cf4f3c"
+        let key = SymmetricKey(hexEncoded: hexKey)
+
+        let hexNonce = "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+        let nonce = try AES._CTR.Nonce(nonceBytes: Array(hexString: hexNonce))
+
+        let ciphertext = """
+        874d6191b620e3261bef6864990db6ce\
+        9806f66b7970fdff8617187bb9fffdff\
+        5ae4df3edbd5d35e5b4f09020db03eab\
+        1e031dda2fbe03d1792170a0f3009cee
+        """
+        let ciphertextBytes = try Array(hexString: ciphertext)
+        let decryptedBytes = try AES._CTR.decrypt(ciphertextBytes, using: key, nonce: nonce)
+        XCTAssertEqual(Self.plaintextBytes, decryptedBytes)
+    }
+
+    func testEncryptionVectorF53() throws {
+        let hexKey = "8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b"
+        let key = SymmetricKey(hexEncoded: hexKey)
+
+        let hexNonce = "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+        let nonce = try AES._CTR.Nonce(nonceBytes: Array(hexString: hexNonce))
+
+        let plaintext = Self.plaintextBytes
+        let encryptedBytes = try AES._CTR.encrypt(plaintext, using: key, nonce: nonce)
+
+        let ciphertext = """
+        1abc932417521ca24f2b0459fe7e6e0b\
+        090339ec0aa6faefd5ccc2c6f4ce8e94\
+        1e36b26bd1ebc670d1bd1d665620abf7\
+        4f78a7f6d29809585a97daec58c6b050
+        """
+        let ciphertextBytes = try Data(hexString: ciphertext)
+        XCTAssertEqual(encryptedBytes, ciphertextBytes)
+    }
+
+    func testDecryptionVectorF54() throws {
+        let hexKey = "8e73b0f7da0e6452c810f32b809079e562f8ead2522c6b7b"
+        let key = SymmetricKey(hexEncoded: hexKey)
+
+        let hexNonce = "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+        let nonce = try AES._CTR.Nonce(nonceBytes: Array(hexString: hexNonce))
+
+        let ciphertext = """
+        1abc932417521ca24f2b0459fe7e6e0b\
+        090339ec0aa6faefd5ccc2c6f4ce8e94\
+        1e36b26bd1ebc670d1bd1d665620abf7\
+        4f78a7f6d29809585a97daec58c6b050
+        """
+        let ciphertextBytes = try Array(hexString: ciphertext)
+        let decryptedBytes = try AES._CTR.decrypt(ciphertextBytes, using: key, nonce: nonce)
+        XCTAssertEqual(Self.plaintextBytes, decryptedBytes)
+    }
+
+    func testEncryptionVectorF55() throws {
+        let hexKey = "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"
+        let key = SymmetricKey(hexEncoded: hexKey)
+
+        let hexNonce = "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+        let nonce = try AES._CTR.Nonce(nonceBytes: Array(hexString: hexNonce))
+
+        let plaintext = Self.plaintextBytes
+        let encryptedBytes = try AES._CTR.encrypt(plaintext, using: key, nonce: nonce)
+
+        let ciphertext = """
+        601ec313775789a5b7a7f504bbf3d228\
+        f443e3ca4d62b59aca84e990cacaf5c5\
+        2b0930daa23de94ce87017ba2d84988d\
+        dfc9c58db67aada613c2dd08457941a6
+        """
+        let ciphertextBytes = try Data(hexString: ciphertext)
+        XCTAssertEqual(encryptedBytes, ciphertextBytes)
+    }
+
+    func testDecryptionVectorF56() throws {
+        let hexKey = "603deb1015ca71be2b73aef0857d77811f352c073b6108d72d9810a30914dff4"
+        let key = SymmetricKey(hexEncoded: hexKey)
+
+        let hexNonce = "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff"
+        let nonce = try AES._CTR.Nonce(nonceBytes: Array(hexString: hexNonce))
+
+        let ciphertext = """
+        601ec313775789a5b7a7f504bbf3d228\
+        f443e3ca4d62b59aca84e990cacaf5c5\
+        2b0930daa23de94ce87017ba2d84988d\
+        dfc9c58db67aada613c2dd08457941a6
+        """
+        let ciphertextBytes = try Array(hexString: ciphertext)
+        let decryptedBytes = try AES._CTR.decrypt(ciphertextBytes, using: key, nonce: nonce)
+        XCTAssertEqual(Self.plaintextBytes, decryptedBytes)
+    }
+
+    func testRejectsInvalidNonceSizes() throws {
+        let someBytes = Array(repeating: UInt8(0), count: 24)
+
+        for count in 0..<someBytes.count {
+            let nonceBytes = someBytes.prefix(count)
+
+            if count != 12 && count != 16 {
+                XCTAssertThrowsError(try AES._CTR.Nonce(nonceBytes: nonceBytes))
+            } else {
+                XCTAssertNoThrow(try AES._CTR.Nonce(nonceBytes: nonceBytes))
+            }
+        }
+    }
+
+    func testOverflowAllNonceBytesWorks() throws {
+        var nonce = try AES._CTR.Nonce(nonceBytes: repeatElement(0xFF, count: 16))
+        nonce.withUnsafeMutableBytes { nonceBytes in
+            XCTAssertTrue(nonceBytes.allSatisfy { $0 == 0xFF })
+        }
+
+        nonce.incrementCounter()
+
+        nonce.withUnsafeMutableBytes { nonceBytes in
+            XCTAssertTrue(nonceBytes.allSatisfy { $0 == 0x00 })
+        }
+    }
+
+    func testOverflowCounterCorrectlyStoresInBigEndian() throws {
+        let nonceBytes: [UInt8] = [
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0x01, 0x02, 0x03, 0x04,
+            0xFF, 0xFF, 0xFF, 0xFF,
+        ]
+        var nonce = try AES._CTR.Nonce(nonceBytes: nonceBytes)
+
+        nonce.incrementCounter()
+
+        let newNonceBytes = nonce.withUnsafeMutableBytes {
+            Array($0)
+        }
+
+        let expectedNonceBytes: [UInt8] = [
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+            0x01, 0x02, 0x03, 0x05,
+            0x00, 0x00, 0x00, 0x00,
+        ]
+        XCTAssertEqual(expectedNonceBytes, newNonceBytes)
+    }
+
+    func testOverflowCounterAndNextUInt32CorrectlyStoresInBigEndian() throws {
+        let nonceBytes: [UInt8] = [
+            0x01, 0x02, 0x03, 0x04,
+            0x05, 0x06, 0x07, 0x08,
+            0xFF, 0xFF, 0xFF, 0xFF,
+            0xFF, 0xFF, 0xFF, 0xFF,
+        ]
+        var nonce = try AES._CTR.Nonce(nonceBytes: nonceBytes)
+
+        nonce.incrementCounter()
+
+        let newNonceBytes = nonce.withUnsafeMutableBytes {
+            Array($0)
+        }
+
+        let expectedNonceBytes: [UInt8] = [
+            0x01, 0x02, 0x03, 0x04,
+            0x05, 0x06, 0x07, 0x09,
+            0x00, 0x00, 0x00, 0x00,
+            0x00, 0x00, 0x00, 0x00,
+        ]
+        XCTAssertEqual(expectedNonceBytes, newNonceBytes)
+    }
+}

--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -17,7 +17,7 @@ set -eu
 here="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 function replace_acceptable_years() {
     # this needs to replace all acceptable forms with 'YEARS'
-    sed -e 's/20[12][8901]-20[12][90123]/YEARS/' -e 's/20[12][90123]/YEARS/'
+    sed -e 's/20[12][8901]-20[12][90123]/YEARS/' -e 's/20[12][901234]/YEARS/'
 }
 
 printf "=> Checking for unacceptable language... "


### PR DESCRIPTION
Add support for AES Counter mode

### Motivation:

AES in counter mode is not an uncommon primitive to see. While this isn't as good as an AEAD construction, there are some cases in which it is necessary to use this mode.

### Modifications:

- Add AES in CTR mode, behind an underscore.

### Result:

Counter mode support is available.