### PR TITLE
Make HMAC authenticationCode and update inlinable

### DIFF
--- a/Sources/Crypto/Message Authentication Codes/HMAC/HMAC.swift
+++ b/Sources/Crypto/Message Authentication Codes/HMAC/HMAC.swift
@@ -106,6 +106,7 @@ public struct HMAC<H: HashFunction>: MACAlgorithm {
     ///   - key: The symmetric key used to secure the computation.
     ///
     /// - Returns: The message authentication code.
+    @inlinable
     public static func authenticationCode<D: DataProtocol>(for data: D, using key: SymmetricKey) -> MAC {
         var authenticator = Self(key: key)
         authenticator.update(data: data)
@@ -148,6 +149,7 @@ public struct HMAC<H: HashFunction>: MACAlgorithm {
     ///
     /// - Parameters:
     ///   - data: The data for which to compute the authentication code.
+    @inlinable
     public mutating func update<D: DataProtocol>(data: D) {
         data.regions.forEach { (memoryRegion) in
             memoryRegion.withUnsafeBytes({ (bp) in
@@ -175,8 +177,8 @@ public struct HMAC<H: HashFunction>: MACAlgorithm {
     /// Adds data to be authenticated by MAC function. This can be called one or more times to append additional data.
     ///
     /// - Parameters:
-    ///   - data: The data to be authenticated.
-    /// - Throws: Throws if the HMAC has already been finalized.
+    ///   - bufferPointer: A pointer to the data for which to compute the authentication code.
+    @usableFromInline
     mutating func update(bufferPointer: UnsafeRawBufferPointer) {
         innerHasher.update(bufferPointer: bufferPointer)
     }


### PR DESCRIPTION
Making the methods inlinable removes the cost of fetching the type metadata.

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

### Motivation:

As stated in #238, generally, users will only compute a few authentication codes and aren't really concerned by the performance. But sometimes, it may be necessary to compute a lot of authentication codes as fast as possible.

Making `authenticationCode(for:using:)` and `update(data:)` inlinable provides a significant performance gain when `D` is known at compile time without exposing much of the implementation.

### Modifications:

* `authenticationCode(for:using:)` is annotated as inlinable.
* `update(data:)` is annotated as inlinable.
* `update(bufferPointer:)` is annotated as usable from inline.

### Result:

On its own, this change makes computing HMAC authentication codes about 125% faster than before.

<details>
<summary>On my machine (MacBook Pro 14-inch 2021)</summary>

HMAC-MD5: 49.6 seconds → 39.4 seconds
HMAC-SHA1: 43.1 seconds → 33.7 seconds
HMAC-SHA256: 44.6 seconds → 34.1 seconds
HMAC-SHA384: 50.7 seconds → 41.3 seconds
HMAC-SHA512: 50.3 seconds → 41.7 seconds

</details>

<details>
<summary>Test code</summary>

```swift
import Crypto
import Foundation

func testHMAC<H: HashFunction>(_ type: H.Type) {
    let start = Date()
    let iterations = 50_000_000
    let key = SymmetricKey(data: Data())
    var hmac = HMAC<H>(key: key)
    let original = hmac
    
    var digest = hmac.finalize()
    for _ in 1 ..< iterations {
        hmac = original
        digest.withUnsafeBytes { bytes in
            hmac.update(data: bytes)
        }
        digest = hmac.finalize()
    }
    
    let duration = -start.timeIntervalSinceNow
    print("HMAC-\(H.self): \(String(format: "%.1f", duration)) seconds")
}

testHMAC(Crypto.Insecure.MD5.self)
testHMAC(Crypto.Insecure.SHA1.self)
testHMAC(Crypto.SHA256.self)
testHMAC(Crypto.SHA384.self)
testHMAC(Crypto.SHA512.self)
```

</details>