### PR TITLE
Fix DocC generation

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,3 +2,4 @@ version: 1
 builder:
   configs:
     - documentation_targets: [Crypto, _CryptoExtras]
+      platform: linux

--- a/Sources/_CryptoExtras/Docs.docc/index.md
+++ b/Sources/_CryptoExtras/Docs.docc/index.md
@@ -1,4 +1,4 @@
-# ``CryptoExtras``
+# ``_CryptoExtras``
 
 Provides additional cryptographic APIs that are not available in CryptoKit (and therefore the core Crypto library).
 


### PR DESCRIPTION
Fix DocC generation. Force Linux build on SPI to get it to render the Crypto docs

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [ ] I've run tests to see all new and existing tests pass
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

Currently the Crypto docs are empty on SPI because they're built on macOS where there are no symbols. CryptoExtras index page also doesn't work because of a name mismatch

### Modifications:

Force Linux build on SPI, fix name for extras documentation

### Result:

Working Docs