### PR TITLE
Add workaround for missing multi-threaded dll support on windows clang/ASM

### DIFF
--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -346,6 +346,8 @@ target_link_libraries(CCryptoBoringSSL PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
   SwiftASN1)
 set_target_properties(CCryptoBoringSSL PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_Swift_MODULE_DIRECTORY}")
+  INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_Swift_MODULE_DIRECTORY}"
+  // Workaround for missing MultiThreadedDLL for this ASM compiler on Windows
+  $<$<PLATFORM_ID:Windows>:MSVC_RUNTIME_LIBRARY "MultiThreaded">)
 
 set_property(GLOBAL APPEND PROPERTY SWIFT_CRYPTO_EXPORTS CCryptoBoringSSL)


### PR DESCRIPTION
When building using CMake with Windows, there is an error regarding missing MultithreadedDLL support. Work around this by setting the MSVC_RUNTIME_LIBRARY on that platform to a supported option.

### Checklist
- [X] I've run tests to see all new and existing tests pass
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [X] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

I'm trying to build swift-crypto on Windows with CMake.

### Modifications:

I've modified the CMakelists.txt such that the clang can compile the assembly files on Windows.

### Result:

Hopefully, Windows builds of swift-crypto are working.