### PR TITLE
Add empty privacy manifest files

### DIFF
--- a/.PrivacyInfo.xcprivacy
+++ b/.PrivacyInfo.xcprivacy
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSPrivacyTracking</key>
+    <false/>
+    <key>NSPrivacyAccessedAPITypes</key>
+    <array/>
+    <key>NSPrivacyCollectedDataTypes</key>
+    <array/>
+    <key>NSPrivacyTrackingDomains</key>
+    <array/>
+</dict>
+</plist>
+

--- a/Package.swift
+++ b/Package.swift
@@ -88,6 +88,9 @@ let package = Package(
                 "crypto/bio/socket_helper.c",
                 "crypto/bio/socket.c"
             ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy"),
+            ],
             cSettings: [
                 // These defines come from BoringSSL's build system
                 .define("_HAS_EXCEPTIONS", to: "0", .when(platforms: [Platform.windows])),
@@ -106,6 +109,9 @@ let package = Package(
             dependencies: ["CCryptoBoringSSL"],
             exclude: [
                 "CMakeLists.txt"
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy"),
             ]
         ),
         .target(
@@ -117,6 +123,9 @@ let package = Package(
                 "Digests/Digests.swift.gyb",
                 "Key Agreement/ECDH.swift.gyb",
                 "Signatures/ECDSA.swift.gyb",
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy"),
             ],
             swiftSettings: swiftSettings
         ),
@@ -131,6 +140,9 @@ let package = Package(
             exclude: [
                 "CMakeLists.txt",
             ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy"),
+            ],
             swiftSettings: swiftSettings
         ),
         .target(
@@ -141,6 +153,9 @@ let package = Package(
             ],
             exclude: [
                 "CMakeLists.txt",
+            ],
+            resources: [
+                .copy("PrivacyInfo.xcprivacy"),
             ]
         ),
         .executableTarget(name: "crypto-shasum", dependencies: ["Crypto"]),

--- a/Sources/CCryptoBoringSSL/PrivacyInfo.xcprivacy
+++ b/Sources/CCryptoBoringSSL/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/CCryptoBoringSSLShims/PrivacyInfo.xcprivacy
+++ b/Sources/CCryptoBoringSSLShims/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/Crypto/PrivacyInfo.xcprivacy
+++ b/Sources/Crypto/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/CryptoBoringWrapper/PrivacyInfo.xcprivacy
+++ b/Sources/CryptoBoringWrapper/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy

--- a/Sources/_CryptoExtras/PrivacyInfo.xcprivacy
+++ b/Sources/_CryptoExtras/PrivacyInfo.xcprivacy
@@ -1,0 +1,1 @@
+../../.PrivacyInfo.xcprivacy


### PR DESCRIPTION
BoringSSL distributions need to be covered by privacy manifest files, so we add one here.

Resolves #225.