### PR TITLE
Add the necessary swift defines in CMake for Crypto module

### DIFF
--- a/Sources/Crypto/CMakeLists.txt
+++ b/Sources/Crypto/CMakeLists.txt
@@ -96,9 +96,13 @@ add_library(Crypto
 target_compile_definitions(Crypto PRIVATE
   "$<$<COMPILE_LANGUAGE:Swift>:CRYPTO_IN_SWIFTPM>")
 
+target_compile_options(Crypto PRIVATE -DCRYPTO_IN_SWIFTPM="true")
+
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "Android" OR CMAKE_SYSTEM_NAME STREQUAL "WASI" OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
   target_compile_definitions(Crypto PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:CRYPTO_IN_SWIFTPM_FORCE_BUILD_API>")
+
+  target_compile_options(Crypto PRIVATE -DCRYPTO_IN_SWIFTPM_FORCE_BUILD_API="true")
 endif()
 
 target_include_directories(Crypto PRIVATE

--- a/Sources/Crypto/CMakeLists.txt
+++ b/Sources/Crypto/CMakeLists.txt
@@ -96,13 +96,9 @@ add_library(Crypto
 target_compile_definitions(Crypto PRIVATE
   "$<$<COMPILE_LANGUAGE:Swift>:CRYPTO_IN_SWIFTPM>")
 
-target_compile_options(Crypto PRIVATE -DCRYPTO_IN_SWIFTPM="true")
-
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "Android" OR CMAKE_SYSTEM_NAME STREQUAL "WASI" OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
   target_compile_definitions(Crypto PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:CRYPTO_IN_SWIFTPM_FORCE_BUILD_API>")
-
-  target_compile_options(Crypto PRIVATE -DCRYPTO_IN_SWIFTPM_FORCE_BUILD_API="true")
 endif()
 
 target_include_directories(Crypto PRIVATE

--- a/Sources/_CryptoExtras/CMakeLists.txt
+++ b/Sources/_CryptoExtras/CMakeLists.txt
@@ -52,6 +52,12 @@ add_library(_CryptoExtras
   "Util/SubjectPublicKeyInfo.swift"
   "ZKPs/DLEQ.swift")
 
+target_compile_options(_CryptoExtras PRIVATE -DCRYPTO_IN_SWIFTPM="true")
+
+if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "Android" OR CMAKE_SYSTEM_NAME STREQUAL "WASI" OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
+  target_compile_options(_CryptoExtras PRIVATE -DCRYPTO_IN_SWIFTPM_FORCE_BUILD_API="true")
+endif()
+
 target_include_directories(_CryptoExtras PRIVATE
   $<TARGET_PROPERTY:CCryptoBoringSSL,INCLUDE_DIRECTORIES>
   $<TARGET_PROPERTY:CCryptoBoringSSLShims,INCLUDE_DIRECTORIES>)


### PR DESCRIPTION
### Checklist
- [X] I've run tests to see all new and existing tests pass
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [X] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

When building SwiftPM with CMake and the swift-crypto package there are errors being produced on macOS relating to missing imports provided by the CryptoKit package.

### Modifications:

Modify the CMakeLists.txt file for the Crypto target so that the defines are set like they are in the Package.swift.

### Result:

After the change, building SwiftPM with CMake on macOS should work.