### PR TITLE
Add Equatable and Hashable conformance for CryptoKitError and CryptoKitASN1Error

### DIFF
--- a/Sources/Crypto/CryptoKitErrors.swift
+++ b/Sources/Crypto/CryptoKitErrors.swift
@@ -33,8 +33,10 @@ public enum CryptoKitError: Error {
     case invalidParameter
 }
 
+extension CryptoKitError: Equatable, Hashable {}
+
 /// Errors from decoding ASN.1 content.
-public enum CryptoKitASN1Error: Error {
+public enum CryptoKitASN1Error: Equatable, Error, Hashable {
     /// The ASN.1 tag for this field is invalid or unsupported.
     case invalidFieldIdentifier
 


### PR DESCRIPTION
## Motivation

`CryptoKitError` and `CryptoKitASN1Error` both conform to `Equatable` and `Hashable` in the SDK, but we are missing these conformances in our copy.

## Modifications

Add Equatable and Hashable conformance for `CryptoKitError` and `CryptoKitASN1Error`.

## Result

`CryptoKitError` and `CryptoKitASN1Error` now conform to `Equatable` and `Hashable`, like their counterpart types in the SDK.