### PR TITLE
build: Revert to using @_implementationOnly for all BoringSSL modules

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -127,7 +127,7 @@ let package = Package(
             resources: [
                 .copy("PrivacyInfo.xcprivacy"),
             ],
-            swiftSettings: swiftSettings
+            swiftSettings: swiftSettings + [.define("MODULE_IS_CRYPTO")]
         ),
         .target(
             name: "_CryptoExtras",
@@ -168,7 +168,6 @@ let package = Package(
             swiftSettings: swiftSettings
         ),
         .testTarget(name: "_CryptoExtrasTests", dependencies: ["_CryptoExtras"]),
-        .testTarget(name: "CryptoBoringWrapperTests", dependencies: ["CryptoBoringWrapper"]),
     ],
     cxxLanguageStandard: .cxx11
 )

--- a/Sources/Crypto/AEADs/AES/GCM/BoringSSL/AES-GCM_boring.swift
+++ b/Sources/Crypto/AEADs/AES/GCM/BoringSSL/AES-GCM_boring.swift
@@ -14,8 +14,8 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import CCryptoBoringSSL
-import CryptoBoringWrapper
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CryptoBoringWrapper
 import Foundation
 
 enum OpenSSLAESGCMImpl {

--- a/Sources/Crypto/AEADs/ChachaPoly/BoringSSL/ChaChaPoly_boring.swift
+++ b/Sources/Crypto/AEADs/ChachaPoly/BoringSSL/ChaChaPoly_boring.swift
@@ -14,9 +14,9 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import CCryptoBoringSSL
-import CCryptoBoringSSLShims
-import CryptoBoringWrapper
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
+@_implementationOnly import CryptoBoringWrapper
 import Foundation
 
 extension BoringSSLAEAD {

--- a/Sources/Crypto/CMakeLists.txt
+++ b/Sources/Crypto/CMakeLists.txt
@@ -89,6 +89,8 @@ add_library(Crypto
   "Util/BoringSSL/CryptoKitErrors_boring.swift"
   "Util/BoringSSL/RNG_boring.swift"
   "Util/BoringSSL/SafeCompare_boring.swift"
+  "Util/BoringSSL/Shared/ArbitraryPrecisionInteger_boring.swift"
+  "Util/BoringSSL/Shared/FiniteFieldArithmeticContext_boring.swift"
   "Util/BoringSSL/Zeroization_boring.swift"
   "Util/PrettyBytes.swift"
   "Util/SafeCompare.swift"

--- a/Sources/Crypto/Digests/BoringSSL/Digest_boring.swift
+++ b/Sources/Crypto/Digests/BoringSSL/Digest_boring.swift
@@ -14,7 +14,7 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSL
 
 protocol HashFunctionImplementationDetails: HashFunction where Digest: DigestPrivate {}
 

--- a/Sources/Crypto/Key Agreement/BoringSSL/ECDH_boring.swift
+++ b/Sources/Crypto/Key Agreement/BoringSSL/ECDH_boring.swift
@@ -14,7 +14,7 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSL
 
 extension P256.KeyAgreement.PrivateKey {
     internal func openSSLSharedSecretFromKeyAgreement(with publicKeyShare: P256.KeyAgreement.PublicKey) throws -> SharedSecret {

--- a/Sources/Crypto/Key Wrapping/BoringSSL/AESWrap_boring.swift
+++ b/Sources/Crypto/Key Wrapping/BoringSSL/AESWrap_boring.swift
@@ -14,7 +14,7 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSL
 import Foundation
 
 enum BoringSSLAESWRAPImpl {

--- a/Sources/Crypto/Keys/EC/BoringSSL/Ed25519_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/Ed25519_boring.swift
@@ -14,8 +14,8 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import CCryptoBoringSSL
-import CCryptoBoringSSLShims
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
 import Foundation
 
 // For signing and verifying, we use BoringSSL's Ed25519, not the X25519 stuff.

--- a/Sources/Crypto/Keys/EC/BoringSSL/EllipticCurvePoint_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/EllipticCurvePoint_boring.swift
@@ -14,8 +14,7 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import CCryptoBoringSSL
-import CryptoBoringWrapper
+@_implementationOnly import CCryptoBoringSSL
 
 /// A wrapper around BoringSSL's EC_POINT with some lifetime management.
 @usableFromInline

--- a/Sources/Crypto/Keys/EC/BoringSSL/EllipticCurve_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/EllipticCurve_boring.swift
@@ -14,8 +14,7 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import CCryptoBoringSSL
-import CryptoBoringWrapper
+@_implementationOnly import CCryptoBoringSSL
 
 /// A wrapper around BoringSSL's EC_GROUP object that handles reference counting and
 /// liveness.

--- a/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
@@ -14,9 +14,8 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import CCryptoBoringSSL
-import CCryptoBoringSSLShims
-import CryptoBoringWrapper
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
 import Foundation
 
 @usableFromInline

--- a/Sources/Crypto/Keys/EC/BoringSSL/X25519Keys_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/X25519Keys_boring.swift
@@ -14,8 +14,8 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import CCryptoBoringSSL
-import CCryptoBoringSSLShims
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
 import Foundation
 
 extension Curve25519.KeyAgreement {

--- a/Sources/Crypto/Signatures/BoringSSL/ECDSASignature_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/ECDSASignature_boring.swift
@@ -14,9 +14,8 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import CCryptoBoringSSL
-import CCryptoBoringSSLShims
-import CryptoBoringWrapper
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
 import Foundation
 
 /// A wrapper around BoringSSL's ECDSA_SIG with some lifetime management.

--- a/Sources/Crypto/Signatures/BoringSSL/ECDSA_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/ECDSA_boring.swift
@@ -14,7 +14,7 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSL
 import Foundation
 
 extension Data {

--- a/Sources/Crypto/Signatures/BoringSSL/EdDSA_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/EdDSA_boring.swift
@@ -14,8 +14,8 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import CCryptoBoringSSL
-import CCryptoBoringSSLShims
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
 import Foundation
 
 extension Curve25519.Signing.PublicKey {

--- a/Sources/Crypto/Util/BoringSSL/CryptoKitErrors_boring.swift
+++ b/Sources/Crypto/Util/BoringSSL/CryptoKitErrors_boring.swift
@@ -14,7 +14,7 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
-import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSL
 
 extension CryptoKitError {
     /// A helper function that packs the value of `ERR_get_error` into the internal error field.

--- a/Sources/Crypto/Util/BoringSSL/Zeroization_boring.swift
+++ b/Sources/Crypto/Util/BoringSSL/Zeroization_boring.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 #if !canImport(Darwin)
-import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSL
 
 typealias errno_t = CInt
 

--- a/Sources/CryptoBoringWrapper/AEAD/BoringSSLAEAD.swift
+++ b/Sources/CryptoBoringWrapper/AEAD/BoringSSLAEAD.swift
@@ -12,8 +12,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-import CCryptoBoringSSL
-import CCryptoBoringSSLShims
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
 import Foundation
 
 /// An abstraction over a BoringSSL AEAD

--- a/Sources/CryptoBoringWrapper/CMakeLists.txt
+++ b/Sources/CryptoBoringWrapper/CMakeLists.txt
@@ -14,9 +14,7 @@
 
 add_library(CryptoBoringWrapper STATIC
   "AEAD/BoringSSLAEAD.swift"
-  "ArbitraryPrecisionInteger.swift"
-  "CryptoKitErrors_boring.swift"
-  "FiniteFieldArithmeticContext.swift")
+  "CryptoKitErrors_boring.swift")
 
 target_include_directories(CryptoBoringWrapper PUBLIC
   $<TARGET_PROPERTY:CCryptoBoringSSL,INCLUDE_DIRECTORIES>

--- a/Sources/CryptoBoringWrapper/CryptoKitErrors_boring.swift
+++ b/Sources/CryptoBoringWrapper/CryptoKitErrors_boring.swift
@@ -12,11 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSL
 
 public enum CryptoBoringWrapperError: Error {
     case underlyingCoreCryptoError(error: Int32)
-    case incorrectParameterSize
 }
 
 extension CryptoBoringWrapperError {

--- a/Sources/_CryptoExtras/AES/AES_GCM_SIV.swift
+++ b/Sources/_CryptoExtras/AES/AES_GCM_SIV.swift
@@ -13,9 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
-import CCryptoBoringSSL
-import CCryptoBoringSSLShims
-import CryptoBoringWrapper
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
+@_implementationOnly import CryptoBoringWrapper
 #if canImport(Darwin) || swift(>=5.9.1)
 import Foundation
 #else

--- a/Sources/_CryptoExtras/AES/Block Function.swift
+++ b/Sources/_CryptoExtras/AES/Block Function.swift
@@ -13,9 +13,9 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
-import CCryptoBoringSSL
-import CCryptoBoringSSLShims
-import CryptoBoringWrapper
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
+@_implementationOnly import CryptoBoringWrapper
 import Foundation
 
 extension AES {

--- a/Sources/_CryptoExtras/AES/BoringSSL/AES_CTR_boring.swift
+++ b/Sources/_CryptoExtras/AES/BoringSSL/AES_CTR_boring.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSL
 import Crypto
 import Foundation
 

--- a/Sources/_CryptoExtras/AES/BoringSSL/AES_GCM_SIV_boring.swift
+++ b/Sources/_CryptoExtras/AES/BoringSSL/AES_GCM_SIV_boring.swift
@@ -14,10 +14,10 @@
 
 // This is a copy ChaChaPoly_boring just with a different set aes algos
 
-import CCryptoBoringSSL
-import CCryptoBoringSSLShims
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
 import Crypto
-import CryptoBoringWrapper
+@_implementationOnly import CryptoBoringWrapper
 import Foundation
 
 extension BoringSSLAEAD {

--- a/Sources/_CryptoExtras/CMakeLists.txt
+++ b/Sources/_CryptoExtras/CMakeLists.txt
@@ -24,7 +24,9 @@ add_library(_CryptoExtras
   "Util/DigestType.swift"
   "Util/Error.swift"
   "Util/PEMDocument.swift"
-  "Util/RandomBytes.swift")
+  "Util/RandomBytes.swift"
+  "Util/Shared/ArbitraryPrecisionInteger_boring.swift"
+  "Util/Shared/FiniteFieldArithmeticContext_boring.swift")
 
 target_include_directories(_CryptoExtras PRIVATE
   $<TARGET_PROPERTY:CCryptoBoringSSL,INCLUDE_DIRECTORIES>

--- a/Sources/_CryptoExtras/ChaCha20CTR/BoringSSL/ChaCha20CTR_boring.swift
+++ b/Sources/_CryptoExtras/ChaCha20CTR/BoringSSL/ChaCha20CTR_boring.swift
@@ -12,10 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import CCryptoBoringSSL
-import CCryptoBoringSSLShims
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
 import Crypto
-import CryptoBoringWrapper
+@_implementationOnly import CryptoBoringWrapper
 import Foundation
 
 enum OpenSSLChaCha20CTRImpl {

--- a/Sources/_CryptoExtras/ChaCha20CTR/ChaCha20CTR.swift
+++ b/Sources/_CryptoExtras/ChaCha20CTR/ChaCha20CTR.swift
@@ -12,10 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-import CCryptoBoringSSL
-import CCryptoBoringSSLShims
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
 import Crypto
-import CryptoBoringWrapper
+@_implementationOnly import CryptoBoringWrapper
 #if canImport(Darwin) || swift(>=5.9.1)
 import Foundation
 #else

--- a/Sources/_CryptoExtras/RSA/RSA_boring.swift
+++ b/Sources/_CryptoExtras/RSA/RSA_boring.swift
@@ -15,9 +15,8 @@ import Foundation
 import Crypto
 
 // NOTE: This file is unconditionally compiled because RSABSSA is implemented using BoringSSL on all platforms.
-import CCryptoBoringSSL
-import CCryptoBoringSSLShims
-import CryptoBoringWrapper
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
 
 internal struct BoringSSLRSAPublicKey: Sendable {
     private var backing: Backing

--- a/Sources/_CryptoExtras/Util/BoringSSLHelpers.swift
+++ b/Sources/_CryptoExtras/Util/BoringSSLHelpers.swift
@@ -13,9 +13,8 @@
 //===----------------------------------------------------------------------===//
 
 // NOTE: This file is unconditionally compiled because RSABSSA is implemented using BoringSSL on all platforms.
-import CCryptoBoringSSL
-import CCryptoBoringSSLShims
-import CryptoBoringWrapper
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
 import Foundation
 import Crypto
 

--- a/Sources/_CryptoExtras/Util/CryptoKitErrors_boring.swift
+++ b/Sources/_CryptoExtras/Util/CryptoKitErrors_boring.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSL
 import Crypto
 
 extension CryptoKitError {

--- a/Sources/_CryptoExtras/Util/DigestType.swift
+++ b/Sources/_CryptoExtras/Util/DigestType.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 // NOTE: This file is unconditionally compiled because RSABSSA is implemented using BoringSSL on all platforms.
-import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSL
 import Crypto
 
 struct DigestType {

--- a/Sources/_CryptoExtras/Util/Shared
+++ b/Sources/_CryptoExtras/Util/Shared
@@ -1,0 +1,1 @@
+../../Crypto/Util/BoringSSL/Shared

--- a/Tests/CryptoTests/BoringSSL/ArbitraryPrecisionIntegerTests.swift
+++ b/Tests/CryptoTests/BoringSSL/ArbitraryPrecisionIntegerTests.swift
@@ -11,7 +11,9 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-@testable import CryptoBoringWrapper
+#if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
+#else
+@testable import Crypto
 import XCTest
 
 final class ArbitraryPrecisionIntegerTests: XCTestCase {
@@ -41,7 +43,7 @@ final class ArbitraryPrecisionIntegerTests: XCTestCase {
     func testPositiveSquareRoot() {
         XCTAssertNoThrow(XCTAssertEqual(try ArbitraryPrecisionInteger(144).positiveSquareRoot(), 12))
         XCTAssertThrowsError(try ArbitraryPrecisionInteger(101).positiveSquareRoot()) { error in
-            guard case .some(.underlyingCoreCryptoError) = error as? CryptoBoringWrapperError else {
+            guard case .some(.underlyingCoreCryptoError) = error as? CryptoKitError else {
                 XCTFail("Unexpected error: \(error)")
                 return
             }
@@ -148,8 +150,8 @@ final class ArbitraryPrecisionIntegerTests: XCTestCase {
         XCTAssertEqual(try ArbitraryPrecisionInteger.random(inclusiveMin: 4, exclusiveMax: 5), 4)
 
         var previousRandom = ArbitraryPrecisionInteger()
-        for _ in 1...1_000 {
-            let exclusiveMax = try ArbitraryPrecisionInteger(bytes: Data(repeating: UInt8.max, count: 2048/8))
+        for _ in 1 ... 1000 {
+            let exclusiveMax = try ArbitraryPrecisionInteger(bytes: Data(repeating: UInt8.max, count: 2048 / 8))
             let random = try ArbitraryPrecisionInteger.random(inclusiveMin: 42, exclusiveMax: exclusiveMax)
             XCTAssert(random >= ArbitraryPrecisionInteger(42))
             XCTAssert(random < exclusiveMax)
@@ -166,3 +168,4 @@ final class ArbitraryPrecisionIntegerTests: XCTestCase {
         }
     }
 }
+#endif // CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Tests/CryptoTests/BoringSSL/FiniteFieldArithmeticTests.swift
+++ b/Tests/CryptoTests/BoringSSL/FiniteFieldArithmeticTests.swift
@@ -11,9 +11,10 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-@testable import CryptoBoringWrapper
+#if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
+#else
+@testable import Crypto
 import XCTest
-
 
 final class FiniteFieldArithmeticTests: XCTestCase {
     func testResidue() throws {
@@ -85,7 +86,7 @@ final class FiniteFieldArithmeticTests: XCTestCase {
         XCTAssertEqual(try ff.inverse(4), 1)
         XCTAssertEqual(try ff.inverse(5), 2)
         XCTAssertEqual(try ff.inverse(6), nil)
-        for i: Int64 in 1...100 {
+        for i: Int64 in 1 ... 100 {
             let integer = ArbitraryPrecisionInteger(integerLiteral: i)
             let inverse = try ff.inverse(integer)
             if i % 3 == 0 {
@@ -104,8 +105,8 @@ final class FiniteFieldArithmeticTests: XCTestCase {
             (2, 0, 1), (2, 1, 2), (2, 2, 4), (2, 3, 1),
             (3, 0, 1), (3, 1, 3), (3, 2, 2), (3, 3, 6),
             (5, 0, 1), (5, 1, 5), (5, 2, 4), (5, 3, 6),
-            (7, 0, 1), (7, 1, 0), (7, 2, 0), (7, 3, 0),  // x = m
-            (8, 0, 1), (8, 1, 1), (8, 2, 1), (8, 3, 1),  // x > m
+            (7, 0, 1), (7, 1, 0), (7, 2, 0), (7, 3, 0), // x = m
+            (8, 0, 1), (8, 1, 1), (8, 2, 1), (8, 3, 1), // x > m
         ] {
             let message = "\(x)^\(p) (mod \(m))"
             XCTAssertEqual(try ff.pow(x, p), expectedResult, message)
@@ -114,8 +115,8 @@ final class FiniteFieldArithmeticTests: XCTestCase {
                 XCTAssertEqual(try ff.pow(secret: x, secret: p), expectedResult, message)
             } else {
                 XCTAssertThrowsError(try ff.pow(secret: x, p), message) { error in
-                    switch (error as? CryptoBoringWrapperError) {
-                    case .incorrectParameterSize: break  // OK
+                    switch error as? CryptoKitError {
+                    case .incorrectParameterSize: break // OK
                     default: XCTFail("Unexpected error: \(error)")
                     }
                 }
@@ -123,3 +124,4 @@ final class FiniteFieldArithmeticTests: XCTestCase {
         }
     }
 }
+#endif // CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Tests/CryptoTests/ECDH/BoringSSL/ASN1.swift
+++ b/Tests/CryptoTests/ECDH/BoringSSL/ASN1.swift
@@ -20,7 +20,7 @@ import XCTest
 #if !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @testable import CryptoKit
 #else
-import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSL
 @testable import Crypto
 #endif
 

--- a/Tests/CryptoTests/ECDH/BoringSSL/secpECDH_Runner_boring.swift
+++ b/Tests/CryptoTests/ECDH/BoringSSL/secpECDH_Runner_boring.swift
@@ -20,7 +20,7 @@ import XCTest
 #if !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @testable import CryptoKit
 #else
-import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSL
 @testable import Crypto
 #endif
 

--- a/scripts/update_cmakelists.sh
+++ b/scripts/update_cmakelists.sh
@@ -55,7 +55,7 @@ function update_cmakelists_source() {
     fi
 
     # Wrap quotes around each filename since it might contain spaces
-    srcs=$($find "${src_root}" -type f \( "${exts_arg[@]}" \) -printf '  "%P"\n' | LC_ALL=POSIX sort)
+    srcs=$($find -L "${src_root}" -type f \( "${exts_arg[@]}" \) -printf '  "%P"\n' | LC_ALL=POSIX sort)
     echo "$srcs"
 
     # Update list of source files in CMakeLists.txt


### PR DESCRIPTION
## Motivation

The 3.5.0 release has been causing some compilation failures for downstream projects that depend on other packages that also vendor in a copy of BoringSSL.

This is likely because we stopped using `@_implementationOnly` when importing our internal `CCryptoBoringSSL` target, which we did because we moved the `ArbitraryPrecisionInteger` and `FiniteFieldArithmeticContext` types, that were previously internal to `Crypto`, into `CryptoBoringWrapper` so they could be used in `_CryptoExtras` to implement RSABSSA.

While Swift Crypto goes to some lengths to avoid clashing with other vendor'd copies of BoringSSL by prefixing its symbols, it clearly isn't enough and we've heard reports of downstream projects failing to build. 

We have shipped one patch release, 3.5.1, with a fix to the vendor script that has resolved a subset of adopters, it hasn't resolved everything.

At this stage, I'd like to propose that we mitigate the impact of the issue and give us time to revisit how we vendor and import the C module, rather than us chasing a long tail of reported issues downstream.

## Modifications

- Moved `ArbitraryPrecisionInteger` and `FiniteFieldArithmeticContext` back into `Crypto` as `internal` types, but bringing along the additional operations that were added as part of 3.5.0.
- Revert to using `@_implementationOnly imports` of `CCryptoBoringSSL` and `CCryptoBoringSSLShims` everywhere.
- Share these two files with `_CryptoExtras` by symlink.
- Update `CMakeLists.txt` to account for new location of files in `Crypto`.
- Update `CMakeLists.txt` to account for new symlinks in `_CryptoExtras`.
- Update CMake script to accommodate use of symlinks.

## Result

Greater confidence that we won't have broken downstream projects due to BoringSSL symbol clashes.