### PR TITLE
Add missing assembly files to CMake and generator script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,7 +15,7 @@
 cmake_minimum_required(VERSION 3.15.1)
 
 project(SwiftCrypto
-  LANGUAGES ASM C Swift)
+  LANGUAGES ASM C CXX Swift)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules)
 

--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -341,6 +341,10 @@ target_include_directories(CCryptoBoringSSL PUBLIC
 
 target_compile_definitions(CCryptoBoringSSL PRIVATE
   $<$<PLATFORM_ID:Windows>:WIN32_LEAN_AND_MEAN>)
+target_link_libraries(CCryptoBoringSSL PUBLIC
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:dispatch>
+  $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
+  SwiftASN1)
 set_target_properties(CCryptoBoringSSL PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_Swift_MODULE_DIRECTORY}")
 

--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -123,6 +123,7 @@ add_library(CCryptoBoringSSL STATIC
   "crypto/fipsmodule/bcm.cc"
   "crypto/fipsmodule/fips_shared_support.cc"
   "crypto/hpke/hpke.cc"
+  "crypto/hrss/asm/poly_rq_mul.S"
   "crypto/hrss/hrss.cc"
   "crypto/kyber/kyber.cc"
   "crypto/lhash/lhash.cc"
@@ -253,7 +254,11 @@ add_library(CCryptoBoringSSL STATIC
   "crypto/x509/x_val.cc"
   "crypto/x509/x_x509.cc"
   "crypto/x509/x_x509a.cc"
-  "gen/crypto/err_data.cc")
+  "gen/crypto/err_data.cc"
+  "third_party/fiat/asm/fiat_curve25519_adx_mul.S"
+  "third_party/fiat/asm/fiat_curve25519_adx_square.S"
+  "third_party/fiat/asm/fiat_p256_adx_mul.S"
+  "third_party/fiat/asm/fiat_p256_adx_sqr.S")
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin AND CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64")
   target_sources(CCryptoBoringSSL PRIVATE

--- a/scripts/update-cmake-lists.sh
+++ b/scripts/update-cmake-lists.sh
@@ -32,7 +32,7 @@ function update_cmakelists_source() {
 
     src_exts=("*.c" "*.swift" "*.cc")
     num_exts=${#src_exts[@]}
-    echo "Finding source files (" "${src_exts[@]}" ") under $src_root"
+    echo "Finding source files (" "${src_exts[@]}" ") platform independent assembly files under $src_root"
 
     # Build file extensions argument for `find`
     declare -a exts_arg
@@ -56,7 +56,7 @@ function update_cmakelists_source() {
     fi
 
     # Wrap quotes around each filename since it might contain spaces
-    srcs=$($find -L "${src_root}" -type f \( "${exts_arg[@]}" \) -printf '  "%P"\n' | LC_ALL=POSIX sort)
+    srcs=$($find -L "${src_root}" -type f \( \( "${exts_arg[@]}" \) -o \( -name *.S -a ! -name *x86_64* -a ! -name *arm* -a ! -name *apple* -a ! -name *linux* \) \) -printf '  "%P"\n' | LC_ALL=POSIX sort)
     echo "$srcs"
 
     # Update list of source files in CMakeLists.txt

--- a/scripts/update-cmake-lists.sh
+++ b/scripts/update-cmake-lists.sh
@@ -56,7 +56,7 @@ function update_cmakelists_source() {
     fi
 
     # Wrap quotes around each filename since it might contain spaces
-    srcs=$($find -L "${src_root}" -type f \( \( "${exts_arg[@]}" \) -o \( -name *.S -a ! -name *x86_64* -a ! -name *arm* -a ! -name *apple* -a ! -name *linux* \) \) -printf '  "%P"\n' | LC_ALL=POSIX sort)
+    srcs=$($find -L "${src_root}" -type f \( \( "${exts_arg[@]}" \) -o \( -name "*.S" -a ! -name "*x86_64*" -a ! -name "*arm*" -a ! -name "*apple*" -a ! -name "*linux*" \) \) -printf '  "%P"\n' | LC_ALL=POSIX sort)
     echo "$srcs"
 
     # Update list of source files in CMakeLists.txt


### PR DESCRIPTION
Update both the CMakeLists.txt for CCryptoBoringSSL and the CMakeLists.txt generator so that it can add platform-independent assembly files.

### Checklist
- [X] I've run tests to see all new and existing tests pass
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [X] I've run `./scripts/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

There are downstream linker failures due to missing symbols from certain platform neutral assembly files.

### Modifications:

The `scripts/update-cmake-lists.sh` has an updated find expression to discover platform-independent assembly files and includes them in the `CMakeLists.txt` files.

### Result:

There will be more symbols included from third-parties such as BoringSSL.