### PR TITLE
Fix macos build failures cmake

### DIFF
--- a/Sources/_CryptoExtras/CMakeLists.txt
+++ b/Sources/_CryptoExtras/CMakeLists.txt
@@ -52,10 +52,10 @@ add_library(_CryptoExtras
   "Util/SubjectPublicKeyInfo.swift"
   "ZKPs/DLEQ.swift")
 
-target_compile_options(_CryptoExtras PRIVATE -DCRYPTO_IN_SWIFTPM="true")
+target_compile_options(_CryptoExtras PRIVATE -DCRYPTO_IN_SWIFTPM)
 
 if(CMAKE_SYSTEM_NAME STREQUAL "Linux" OR CMAKE_SYSTEM_NAME STREQUAL "Windows" OR CMAKE_SYSTEM_NAME STREQUAL "Android" OR CMAKE_SYSTEM_NAME STREQUAL "WASI" OR CMAKE_SYSTEM_NAME STREQUAL FreeBSD)
-  target_compile_options(_CryptoExtras PRIVATE -DCRYPTO_IN_SWIFTPM_FORCE_BUILD_API="true")
+  target_compile_options(_CryptoExtras PRIVATE -DCRYPTO_IN_SWIFTPM_FORCE_BUILD_API)
 endif()
 
 target_include_directories(_CryptoExtras PRIVATE


### PR DESCRIPTION
Remove the extra true values for the swift defines in the CryptoExtras modules CMakeLists.txt file.

### Checklist
- [X] I've run tests to see all new and existing tests pass
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [X] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

The defines don't take effect with a value. Remove the value "true" from them.

### Modifications:

Modified the CMakeLists.txt file in the CryptoExtras module.

### Result:

After the change the swift defines will hopefully be defined correctly.