### PR TITLE
Fix CMakeLists.txt for Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ if(NOT SwiftASN1_FOUND)
   message("-- Vending swift-asn1")
   FetchContent_Declare(ASN1
     GIT_REPOSITORY https://github.com/apple/swift-asn1
-    GIT_TAG 1.1.0)
+    GIT_TAG 1.3.1)
   FetchContent_MakeAvailable(ASN1)
 endif()
 

--- a/Package.swift
+++ b/Package.swift
@@ -94,7 +94,7 @@ let package = Package(
             MANGLE_END */
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-asn1.git", from: "1.2.0")
+        // Dependencies are added below so that they can be switched between local and absolute URLs
     ],
     targets: [
         .target(
@@ -200,6 +200,13 @@ let package = Package(
     ],
     cxxLanguageStandard: .cxx14
 )
+
+// Switch between local and remote dependencies depending on an environment variable
+if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
+    .package(url: "https://github.com/apple/swift-asn1.git", from: "1.2.0")
+} else {
+    .package(path: "../swift-asn1")
+}
 
 // ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //
 for target in package.targets {

--- a/Package.swift
+++ b/Package.swift
@@ -22,6 +22,7 @@
 //
 // BoringSSL Commit: aefa5d24da34ef77ac797bdbe684734e5bd870f4
 
+import class Foundation.ProcessInfo
 import PackageDescription
 
 // To develop this on Apple platforms, set this to true
@@ -203,9 +204,13 @@ let package = Package(
 
 // Switch between local and remote dependencies depending on an environment variable
 if ProcessInfo.processInfo.environment["SWIFTCI_USE_LOCAL_DEPS"] == nil {
-    .package(url: "https://github.com/apple/swift-asn1.git", from: "1.2.0")
+    package.dependencies += [
+        .package(url: "https://github.com/apple/swift-asn1.git", from: "1.2.0"),
+    ]
 } else {
-    .package(path: "../swift-asn1")
+    package.dependencies += [
+        .package(path: "../swift-asn1"),
+    ]
 }
 
 // ---    STANDARD CROSS-REPO SETTINGS DO NOT EDIT   --- //

--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -14,6 +14,8 @@
 
 enable_language(ASM)
 
+set(CMAKE_ASM_SOURCE_FILE_EXTENSIONS s;S;asm)
+
 add_library(CCryptoBoringSSL STATIC
   "crypto/asn1/a_bitstr.cc"
   "crypto/asn1/a_bool.cc"

--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -348,7 +348,7 @@ target_link_libraries(CCryptoBoringSSL PUBLIC
 set_target_properties(CCryptoBoringSSL PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_Swift_MODULE_DIRECTORY}")
 
-// FIXME: Make this setting conditional on Windows
+## FIXME: Make this setting conditional on Windows
 set_target_property(TARGET CCryptoBoringSSL PROPERTY
   MSVC_RUNTIME_LIBRARY "MultiThreaded")
 

--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -350,6 +350,6 @@ set_target_properties(CCryptoBoringSSL PROPERTIES
 
 ## FIXME: Make this setting conditional on Windows
 set_property(TARGET CCryptoBoringSSL PROPERTY
-  MSVC_RUNTIME_LIBRARY "MultiThreaded")
+  MSVC_RUNTIME_LIBRARY "")
 
 set_property(GLOBAL APPEND PROPERTY SWIFT_CRYPTO_EXPORTS CCryptoBoringSSL)

--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -349,7 +349,7 @@ set_target_properties(CCryptoBoringSSL PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_Swift_MODULE_DIRECTORY}")
 
 ## FIXME: Make this setting conditional on Windows
-set_target_property(TARGET CCryptoBoringSSL PROPERTY
+set_property(TARGET CCryptoBoringSSL PROPERTY
   MSVC_RUNTIME_LIBRARY "MultiThreaded")
 
 set_property(GLOBAL APPEND PROPERTY SWIFT_CRYPTO_EXPORTS CCryptoBoringSSL)

--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -12,10 +12,6 @@
 ##
 ##===----------------------------------------------------------------------===##
 
-enable_language(ASM)
-
-set(CMAKE_ASM_SOURCE_FILE_EXTENSIONS s;S;asm)
-
 add_library(CCryptoBoringSSL STATIC
   "crypto/asn1/a_bitstr.cc"
   "crypto/asn1/a_bool.cc"
@@ -127,7 +123,6 @@ add_library(CCryptoBoringSSL STATIC
   "crypto/fipsmodule/bcm.cc"
   "crypto/fipsmodule/fips_shared_support.cc"
   "crypto/hpke/hpke.cc"
-  "crypto/hrss/asm/poly_rq_mul.S"
   "crypto/hrss/hrss.cc"
   "crypto/kyber/kyber.cc"
   "crypto/lhash/lhash.cc"
@@ -259,10 +254,11 @@ add_library(CCryptoBoringSSL STATIC
   "crypto/x509/x_x509.cc"
   "crypto/x509/x_x509a.cc"
   "gen/crypto/err_data.cc"
-  "third_party/fiat/asm/fiat_curve25519_adx_mul.S"
-  "third_party/fiat/asm/fiat_curve25519_adx_square.S"
-  "third_party/fiat/asm/fiat_p256_adx_mul.S"
-  "third_party/fiat/asm/fiat_p256_adx_sqr.S")
+  "$<$<NOT:$<PLATFORM_ID:Windows>>:crypto/hrss/asm/poly_rq_mul.S>"
+  "$<$<NOT:$<PLATFORM_ID:Windows>>:third_party/fiat/asm/fiat_curve25519_adx_mul.S>"
+  "$<$<NOT:$<PLATFORM_ID:Windows>>:third_party/fiat/asm/fiat_curve25519_adx_square.S>"
+  "$<$<NOT:$<PLATFORM_ID:Windows>>:third_party/fiat/asm/fiat_p256_adx_mul.S>"
+  "$<$<NOT:$<PLATFORM_ID:Windows>>:third_party/fiat/asm/fiat_p256_adx_sqr.S>")
 
 if(CMAKE_SYSTEM_NAME STREQUAL Darwin AND CMAKE_SYSTEM_PROCESSOR MATCHES "amd64|x86_64")
   target_sources(CCryptoBoringSSL PRIVATE
@@ -351,9 +347,5 @@ target_link_libraries(CCryptoBoringSSL PUBLIC
   SwiftASN1)
 set_target_properties(CCryptoBoringSSL PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_Swift_MODULE_DIRECTORY}")
-
-## FIXME: Make this setting conditional on Windows
-set_property(TARGET CCryptoBoringSSL PROPERTY
-  MSVC_RUNTIME_LIBRARY "")
 
 set_property(GLOBAL APPEND PROPERTY SWIFT_CRYPTO_EXPORTS CCryptoBoringSSL)

--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -346,8 +346,10 @@ target_link_libraries(CCryptoBoringSSL PUBLIC
   $<$<NOT:$<PLATFORM_ID:Darwin>>:Foundation>
   SwiftASN1)
 set_target_properties(CCryptoBoringSSL PROPERTIES
-  INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_Swift_MODULE_DIRECTORY}"
-  // Workaround for missing MultiThreadedDLL for the ASM compiler on Windows with clang
-  $<$<PLATFORM_ID:Windows>:MSVC_RUNTIME_LIBRARY "MultiThreaded">)
+  INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_Swift_MODULE_DIRECTORY}")
+
+// FIXME: Make this setting conditional on Windows
+set_target_property(TARGET CCryptoBoringSSL PROPERTY
+  MSVC_RUNTIME_LIBRARY "MultiThreaded")
 
 set_property(GLOBAL APPEND PROPERTY SWIFT_CRYPTO_EXPORTS CCryptoBoringSSL)

--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -12,6 +12,8 @@
 ##
 ##===----------------------------------------------------------------------===##
 
+enable_language(ASM)
+
 add_library(CCryptoBoringSSL STATIC
   "crypto/asn1/a_bitstr.cc"
   "crypto/asn1/a_bool.cc"

--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -347,7 +347,7 @@ target_link_libraries(CCryptoBoringSSL PUBLIC
   SwiftASN1)
 set_target_properties(CCryptoBoringSSL PROPERTIES
   INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/include;${CMAKE_Swift_MODULE_DIRECTORY}"
-  // Workaround for missing MultiThreadedDLL for this ASM compiler on Windows
+  // Workaround for missing MultiThreadedDLL for the ASM compiler on Windows with clang
   $<$<PLATFORM_ID:Windows>:MSVC_RUNTIME_LIBRARY "MultiThreaded">)
 
 set_property(GLOBAL APPEND PROPERTY SWIFT_CRYPTO_EXPORTS CCryptoBoringSSL)

--- a/Sources/CCryptoBoringSSLShims/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSLShims/CMakeLists.txt
@@ -13,7 +13,8 @@
 ##===----------------------------------------------------------------------===##
 
 add_library(CCryptoBoringSSLShims STATIC
-  "shims.c")
+  "shims.c"
+)
 
 target_include_directories(CCryptoBoringSSLShims PUBLIC
   include

--- a/Sources/Crypto/CMakeLists.txt
+++ b/Sources/Crypto/CMakeLists.txt
@@ -91,7 +91,8 @@ add_library(Crypto
   "Util/PrettyBytes.swift"
   "Util/SafeCompare.swift"
   "Util/SecureBytes.swift"
-  "Util/Zeroization.swift")
+  "Util/Zeroization.swift"
+)
 
 target_compile_definitions(Crypto PRIVATE
   "$<$<COMPILE_LANGUAGE:Swift>:CRYPTO_IN_SWIFTPM>")

--- a/Sources/CryptoBoringWrapper/CMakeLists.txt
+++ b/Sources/CryptoBoringWrapper/CMakeLists.txt
@@ -19,7 +19,8 @@ add_library(CryptoBoringWrapper STATIC
   "EC/EllipticCurvePoint.swift"
   "Util/ArbitraryPrecisionInteger.swift"
   "Util/FiniteFieldArithmeticContext.swift"
-  "Util/RandomBytes.swift")
+  "Util/RandomBytes.swift"
+)
 
 target_include_directories(CryptoBoringWrapper PUBLIC
   $<TARGET_PROPERTY:CCryptoBoringSSL,INCLUDE_DIRECTORIES>

--- a/Sources/_CryptoExtras/CMakeLists.txt
+++ b/Sources/_CryptoExtras/CMakeLists.txt
@@ -50,7 +50,8 @@ add_library(_CryptoExtras
   "Util/PEMDocument.swift"
   "Util/PrettyBytes.swift"
   "Util/SubjectPublicKeyInfo.swift"
-  "ZKPs/DLEQ.swift")
+  "ZKPs/DLEQ.swift"
+)
 
 target_compile_options(_CryptoExtras PRIVATE -DCRYPTO_IN_SWIFTPM)
 

--- a/scripts/update-cmake-lists.sh
+++ b/scripts/update-cmake-lists.sh
@@ -32,7 +32,7 @@ function update_cmakelists_source() {
 
     src_exts=("*.c" "*.swift" "*.cc")
     num_exts=${#src_exts[@]}
-    echo "Finding source files (" "${src_exts[@]}" ") platform independent assembly files under $src_root"
+    echo "Finding source files (" "${src_exts[@]}" ") and platform independent assembly files under $src_root"
 
     # Build file extensions argument for `find`
     declare -a exts_arg
@@ -56,7 +56,10 @@ function update_cmakelists_source() {
     fi
 
     # Wrap quotes around each filename since it might contain spaces
-    srcs=$($find -L "${src_root}" -type f \( \( "${exts_arg[@]}" \) -o \( -name "*.S" -a ! -name "*x86_64*" -a ! -name "*arm*" -a ! -name "*apple*" -a ! -name "*linux*" \) \) -printf '  "%P"\n' | LC_ALL=POSIX sort)
+    srcs=$($find -L "${src_root}" -type f \( "${exts_arg[@]}" \) -printf '  "%P"\n' | LC_ALL=POSIX sort)
+    asm_srcs=$($find -L "${src_root}" -type f \( \( -name "*.S" -a ! -name "*x86_64*" -a ! -name "*arm*" -a ! -name "*apple*" -a ! -name "*linux*" \) \) -printf '  "$<$<NOT:$<PLATFORM_ID:Windows>>:%P>"\n' | LC_ALL=POSIX sort)
+
+    srcs="$srcs"$'\n'"$asm_srcs"
     echo "$srcs"
 
     # Update list of source files in CMakeLists.txt


### PR DESCRIPTION
This change prepares swift-crypto for use on Windows with CMake and also the Package.swift for use in the Swift toolchain CI system.

### Checklist
- [X] I've run tests to see all new and existing tests pass
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [X] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

Upgrading swift-crypto from an older version requires that Windows works properly with CMake, and also SwiftPM.

### Modifications:

Modify the CMakeLists.txt files and the generator script so that it conditionally adds assembly files for non-Windows platforms. Prepare the Package.swift file for use in Swift CI pipelines, by consulting an environment to either use the absolute URL, or a prepared version of the swift-asn1 dependency.

### Result:

After this change it should be possible to build with the newest swift-crypto in the Swift CI system.