### PR TITLE
Fix RSA.Encryption.PublicKey unsafePEMRepresentation incorrect keySizeInBits 

### DIFF
--- a/Sources/_CryptoExtras/RSA/RSA.swift
+++ b/Sources/_CryptoExtras/RSA/RSA.swift
@@ -414,7 +414,7 @@ extension _RSA.Encryption {
         /// - Warning: Key sizes less than 2048 are not recommended and should only be used for compatibility reasons.
         public init(unsafePEMRepresentation pemRepresentation: String) throws {
             self.backing = try BackingPublicKey(pemRepresentation: pemRepresentation)
-            guard self.keySizeInBits >= 2048, self.keySizeInBits % 8 == 0 else { throw CryptoKitError.incorrectParameterSize }
+            guard self.keySizeInBits >= 1024, self.keySizeInBits % 8 == 0 else { throw CryptoKitError.incorrectParameterSize }
         }
 
         /// Construct an RSA public key from a DER representation.


### PR DESCRIPTION
In version 3.4, the `_RSA.Encryption.PublicKey` introduced a set of unsafe APIs to handle cases where `keySizeInBits` is less than 2048. However, in the implementation, the boundary check for `keySizeInBits` in `init(unsafePEMRepresentation:)` was incorrectly set as `self.keySizeInBits >= 2048`. Similar APIs indicate that it should actually be `self.keySizeInBits >= 1024`. This PR attempts to correct this issue.