### PR TITLE
Making ivBytes accessible for _CBC.IV

### DIFF
--- a/Sources/_CryptoExtras/AES/AES_CBC.swift
+++ b/Sources/_CryptoExtras/AES/AES_CBC.swift
@@ -145,7 +145,7 @@ extension AES._CBC {
     /// An initialization vector.
     public struct IV: Sendable {
         // AES CBC uses a 128-bit IV.
-        var ivBytes: (
+        public var ivBytes: (
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
         )


### PR DESCRIPTION
### Checklist
- [ ] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

### Motivation:

Right now, we're using CommonCrypto and would like to switch to Crypto instead.  However, the requirement we need is that we send the data for IV to the server for them to verify the signature we are sending them.  Similarly, they send us their IV and we verify the signature of other data. (Which is supported currently)

### Modifications:

By making `ivBytes` public, we can access the randomly generated salt for our cipher.

### Result:

I can replace CommonCrypto code in my repo with Crypto instead :)