### PR TITLE
Fix broken `DataProtocol.hexString` test utility

### DIFF
--- a/Tests/_CryptoExtrasTests/Utils/BytesUtil.swift
+++ b/Tests/_CryptoExtrasTests/Utils/BytesUtil.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import Foundation
+import XCTest
 
 enum ByteHexEncodingErrors: Error {
     case incorrectHexValue
@@ -70,7 +71,7 @@ extension DataProtocol {
                         offset += 1
                     }
                 }
-                count = offset
+                count = offset * 2
             }
             return String(decoding: bytes, as: UTF8.self)
         }
@@ -99,4 +100,10 @@ extension Data {
         }
     }
 
+}
+
+final class BytesUtilTests: XCTestCase {
+    func testHexStringUtils() throws {
+        XCTAssertEqual(try Data(hexString: "deadbeef").hexString, "deadbeef")
+    }
 }


### PR DESCRIPTION
### Motivation:

The test code has utility extensions for converting bytes to and from hex strings. However, the `hexString` computed property only returned half the bytes it should because it uses `Array.init(unsafeUnitializedCapacity:_:)` and set the array count to the number of bytes, rather than double the number of bytes, which is the required number of hexadecimal characters in the resulting string.

### Modifications:

- Return the correct count in array initializer in `DataProtocol.hexString`.
- Add trivial test to roundtrip `Data` through the two hex string utilities.

### Result:

`DataProtocol.hexString: String` now returns a hex string for all the bytes.