### PR TITLE
Add support for new Android overlay, swiftlang/swift#74758

### DIFF
--- a/Sources/Crypto/Key Derivation/HKDF.swift
+++ b/Sources/Crypto/Key Derivation/HKDF.swift
@@ -15,6 +15,9 @@
 @_exported import CryptoKit
 #else
 import Foundation
+#if canImport(Android)
+import Android
+#endif
 
 /// A standards-based implementation of an HMAC-based Key Derivation Function
 /// (HKDF).

--- a/Sources/_CryptoExtras/Key Derivation/Scrypt/BoringSSL/Scrypt_boring.swift
+++ b/Sources/_CryptoExtras/Key Derivation/Scrypt/BoringSSL/Scrypt_boring.swift
@@ -21,6 +21,10 @@ import Foundation
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 
+#if canImport(Android)
+import Android
+#endif
+
 internal struct BoringSSLScrypt {
     /// Derives a secure key using the provided passphrase and salt.
     ///


### PR DESCRIPTION
### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

I don't know why [these imports are required only for the Android overlay and not other platforms](https://github.com/apple/swift-certificates/pull/183#discussion_r1730366251), but I needed this patch for my Android CI.