### PR TITLE
Potentially Inconsistent Coordinate Slicing

### DIFF
--- a/Sources/Crypto/Signatures/ECDSA.swift
+++ b/Sources/Crypto/Signatures/ECDSA.swift
@@ -66,7 +66,7 @@ extension P256.Signing {
             let combined = rawRepresentation
             assert(combined.count % 2 == 0)
             let half = combined.count / 2
-            return (combined.prefix(upTo: half), combined.suffix(from: half))
+            return (combined.prefix(half), combined.suffix(half))
         }
 
         /// Creates a P-256 digital signature from a Distinguished Encoding
@@ -115,8 +115,8 @@ extension P256.Signing {
             #else
             let raw = rawRepresentation
             let half = raw.count / 2
-            let r = Array(raw.prefix(upTo: half))[...]
-            let s = Array(raw.suffix(from: half))[...]
+            let r = Array(raw.prefix(half))[...]
+            let s = Array(raw.suffix(half))[...]
 
             let sig = ASN1.ECDSASignature(r: r, s: s)
             var serializer = ASN1.Serializer()
@@ -229,7 +229,7 @@ extension P384.Signing {
             let combined = rawRepresentation
             assert(combined.count % 2 == 0)
             let half = combined.count / 2
-            return (combined.prefix(upTo: half), combined.suffix(from: half))
+            return (combined.prefix(half), combined.suffix(half))
         }
 
         /// Creates a P-384 digital signature from a Distinguished Encoding
@@ -278,8 +278,8 @@ extension P384.Signing {
             #else
             let raw = rawRepresentation
             let half = raw.count / 2
-            let r = Array(raw.prefix(upTo: half))[...]
-            let s = Array(raw.suffix(from: half))[...]
+            let r = Array(raw.prefix(half))[...]
+            let s = Array(raw.suffix(half))[...]
 
             let sig = ASN1.ECDSASignature(r: r, s: s)
             var serializer = ASN1.Serializer()
@@ -392,7 +392,7 @@ extension P521.Signing {
             let combined = rawRepresentation
             assert(combined.count % 2 == 0)
             let half = combined.count / 2
-            return (combined.prefix(upTo: half), combined.suffix(from: half))
+            return (combined.prefix(half), combined.suffix(half))
         }
 
         /// Creates a P-521 digital signature from a Distinguished Encoding
@@ -441,8 +441,8 @@ extension P521.Signing {
             #else
             let raw = rawRepresentation
             let half = raw.count / 2
-            let r = Array(raw.prefix(upTo: half))[...]
-            let s = Array(raw.suffix(from: half))[...]
+            let r = Array(raw.prefix(half))[...]
+            let s = Array(raw.suffix(half))[...]
 
             let sig = ASN1.ECDSASignature(r: r, s: s)
             var serializer = ASN1.Serializer()

--- a/Sources/Crypto/Signatures/ECDSA.swift.gyb
+++ b/Sources/Crypto/Signatures/ECDSA.swift.gyb
@@ -76,7 +76,7 @@ extension ${CURVE}.Signing {
             let combined = rawRepresentation
             assert(combined.count % 2 == 0)
             let half = combined.count / 2
-            return (combined.prefix(upTo: half), combined.suffix(from: half))
+            return (combined.prefix(half), combined.suffix(half))
         }
 
         /// Creates a ${DISPLAY_CURVE} digital signature from a Distinguished Encoding
@@ -125,8 +125,8 @@ extension ${CURVE}.Signing {
             #else
             let raw = rawRepresentation
             let half = raw.count / 2
-            let r = Array(raw.prefix(upTo: half))[...]
-            let s = Array(raw.suffix(from: half))[...]
+            let r = Array(raw.prefix(half))[...]
+            let s = Array(raw.suffix(half))[...]
 
             let sig = ASN1.ECDSASignature(r: r, s: s)
             var serializer = ASN1.Serializer()


### PR DESCRIPTION
Replaced potentially unexpected accesses to coordinate slices with consistent ranges no matter if the raw representation is a root or a slice of data.

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [x] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

As discussed [in slack](https://swift-open-source.slack.com/archives/C04SH3Y3X27/p1731924717212829), `.prefix(upTo:)` and `.suffix(from:)` are problematic when you don't know the origin of `Data`, as a slice of Data can have a non-zero `startIndex`, causing downstream misalignment. For myself, this happened when I tried accessing the `rawRepresentation` of an ECDSA's PublicKey, which was derived from the x963 representation, and thus had a start offset of 1. Although the code performed as expected, this seemed like a mistake waiting to happen as changing how `rawRepresentation` is derived for signatures could cause a similar headache in the future, especially so for anyone reading the code as a reference (it me!).

### Modifications:

Since the use cases here were to split the `Data` in half, I replaces the uses of `.prefix(upTo:)` and `.suffix(from:)` with `.prefix()` and `.suffix()` respectfully.

### Result:

No change to behavior, but more semantically correct code.