### PR TITLE
Refactor and adopt package access to remove symlinked files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ endif()
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
 set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
+set(SWIFT_CRYPTO_COMPILE_OPTIONS
+    -package-name com.apple.swift-crypto
+)
+
 option(BUILD_SHARED_LIBS "Build shared libraries by default" YES)
 
 if(BUILD_SHARED_LIBS)

--- a/Package.swift
+++ b/Package.swift
@@ -135,7 +135,7 @@ let package = Package(
                 "Signatures/ECDSA.swift.gyb",
             ],
             resources: privacyManifestResource,
-            swiftSettings: swiftSettings + [.define("MODULE_IS_CRYPTO")]
+            swiftSettings: swiftSettings
         ),
         .target(
             name: "_CryptoExtras",
@@ -173,6 +173,7 @@ let package = Package(
             swiftSettings: swiftSettings
         ),
         .testTarget(name: "_CryptoExtrasTests", dependencies: ["_CryptoExtras"]),
+        .testTarget(name: "CryptoBoringWrapperTests", dependencies: ["CryptoBoringWrapper"]),
     ],
     cxxLanguageStandard: .cxx11
 )

--- a/Sources/Crypto/AEADs/AES/GCM/BoringSSL/AES-GCM_boring.swift
+++ b/Sources/Crypto/AEADs/AES/GCM/BoringSSL/AES-GCM_boring.swift
@@ -15,7 +15,7 @@
 @_exported import CryptoKit
 #else
 @_implementationOnly import CCryptoBoringSSL
-@_implementationOnly import CryptoBoringWrapper
+import CryptoBoringWrapper
 import Foundation
 
 enum OpenSSLAESGCMImpl {

--- a/Sources/Crypto/AEADs/ChachaPoly/BoringSSL/ChaChaPoly_boring.swift
+++ b/Sources/Crypto/AEADs/ChachaPoly/BoringSSL/ChaChaPoly_boring.swift
@@ -16,7 +16,7 @@
 #else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
-@_implementationOnly import CryptoBoringWrapper
+import CryptoBoringWrapper
 import Foundation
 
 extension BoringSSLAEAD {

--- a/Sources/Crypto/CMakeLists.txt
+++ b/Sources/Crypto/CMakeLists.txt
@@ -89,8 +89,6 @@ add_library(Crypto
   "Util/BoringSSL/CryptoKitErrors_boring.swift"
   "Util/BoringSSL/RNG_boring.swift"
   "Util/BoringSSL/SafeCompare_boring.swift"
-  "Util/BoringSSL/Shared/ArbitraryPrecisionInteger_boring.swift"
-  "Util/BoringSSL/Shared/FiniteFieldArithmeticContext_boring.swift"
   "Util/BoringSSL/Zeroization_boring.swift"
   "Util/PrettyBytes.swift"
   "Util/SafeCompare.swift"
@@ -115,6 +113,7 @@ target_link_libraries(Crypto PUBLIC
   CCryptoBoringSSL
   CCryptoBoringSSLShims
   CryptoBoringWrapper)
+target_compile_options(Crypto PRIVATE ${SWIFT_CRYPTO_COMPILE_OPTIONS})
 set_target_properties(Crypto PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})
 

--- a/Sources/Crypto/Keys/EC/BoringSSL/EllipticCurvePoint_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/EllipticCurvePoint_boring.swift
@@ -15,6 +15,7 @@
 @_exported import CryptoKit
 #else
 @_implementationOnly import CCryptoBoringSSL
+import CryptoBoringWrapper
 
 /// A wrapper around BoringSSL's EC_POINT with some lifetime management.
 @usableFromInline

--- a/Sources/Crypto/Keys/EC/BoringSSL/EllipticCurve_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/EllipticCurve_boring.swift
@@ -15,6 +15,7 @@
 @_exported import CryptoKit
 #else
 @_implementationOnly import CCryptoBoringSSL
+import CryptoBoringWrapper
 
 /// A wrapper around BoringSSL's EC_GROUP object that handles reference counting and
 /// liveness.

--- a/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
@@ -16,6 +16,7 @@
 #else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+import CryptoBoringWrapper
 import Foundation
 
 @usableFromInline

--- a/Sources/Crypto/Signatures/BoringSSL/ECDSASignature_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/ECDSASignature_boring.swift
@@ -16,6 +16,7 @@
 #else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+import CryptoBoringWrapper
 import Foundation
 
 /// A wrapper around BoringSSL's ECDSA_SIG with some lifetime management.

--- a/Sources/CryptoBoringWrapper/CMakeLists.txt
+++ b/Sources/CryptoBoringWrapper/CMakeLists.txt
@@ -14,7 +14,9 @@
 
 add_library(CryptoBoringWrapper STATIC
   "AEAD/BoringSSLAEAD.swift"
-  "CryptoKitErrors_boring.swift")
+  "CryptoKitErrors_boring.swift"
+  "Util/ArbitraryPrecisionInteger_boring.swift"
+  "Util/FiniteFieldArithmeticContext_boring.swift")
 
 target_include_directories(CryptoBoringWrapper PUBLIC
   $<TARGET_PROPERTY:CCryptoBoringSSL,INCLUDE_DIRECTORIES>
@@ -24,6 +26,8 @@ target_link_libraries(CryptoBoringWrapper PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
   CCryptoBoringSSL
   CCryptoBoringSSLShims)
+
+target_compile_options(CryptoBoringWrapper PRIVATE ${SWIFT_CRYPTO_COMPILE_OPTIONS})
 
 set_target_properties(CryptoBoringWrapper PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES ${CMAKE_Swift_MODULE_DIRECTORY})

--- a/Sources/CryptoBoringWrapper/CryptoKitErrors_boring.swift
+++ b/Sources/CryptoBoringWrapper/CryptoKitErrors_boring.swift
@@ -15,13 +15,27 @@
 @_implementationOnly import CCryptoBoringSSL
 
 public enum CryptoBoringWrapperError: Error {
+    /// The key size is incorrect.
+    case incorrectKeySize
+    /// The parameter size is incorrect.
+    case incorrectParameterSize
+    /// The authentication tag or signature is incorrect.
+    case authenticationFailure
+    /// The underlying corecrypto library is unable to complete the requested
+    /// action.
     case underlyingCoreCryptoError(error: Int32)
+    /// The framework can't wrap the specified key.
+    case wrapFailure
+    /// The framework can't unwrap the specified key.
+    case unwrapFailure
+    /// The parameter is invalid.
+    case invalidParameter
 }
 
 extension CryptoBoringWrapperError {
     /// A helper function that packs the value of `ERR_get_error` into the internal error field.
     @usableFromInline
-    static func internalBoringSSLError() -> CryptoBoringWrapperError {
+    package static func internalBoringSSLError() -> CryptoBoringWrapperError {
         return .underlyingCoreCryptoError(error: Int32(bitPattern: CCryptoBoringSSL_ERR_get_error()))
     }
 }

--- a/Sources/CryptoBoringWrapper/Util/ArbitraryPrecisionInteger_boring.swift
+++ b/Sources/CryptoBoringWrapper/Util/ArbitraryPrecisionInteger_boring.swift
@@ -11,38 +11,35 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if MODULE_IS_CRYPTO && CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
+#if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 import Foundation
-#if !MODULE_IS_CRYPTO
-import enum Crypto.CryptoKitError
-#endif
 
 /// A wrapper around the OpenSSL BIGNUM object that is appropriately lifetime managed,
 /// and that provides better Swift types for this object.
 @usableFromInline
-struct ArbitraryPrecisionInteger {
+package struct ArbitraryPrecisionInteger {
     private var _backing: BackingStorage
 
     @usableFromInline
-    init() {
+    package init() {
         self._backing = BackingStorage()
     }
 
-    init(copying original: UnsafePointer<BIGNUM>) throws {
+    package init(copying original: UnsafePointer<BIGNUM>) throws {
         self._backing = try BackingStorage(copying: original)
     }
 
     @usableFromInline
-    init(_ original: ArbitraryPrecisionInteger) throws {
+    package init(_ original: ArbitraryPrecisionInteger) throws {
         self._backing = try BackingStorage(copying: original._backing)
     }
 
     @usableFromInline
-    init(integerLiteral value: Int64) {
+    package init(integerLiteral value: Int64) {
         self._backing = BackingStorage(value)
     }
 }
@@ -50,7 +47,7 @@ struct ArbitraryPrecisionInteger {
 // MARK: - BackingStorage
 
 extension ArbitraryPrecisionInteger {
-    final class BackingStorage {
+    fileprivate final class BackingStorage {
         private var _backing: BIGNUM
 
         init() {
@@ -61,7 +58,7 @@ extension ArbitraryPrecisionInteger {
         init(copying original: UnsafePointer<BIGNUM>) throws {
             self._backing = BIGNUM()
             guard CCryptoBoringSSL_BN_copy(&self._backing, original) != nil else {
-                throw CryptoKitError.internalBoringSSLError()
+                throw CryptoBoringWrapperError.internalBoringSSLError()
             }
         }
 
@@ -70,7 +67,7 @@ extension ArbitraryPrecisionInteger {
 
             try original.withUnsafeMutableBignumPointer { bnPtr in
                 guard CCryptoBoringSSL_BN_copy(&self._backing, bnPtr) != nil else {
-                    throw CryptoKitError.internalBoringSSLError()
+                    throw CryptoBoringWrapperError.internalBoringSSLError()
                 }
             }
         }
@@ -95,7 +92,7 @@ extension ArbitraryPrecisionInteger {
 
 extension ArbitraryPrecisionInteger {
     @usableFromInline
-    init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
+    package init<Bytes: ContiguousBytes>(bytes: Bytes) throws {
         self._backing = try BackingStorage(bytes: bytes)
     }
 
@@ -103,7 +100,7 @@ extension ArbitraryPrecisionInteger {
     ///
     /// - Parameter hexString: Hex byte string (big-endian, no `0x` prefix, may start with `-` for a negative number).
     @usableFromInline
-    init(hexString: String) throws {
+    package init(hexString: String) throws {
         self._backing = try BackingStorage(hexString: hexString)
     }
 }
@@ -116,7 +113,7 @@ extension ArbitraryPrecisionInteger.BackingStorage {
             CCryptoBoringSSLShims_BN_bin2bn(bytesPointer.baseAddress, bytesPointer.count, &self._backing)
         }
         guard rc != nil else {
-            throw CryptoKitError.internalBoringSSLError()
+            throw CryptoBoringWrapperError.internalBoringSSLError()
         }
     }
 
@@ -130,7 +127,7 @@ extension ArbitraryPrecisionInteger.BackingStorage {
                 try withUnsafeMutablePointer(to: &backingPtr) { backingPtrPtr in
                     /// `BN_hex2bin` returns the number of bytes of `in` processed or zero on error.
                     guard CCryptoBoringSSL_BN_hex2bn(backingPtrPtr, hexStringPtr) == hexString.count else {
-                        throw CryptoKitError.incorrectParameterSize
+                        throw CryptoBoringWrapperError.incorrectParameterSize
                     }
                 }
             }
@@ -141,11 +138,11 @@ extension ArbitraryPrecisionInteger.BackingStorage {
 // MARK: - Pointer helpers
 
 extension ArbitraryPrecisionInteger {
-    func withUnsafeBignumPointer<T>(_ body: (UnsafePointer<BIGNUM>) throws -> T) rethrows -> T {
+    package func withUnsafeBignumPointer<T>(_ body: (UnsafePointer<BIGNUM>) throws -> T) rethrows -> T {
         try self._backing.withUnsafeBignumPointer(body)
     }
 
-    mutating func withUnsafeMutableBignumPointer<T>(_ body: (UnsafeMutablePointer<BIGNUM>) throws -> T) rethrows -> T {
+    package mutating func withUnsafeMutableBignumPointer<T>(_ body: (UnsafeMutablePointer<BIGNUM>) throws -> T) rethrows -> T {
         if !isKnownUniquelyReferenced(&self._backing) {
             // Failing to CoW is a fatal error here.
             self._backing = try! BackingStorage(copying: self._backing)
@@ -184,7 +181,7 @@ extension ArbitraryPrecisionInteger {
     }
 
     @usableFromInline
-    func squared() -> ArbitraryPrecisionInteger {
+    package func squared() -> ArbitraryPrecisionInteger {
         var result = ArbitraryPrecisionInteger()
         let rc = result.withUnsafeMutableBignumPointer { resultPtr in
             self.withUnsafeBignumPointer { selfPtr in
@@ -198,7 +195,7 @@ extension ArbitraryPrecisionInteger {
     }
 
     @usableFromInline
-    func positiveSquareRoot() throws -> ArbitraryPrecisionInteger {
+    package func positiveSquareRoot() throws -> ArbitraryPrecisionInteger {
         var result = ArbitraryPrecisionInteger()
         let rc = result.withUnsafeMutableBignumPointer { resultPtr in
             self.withUnsafeBignumPointer { selfPtr in
@@ -209,13 +206,13 @@ extension ArbitraryPrecisionInteger {
         }
 
         guard rc == 1 else {
-            throw CryptoKitError.internalBoringSSLError()
+            throw CryptoBoringWrapperError.internalBoringSSLError()
         }
         return result
     }
 
     @usableFromInline
-    var byteCount: Int {
+    package var byteCount: Int {
         self._backing.withUnsafeBignumPointer {
             Int(CCryptoBoringSSL_BN_num_bytes($0))
         }
@@ -238,7 +235,7 @@ extension ArbitraryPrecisionInteger {
 
 extension ArbitraryPrecisionInteger: Equatable {
     @inlinable
-    static func == (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> Bool {
+    package static func == (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> Bool {
         self._compare(lhs: lhs, rhs: rhs) == 0
     }
 }
@@ -247,22 +244,22 @@ extension ArbitraryPrecisionInteger: Equatable {
 
 extension ArbitraryPrecisionInteger: Comparable {
     @inlinable
-    static func < (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> Bool {
+    package static func < (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> Bool {
         self._compare(lhs: lhs, rhs: rhs) < 0
     }
 
     @inlinable
-    static func <= (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> Bool {
+    package static func <= (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> Bool {
         self._compare(lhs: lhs, rhs: rhs) <= 0
     }
 
     @inlinable
-    static func > (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> Bool {
+    package static func > (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> Bool {
         self._compare(lhs: lhs, rhs: rhs) > 0
     }
 
     @inlinable
-    static func >= (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> Bool {
+    package static func >= (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> Bool {
         self._compare(lhs: lhs, rhs: rhs) >= 0
     }
 }
@@ -275,12 +272,12 @@ extension ArbitraryPrecisionInteger: ExpressibleByIntegerLiteral {}
 
 extension ArbitraryPrecisionInteger: AdditiveArithmetic {
     @inlinable
-    static var zero: ArbitraryPrecisionInteger {
+    package static var zero: ArbitraryPrecisionInteger {
         0
     }
 
     @usableFromInline
-    static func + (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> ArbitraryPrecisionInteger {
+    package static func + (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> ArbitraryPrecisionInteger {
         var result = ArbitraryPrecisionInteger()
 
         let rc = result.withUnsafeMutableBignumPointer { resultPtr in
@@ -296,7 +293,7 @@ extension ArbitraryPrecisionInteger: AdditiveArithmetic {
     }
 
     @usableFromInline
-    static func += (lhs: inout ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) {
+    package static func += (lhs: inout ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) {
         let rc = lhs.withUnsafeMutableBignumPointer { lhsPtr in
             rhs.withUnsafeBignumPointer { rhsPtr in
                 CCryptoBoringSSL_BN_add(lhsPtr, lhsPtr, rhsPtr)
@@ -306,7 +303,7 @@ extension ArbitraryPrecisionInteger: AdditiveArithmetic {
     }
 
     @usableFromInline
-    static func - (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> ArbitraryPrecisionInteger {
+    package static func - (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> ArbitraryPrecisionInteger {
         var result = ArbitraryPrecisionInteger()
 
         let rc = result.withUnsafeMutableBignumPointer { resultPtr in
@@ -322,7 +319,7 @@ extension ArbitraryPrecisionInteger: AdditiveArithmetic {
     }
 
     @usableFromInline
-    static func -= (lhs: inout ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) {
+    package static func -= (lhs: inout ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) {
         let rc = lhs.withUnsafeMutableBignumPointer { lhsPtr in
             rhs.withUnsafeBignumPointer { rhsPtr in
                 CCryptoBoringSSL_BN_sub(lhsPtr, lhsPtr, rhsPtr)
@@ -336,10 +333,10 @@ extension ArbitraryPrecisionInteger: AdditiveArithmetic {
 
 extension ArbitraryPrecisionInteger: Numeric {
     @usableFromInline
-    typealias Magnitude = Self
+    package typealias Magnitude = Self
 
     @usableFromInline
-    var magnitude: Magnitude {
+    package var magnitude: Magnitude {
         if self._positive {
             return self
         }
@@ -354,7 +351,7 @@ extension ArbitraryPrecisionInteger: Numeric {
     }
 
     @usableFromInline
-    static func * (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> ArbitraryPrecisionInteger {
+    package static func * (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> ArbitraryPrecisionInteger {
         var result = ArbitraryPrecisionInteger()
 
         let rc = result.withUnsafeMutableBignumPointer { resultPtr in
@@ -372,7 +369,7 @@ extension ArbitraryPrecisionInteger: Numeric {
     }
 
     @usableFromInline
-    static func *= (lhs: inout ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) {
+    package static func *= (lhs: inout ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) {
         let rc = lhs.withUnsafeMutableBignumPointer { lhsPtr in
             rhs.withUnsafeBignumPointer { rhsPtr in
                 ArbitraryPrecisionInteger.withUnsafeBN_CTX { bnCtx in
@@ -384,7 +381,7 @@ extension ArbitraryPrecisionInteger: Numeric {
     }
 
     @inlinable
-    init?<T: BinaryInteger>(exactly integer: T) {
+    package init?<T: BinaryInteger>(exactly integer: T) {
         fatalError("Not currently implemented")
     }
 }
@@ -393,7 +390,7 @@ extension ArbitraryPrecisionInteger: Numeric {
 
 extension ArbitraryPrecisionInteger: SignedNumeric {
     @usableFromInline
-    mutating func negate() {
+    package mutating func negate() {
         let signBit: CInt = self._positive ? 1 : 0
 
         self.withUnsafeMutableBignumPointer {
@@ -406,14 +403,14 @@ extension ArbitraryPrecisionInteger: SignedNumeric {
 
 extension ArbitraryPrecisionInteger {
     @usableFromInline
-    var trailingZeroBitCount: Int32 {
+    package var trailingZeroBitCount: Int32 {
         self.withUnsafeBignumPointer {
             CCryptoBoringSSL_BN_count_low_zero_bits($0)
         }
     }
 
     @usableFromInline
-    static func gcd(_ a: ArbitraryPrecisionInteger, _ b: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
+    package static func gcd(_ a: ArbitraryPrecisionInteger, _ b: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
         var result = ArbitraryPrecisionInteger()
 
         guard result.withUnsafeMutableBignumPointer({ resultPtr in
@@ -425,19 +422,19 @@ extension ArbitraryPrecisionInteger {
                 }
             }
         }) == 1 else {
-            throw CryptoKitError.internalBoringSSLError()
+            throw CryptoBoringWrapperError.internalBoringSSLError()
         }
 
         return result
     }
 
     @usableFromInline
-    func isCoprime(with other: ArbitraryPrecisionInteger) throws -> Bool {
+    package func isCoprime(with other: ArbitraryPrecisionInteger) throws -> Bool {
         try Self.gcd(self, other) == 1
     }
 
     @usableFromInline
-    static func random(inclusiveMin: UInt, exclusiveMax: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
+    package static func random(inclusiveMin: UInt, exclusiveMax: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
         var result = ArbitraryPrecisionInteger()
 
         guard result.withUnsafeMutableBignumPointer({ resultPtr in
@@ -445,14 +442,14 @@ extension ArbitraryPrecisionInteger {
                 CCryptoBoringSSL_BN_rand_range_ex(resultPtr, BN_ULONG(inclusiveMin), exclusiveMaxPtr)
             }
         }) == 1 else {
-            throw CryptoKitError.internalBoringSSLError()
+            throw CryptoBoringWrapperError.internalBoringSSLError()
         }
 
         return result
     }
 
     @usableFromInline
-    static func >> (lhs: ArbitraryPrecisionInteger, rhs: Int32) -> ArbitraryPrecisionInteger {
+    package static func >> (lhs: ArbitraryPrecisionInteger, rhs: Int32) -> ArbitraryPrecisionInteger {
         var result = ArbitraryPrecisionInteger()
 
         let rc = result.withUnsafeMutableBignumPointer { resultPtr in
@@ -467,7 +464,7 @@ extension ArbitraryPrecisionInteger {
     }
 
     @usableFromInline
-    static func / (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> ArbitraryPrecisionInteger {
+    package static func / (lhs: ArbitraryPrecisionInteger, rhs: ArbitraryPrecisionInteger) -> ArbitraryPrecisionInteger {
         var result = ArbitraryPrecisionInteger()
 
         let rc = result.withUnsafeMutableBignumPointer { resultPtr in
@@ -485,7 +482,7 @@ extension ArbitraryPrecisionInteger {
     }
 
     @usableFromInline
-    var isEven: Bool {
+    package var isEven: Bool {
         self.withUnsafeBignumPointer {
             CCryptoBoringSSL_BN_is_odd($0) == 0
         }
@@ -497,11 +494,11 @@ extension ArbitraryPrecisionInteger {
 extension Data {
     /// Serializes an ArbitraryPrecisionInteger padded out to a certain minimum size.
     @usableFromInline
-    mutating func append(bytesOf integer: ArbitraryPrecisionInteger, paddedToSize paddingSize: Int) throws {
+    package mutating func append(bytesOf integer: ArbitraryPrecisionInteger, paddedToSize paddingSize: Int) throws {
         let byteCount = integer.byteCount
 
         guard paddingSize >= byteCount else {
-            throw CryptoKitError.incorrectParameterSize
+            throw CryptoBoringWrapperError.incorrectParameterSize
         }
 
         // To extend the data we need to write some zeroes into it.
@@ -521,7 +518,7 @@ extension Data {
     }
 
     @usableFromInline
-    init(bytesOf integer: ArbitraryPrecisionInteger, paddedToSize paddingSize: Int) throws {
+    package init(bytesOf integer: ArbitraryPrecisionInteger, paddedToSize paddingSize: Int) throws {
         self.init(capacity: paddingSize)
         try self.append(bytesOf: integer, paddedToSize: paddingSize)
     }
@@ -531,7 +528,7 @@ extension Data {
 
 extension ArbitraryPrecisionInteger: CustomDebugStringConvertible {
     @usableFromInline
-    var debugDescription: String {
+    package var debugDescription: String {
         guard let bio = CCryptoBoringSSL_BIO_new(CCryptoBoringSSL_BIO_s_mem()) else {
             return "ArbitraryPrecisionInteger: (error generating representation)"
         }

--- a/Sources/CryptoBoringWrapper/Util/FiniteFieldArithmeticContext_boring.swift
+++ b/Sources/CryptoBoringWrapper/Util/FiniteFieldArithmeticContext_boring.swift
@@ -11,14 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if MODULE_IS_CRYPTO && CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
+#if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
 @_implementationOnly import CCryptoBoringSSL
 import Foundation
-#if !MODULE_IS_CRYPTO
-import enum Crypto.CryptoKitError
-#endif
 
 /// A context for performing mathematical operations on ArbitraryPrecisionIntegers over a finite field.
 ///
@@ -32,15 +29,15 @@ import enum Crypto.CryptoKitError
 /// Annoyingly, because of the way we have implemented ArbitraryPrecisionInteger, we can't actually use these temporary bignums
 /// ourselves.
 @usableFromInline
-class FiniteFieldArithmeticContext {
+package class FiniteFieldArithmeticContext {
     private var fieldSize: ArbitraryPrecisionInteger
     private var bnCtx: OpaquePointer
 
     @usableFromInline
-    init(fieldSize: ArbitraryPrecisionInteger) throws {
+    package init(fieldSize: ArbitraryPrecisionInteger) throws {
         self.fieldSize = fieldSize
         guard let bnCtx = CCryptoBoringSSL_BN_CTX_new() else {
-            throw CryptoKitError.internalBoringSSLError()
+            throw CryptoBoringWrapperError.internalBoringSSLError()
         }
         CCryptoBoringSSL_BN_CTX_start(bnCtx)
         self.bnCtx = bnCtx
@@ -56,7 +53,7 @@ class FiniteFieldArithmeticContext {
 
 extension FiniteFieldArithmeticContext {
     @usableFromInline
-    func residue(_ x: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
+    package func residue(_ x: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
         var result = ArbitraryPrecisionInteger()
 
         guard x.withUnsafeBignumPointer({ xPtr in
@@ -66,14 +63,14 @@ extension FiniteFieldArithmeticContext {
                 }
             }
         }) == 1 else {
-            throw CryptoKitError.internalBoringSSLError()
+            throw CryptoBoringWrapperError.internalBoringSSLError()
         }
 
         return result
     }
 
     @usableFromInline
-    func square(_ input: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
+    package func square(_ input: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
         var output = ArbitraryPrecisionInteger()
 
         let rc = input.withUnsafeBignumPointer { inputPointer in
@@ -85,14 +82,14 @@ extension FiniteFieldArithmeticContext {
         }
 
         guard rc == 1 else {
-            throw CryptoKitError.internalBoringSSLError()
+            throw CryptoBoringWrapperError.internalBoringSSLError()
         }
 
         return output
     }
 
     @usableFromInline
-    func multiply(_ x: ArbitraryPrecisionInteger, _ y: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
+    package func multiply(_ x: ArbitraryPrecisionInteger, _ y: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
         var output = ArbitraryPrecisionInteger()
 
         let rc = x.withUnsafeBignumPointer { xPointer in
@@ -106,14 +103,14 @@ extension FiniteFieldArithmeticContext {
         }
 
         guard rc == 1 else {
-            throw CryptoKitError.internalBoringSSLError()
+            throw CryptoBoringWrapperError.internalBoringSSLError()
         }
 
         return output
     }
 
     @usableFromInline
-    func add(_ x: ArbitraryPrecisionInteger, _ y: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
+    package func add(_ x: ArbitraryPrecisionInteger, _ y: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
         var output = ArbitraryPrecisionInteger()
 
         let rc = x.withUnsafeBignumPointer { xPointer in
@@ -127,14 +124,14 @@ extension FiniteFieldArithmeticContext {
         }
 
         guard rc == 1 else {
-            throw CryptoKitError.internalBoringSSLError()
+            throw CryptoBoringWrapperError.internalBoringSSLError()
         }
 
         return output
     }
 
     @usableFromInline
-    func subtract(_ x: ArbitraryPrecisionInteger, from y: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
+    package func subtract(_ x: ArbitraryPrecisionInteger, from y: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
         var output = ArbitraryPrecisionInteger()
 
         let rc = x.withUnsafeBignumPointer { xPointer in
@@ -149,14 +146,14 @@ extension FiniteFieldArithmeticContext {
         }
 
         guard rc == 1 else {
-            throw CryptoKitError.internalBoringSSLError()
+            throw CryptoBoringWrapperError.internalBoringSSLError()
         }
 
         return output
     }
 
     @usableFromInline
-    func positiveSquareRoot(_ x: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
+    package func positiveSquareRoot(_ x: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
         let outputPointer = x.withUnsafeBignumPointer { xPointer in
             self.fieldSize.withUnsafeBignumPointer { fieldSizePointer in
                 // We can't pass a pointer in as BN_mod_sqrt may attempt to free it.
@@ -165,7 +162,7 @@ extension FiniteFieldArithmeticContext {
         }
 
         guard let actualOutputPointer = outputPointer else {
-            throw CryptoKitError.internalBoringSSLError()
+            throw CryptoBoringWrapperError.internalBoringSSLError()
         }
 
         // Ok, we own this pointer now.
@@ -177,7 +174,7 @@ extension FiniteFieldArithmeticContext {
     }
 
     @usableFromInline
-    func inverse(_ x: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger? {
+    package func inverse(_ x: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger? {
         var result = ArbitraryPrecisionInteger()
 
         guard result.withUnsafeMutableBignumPointer({ resultPtr in
@@ -192,19 +189,19 @@ extension FiniteFieldArithmeticContext {
     }
 
     @usableFromInline
-    func pow(_ x: ArbitraryPrecisionInteger, _ p: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
+    package func pow(_ x: ArbitraryPrecisionInteger, _ p: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
         try self.pow(x, p) { r, x, p, m, ctx, _ in CCryptoBoringSSL_BN_mod_exp(r, x, p, m, ctx) }
     }
 
     @usableFromInline
-    func pow(secret x: ArbitraryPrecisionInteger, _ p: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
-        guard x < self.fieldSize else { throw CryptoKitError.incorrectParameterSize }
+    package func pow(secret x: ArbitraryPrecisionInteger, _ p: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
+        guard x < self.fieldSize else { throw CryptoBoringWrapperError.incorrectParameterSize }
         return try self.pow(x, p, using: CCryptoBoringSSL_BN_mod_exp_mont)
     }
 
     @usableFromInline
-    func pow(secret x: ArbitraryPrecisionInteger, secret p: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
-        guard x < self.fieldSize else { throw CryptoKitError.incorrectParameterSize }
+    package func pow(secret x: ArbitraryPrecisionInteger, secret p: ArbitraryPrecisionInteger) throws -> ArbitraryPrecisionInteger {
+        guard x < self.fieldSize else { throw CryptoBoringWrapperError.incorrectParameterSize }
         return try self.pow(x, p, using: CCryptoBoringSSL_BN_mod_exp_mont_consttime)
     }
 
@@ -233,7 +230,7 @@ extension FiniteFieldArithmeticContext {
                 }
             }
         }) == 1 else {
-            throw CryptoKitError.internalBoringSSLError()
+            throw CryptoBoringWrapperError.internalBoringSSLError()
         }
 
         return result

--- a/Sources/_CryptoExtras/AES/AES_GCM_SIV.swift
+++ b/Sources/_CryptoExtras/AES/AES_GCM_SIV.swift
@@ -15,7 +15,7 @@
 import Crypto
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
-@_implementationOnly import CryptoBoringWrapper
+import CryptoBoringWrapper
 import Foundation
 
 /// Types associated with the AES GCM SIV algorithm

--- a/Sources/_CryptoExtras/AES/Block Function.swift
+++ b/Sources/_CryptoExtras/AES/Block Function.swift
@@ -15,7 +15,7 @@
 import Crypto
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
-@_implementationOnly import CryptoBoringWrapper
+import CryptoBoringWrapper
 import Foundation
 
 extension AES {

--- a/Sources/_CryptoExtras/AES/BoringSSL/AES_GCM_SIV_boring.swift
+++ b/Sources/_CryptoExtras/AES/BoringSSL/AES_GCM_SIV_boring.swift
@@ -17,7 +17,7 @@
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 import Crypto
-@_implementationOnly import CryptoBoringWrapper
+import CryptoBoringWrapper
 import Foundation
 
 extension BoringSSLAEAD {

--- a/Sources/_CryptoExtras/CMakeLists.txt
+++ b/Sources/_CryptoExtras/CMakeLists.txt
@@ -25,8 +25,6 @@ add_library(_CryptoExtras
   "Util/Error.swift"
   "Util/PEMDocument.swift"
   "Util/RandomBytes.swift"
-  "Util/Shared/ArbitraryPrecisionInteger_boring.swift"
-  "Util/Shared/FiniteFieldArithmeticContext_boring.swift"
   "Util/SubjectPublicKeyInfo.swift")
 
 target_include_directories(_CryptoExtras PRIVATE
@@ -39,6 +37,8 @@ target_link_libraries(_CryptoExtras PUBLIC
   CryptoBoringWrapper
   CCryptoBoringSSL
   CCryptoBoringSSLShims)
+
+target_compile_options(_CryptoExtras PRIVATE ${SWIFT_CRYPTO_COMPILE_OPTIONS})
 
 target_link_options(_CryptoExtras PRIVATE
     "$<$<PLATFORM_ID:Darwin>:SHELL:-Xlinker -framework -Xlinker Security>")

--- a/Sources/_CryptoExtras/ChaCha20CTR/BoringSSL/ChaCha20CTR_boring.swift
+++ b/Sources/_CryptoExtras/ChaCha20CTR/BoringSSL/ChaCha20CTR_boring.swift
@@ -15,7 +15,7 @@
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 import Crypto
-@_implementationOnly import CryptoBoringWrapper
+import CryptoBoringWrapper
 import Foundation
 
 enum OpenSSLChaCha20CTRImpl {

--- a/Sources/_CryptoExtras/ChaCha20CTR/ChaCha20CTR.swift
+++ b/Sources/_CryptoExtras/ChaCha20CTR/ChaCha20CTR.swift
@@ -15,7 +15,7 @@
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 import Crypto
-@_implementationOnly import CryptoBoringWrapper
+import CryptoBoringWrapper
 import Foundation
 
 typealias ChaCha20CTRImpl = OpenSSLChaCha20CTRImpl

--- a/Sources/_CryptoExtras/RSA/RSA+BlindSigning.swift
+++ b/Sources/_CryptoExtras/RSA/RSA+BlindSigning.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 import Crypto
+import CryptoBoringWrapper
 
 // NOTE: RSABSSA API is implemented using BoringSSL on all platforms.
 fileprivate typealias BackingPublicKey = BoringSSLRSAPublicKey

--- a/Sources/_CryptoExtras/RSA/RSA.swift
+++ b/Sources/_CryptoExtras/RSA/RSA.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import Foundation
 import Crypto
+import CryptoBoringWrapper
 import SwiftASN1
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Sources/_CryptoExtras/RSA/RSA_boring.swift
+++ b/Sources/_CryptoExtras/RSA/RSA_boring.swift
@@ -15,6 +15,7 @@ import Foundation
 import Crypto
 
 // NOTE: This file is unconditionally compiled because RSABSSA is implemented using BoringSSL on all platforms.
+import CryptoBoringWrapper
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 

--- a/Sources/_CryptoExtras/Util/Shared
+++ b/Sources/_CryptoExtras/Util/Shared
@@ -1,1 +1,0 @@
-../../Crypto/Util/BoringSSL/Shared

--- a/Tests/CryptoBoringWrapperTests/ArbitraryPrecisionIntegerTests.swift
+++ b/Tests/CryptoBoringWrapperTests/ArbitraryPrecisionIntegerTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 #else
-@testable import Crypto
+@testable import CryptoBoringWrapper
 import XCTest
 
 final class ArbitraryPrecisionIntegerTests: XCTestCase {
@@ -43,7 +43,7 @@ final class ArbitraryPrecisionIntegerTests: XCTestCase {
     func testPositiveSquareRoot() {
         XCTAssertNoThrow(XCTAssertEqual(try ArbitraryPrecisionInteger(144).positiveSquareRoot(), 12))
         XCTAssertThrowsError(try ArbitraryPrecisionInteger(101).positiveSquareRoot()) { error in
-            guard case .some(.underlyingCoreCryptoError) = error as? CryptoKitError else {
+            guard case .some(.underlyingCoreCryptoError) = error as? CryptoBoringWrapperError else {
                 XCTFail("Unexpected error: \(error)")
                 return
             }

--- a/Tests/CryptoBoringWrapperTests/FiniteFieldArithmeticTests.swift
+++ b/Tests/CryptoBoringWrapperTests/FiniteFieldArithmeticTests.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 #else
-@testable import Crypto
+@testable import CryptoBoringWrapper
 import XCTest
 
 final class FiniteFieldArithmeticTests: XCTestCase {
@@ -115,7 +115,7 @@ final class FiniteFieldArithmeticTests: XCTestCase {
                 XCTAssertEqual(try ff.pow(secret: x, secret: p), expectedResult, message)
             } else {
                 XCTAssertThrowsError(try ff.pow(secret: x, p), message) { error in
-                    switch error as? CryptoKitError {
+                    switch error as? CryptoBoringWrapperError {
                     case .incorrectParameterSize: break // OK
                     default: XCTFail("Unexpected error: \(error)")
                     }

--- a/Tests/_CryptoExtrasTests/TestRSASigning.swift
+++ b/Tests/_CryptoExtrasTests/TestRSASigning.swift
@@ -14,6 +14,7 @@
 import Foundation
 import XCTest
 import Crypto
+import CryptoBoringWrapper
 @testable import _CryptoExtras
 
 final class TestRSASigning: XCTestCase {


### PR DESCRIPTION
## Motivation

Back in 3.5.0 we needed to make use of `ArbitraryPrecisionInteger` and `FiniteFieldArithmeticContext` from `_CryptoExtras`. These types lived in `Crypto` and used `@_implementationOnly import CCryptoBoringSSL`. We mistakenly removed the `@_implementationOnly` from the import after some failed analyses, resulting in compilation failures in downstream projects that had other vendored copies of BoringSSL (aside: this was in spite of the namespaced symbol rewriting which wasn't catching some BoringSSL C macro expansions).

We reverted to using `@_implementationOnly import` in 3.5.1 and resorted to using symlinks to share the code between `Crypto` and `_CryptoExtras`. This was the best we could do at the time because we still supported Swift 5.8 and so could not make use of `package` access. It also required an additional workaround define, `MODULE_IS_CRYPTO`.

We have now dropped support for 5.8 and have the opportunity to unwind this workaround.

For additional context, note that these types are needed by both:

1. (Conditionally) `Crypto`, when compiling for non-Darwin platforms; and
2. (Unconditionally) `_CryptoExtras`, when compiling features that do not have the required primitives exposed in Darwin APIs.

Fortunately, we have the internal `CryptoBoringWrapper` target, which is the existing home for exactly such code.

Finally, note that existing uses of `CryptoBoringWrapper` are importing it _with_ `@_implementationOnly` but this seems to be unnecessary since `CryptoBoringWrapper` makes use of `@_implementationOnly` when importing `CCryptoBoringSSL` (as it should).

## Modifications

- Delete the symlinks in `_CryptoExtras` to `ArbitraryPrecisionInteger.swift` and `FiniteFieldArithmeticContext.swift`.
- Remove the `MODULE_IS_CRYPTO` workaround compile-time define.
- Move `ArbitraryPrecisionInteger.swift` and `FiniteFieldArithmeticContext.swift` to `CryptoBoringWrapper`.
- Adopt `package` access for the types and all their (internal) API surface.
- Mark `ArbitraryPrecisionInteger.BackingStorage` as `fileprivate` for good measure.
- Flesh out `CryptoBoringWrapperError` to match `CryptoError` because some of these errors are used.
- Drop `@_implementationOnly` on all _existing_ imports of `CryptoBoringWrapper`.
- Import `CryptoBoringWrapper` in all places that required `ArbitraryPrecisionInteger` and/or `FiniteFieldArithmeticContext`.
- Move `ArbitraryPrecisionIntegerTests.swift` and `FiniteFieldArithmeticContextTests.swift` to new `CryptoBoringWrapperTests` test target.
- Update CMake files to account for the moved sources and to add `-package-name` to compiler arguments.

## Additional notes

Note that I tried to make use of `package import CryptoBoringWrapper` but at this time this isn't working well with `@inlinable` or `@usableFromInline` symbols.

## Results

- No adopter-visible change.
- The symlinks and manifest hacks are removed and we can continue to share code between `Crypto` and `_CryptoExtras`.

## Testing

The breakage caused by the 3.5.0 was caught by a Dependabot update on penny-bot[^0] and so I have used that project to validate that this change is safe:

- Using penny-bot commit `e9b7340` (commit at time of last break).
- Using `swift:5.10-noble` image (CI used by the previously failing pipeline).
- Using local package dependency of swift-crypto; otherwise unmodified penny-bot.
- Builds with swift-crypto 3.4.0
- Fails with swift-crypto 3.5.0 (repro of leaking BoringSSL).
- Builds with this PR patch.

[^0]: https://github.com/vapor/penny-bot/actions/runs/9767425786/job/26962669715?pr=211
