### PR TITLE
extras: Add meaningful description to BoringSSL errors

### DIFF
--- a/Sources/_CryptoExtras/Util/CryptoKitErrors_boring.swift
+++ b/Sources/_CryptoExtras/Util/CryptoKitErrors_boring.swift
@@ -22,3 +22,28 @@ extension CryptoKitError {
         return .underlyingCoreCryptoError(error: Int32(bitPattern: CCryptoBoringSSL_ERR_get_error()))
     }
 }
+
+extension CryptoKitError {
+    public var description: String {
+        switch self {
+        case .underlyingCoreCryptoError(error: let error):
+            let errorCode = UInt32(bitPattern: error)
+            let lib = String(cString: CCryptoBoringSSL_ERR_lib_error_string(errorCode))
+            let reason = String(cString: CCryptoBoringSSL_ERR_reason_error_string(errorCode))
+            return "lib: \(lib), reason: \(reason), code: \(errorCode)"
+        case .incorrectKeySize: return "incorrectKeySize"
+        case .incorrectParameterSize: return "incorrectParameterSize"
+        case .authenticationFailure: return "authenticationFailure"
+        case .wrapFailure: return "wrapFailure"
+        case .unwrapFailure: return "unwrapFailure"
+        case .invalidParameter: return "invalidParameter"
+        @unknown default: return "unknown"
+        }
+    }
+}
+
+#if hasAttribute(retroactive)
+extension CryptoKitError: @retroactive CustomStringConvertible {}
+#else
+extension CryptoKitError: CustomStringConvertible {}
+#endif


### PR DESCRIPTION
### Motivation

When an error occurs in a BoringSSL call, we typically embed the packed error code in a `CryptoKitError.underlyingCoreCryptoError(error: Int32)`. This packed error code consists of the library and the reason and BoringSSL has functions for unpacking these and getting descriptive messages for them. I often spend my time in a debugger, manually calling these C functions and then looking things up in header files. 

### Modifications

In `_CryptoExtras` (not in `Crypto`) add a (possibly retroactive) conformance to `CustomStringConvertible`. 

### Result

If `_CryptoExtras` is imported, errors will likely be much more informative. For example,

```
error: "underlyingCoreCryptoError(error: 50331755)"  // before

error: "lib: bignum routines, reason: INPUT_NOT_REDUCED, code: 50331755"  // after
```