### PR TITLE
Add missing availability on ARC types

### DIFF
--- a/Sources/_CryptoExtras/ARC/ARC.swift
+++ b/Sources/_CryptoExtras/ARC/ARC.swift
@@ -16,8 +16,10 @@ import Foundation
 
 /// Anonymous Rate-Limited Credentials (ARC) using the CMZ14 MACGGM construction, as defined in
 /// https://chris-wood.github.io/draft-arc/draft-yun-cfrg-arc.html
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 enum ARC {}
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 extension ARC {
     static let domain = "ARCV1-P384"
 

--- a/Sources/_CryptoExtras/ARC/ARCCredential.swift
+++ b/Sources/_CryptoExtras/ARC/ARCCredential.swift
@@ -14,6 +14,7 @@
 import Crypto
 import Foundation
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 extension ARC {
     struct Credential<H2G: HashToGroup> {
         typealias Group = H2G.G

--- a/Sources/_CryptoExtras/ARC/ARCEncoding.swift
+++ b/Sources/_CryptoExtras/ARC/ARCEncoding.swift
@@ -15,6 +15,7 @@ import Foundation
 import Crypto
 
 typealias ARCCurve = P384
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 typealias ARCH2G = HashToCurveImpl<ARCCurve>
 
 internal func DecodeInt(value: Data) -> Int {
@@ -32,6 +33,7 @@ internal func EncodeInt(value: Int) -> Data {
     return I2OSP(value: value, outputByteCount: 4)
 }
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 extension ARC.CredentialRequest where H2G == ARCH2G {
     static let scalarCount = 5
     static let pointCount = 2
@@ -61,6 +63,7 @@ extension ARC.CredentialRequest where H2G == ARCH2G {
     }
 }
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 extension ARC.CredentialResponse where H2G == ARCH2G {
     static let scalarCount = 8
     static let pointCount = 6
@@ -104,6 +107,7 @@ extension ARC.CredentialResponse where H2G == ARCH2G {
     }
 }
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 extension ARC.Presentation where H2G == ARCH2G {
     static let scalarCount = 5
     static let pointCount = 4
@@ -142,6 +146,7 @@ extension ARC.Presentation where H2G == ARCH2G {
     }
 }
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 extension ARC.ServerPublicKey where H2G == ARCH2G {
     static let pointCount = 3
 
@@ -173,6 +178,7 @@ extension ARC.ServerPublicKey where H2G == ARCH2G {
     }
 }
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 extension Proof where H2G == ARCH2G {
     func serialize() -> Data {
         let scalarCount = self.responses.count + 1
@@ -212,6 +218,7 @@ extension Proof where H2G == ARCH2G {
 
 // Serialize a ARC credential, to save and restore client state.
 // This will only be called client-side, and never be sent over the wire.
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 extension ARC.Credential where H2G == ARCH2G {
     static let scalarCount = 1
     static let pointCount = 5

--- a/Sources/_CryptoExtras/ARC/ARCPrecredential.swift
+++ b/Sources/_CryptoExtras/ARC/ARCPrecredential.swift
@@ -14,6 +14,7 @@
 import Crypto
 import Foundation
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 extension ARC {
     struct ClientSecrets<Scalar> {
         let m1: Scalar // secret at request and verification

--- a/Sources/_CryptoExtras/ARC/ARCPresentation.swift
+++ b/Sources/_CryptoExtras/ARC/ARCPresentation.swift
@@ -14,6 +14,7 @@
 import Crypto
 import Foundation
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 extension ARC {
     /// Presentation consists of a commitment to a MACGGC evaluation over two attributes,
     /// a commitment to one of the attributes, a tag and its public inputs (presentationContext, nonce),

--- a/Sources/_CryptoExtras/ARC/ARCRequest.swift
+++ b/Sources/_CryptoExtras/ARC/ARCRequest.swift
@@ -14,6 +14,7 @@
 import Crypto
 import Foundation
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 extension ARC {
     /// CredentialRequest consists of encryptions of the two client attributes, in the form of Pedersen commitments,
     /// along with a zero-knowledge proof of the following statements:

--- a/Sources/_CryptoExtras/ARC/ARCResponse.swift
+++ b/Sources/_CryptoExtras/ARC/ARCResponse.swift
@@ -14,6 +14,7 @@
 import Crypto
 import Foundation
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 extension ARC {
     /// CredentialResponse consists of a MACGGM evaluation over a Pedersen commitment to a private attribute,
     /// along with the corresponding proof that it was calculated correctly over the expected key commitments:

--- a/Sources/_CryptoExtras/ARC/ARCServer.swift
+++ b/Sources/_CryptoExtras/ARC/ARCServer.swift
@@ -14,6 +14,7 @@
 import Crypto
 import Foundation
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 extension ARC {
     struct ServerPrivateKey<Scalar> {
         let x0: Scalar

--- a/Tests/_CryptoExtrasTests/ARC/ARCEncodingTests.swift
+++ b/Tests/_CryptoExtrasTests/ARC/ARCEncodingTests.swift
@@ -15,6 +15,7 @@
 import XCTest
 import Crypto
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 class ARCEncodingTests: XCTestCase {
     func testserverPublicKeyEncoding() throws {
         let ciphersuite = ARC.Ciphersuite(HashToCurveImpl<ARCCurve>.self)

--- a/Tests/_CryptoExtrasTests/ARC/ARCTestVectors.swift
+++ b/Tests/_CryptoExtrasTests/ARC/ARCTestVectors.swift
@@ -144,6 +144,7 @@ struct ARCTestVector: Codable {
     let Presentation2: ARCPresentationTestVector
 }
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 class ARCTestVectors: XCTestCase {
     func testVectors() throws {
         let data = ARCEncodedTestVector.data(using: .utf8)!
@@ -264,6 +265,7 @@ private func elementFromString<Curve: SupportedCurveDetailsImpl>(CurveType _: Cu
     return try GroupImpl<Curve>.Element(oprfRepresentation: Data(hexString: value))
 }
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 private func proofFromString<Curve: SupportedCurveDetailsImpl>(CurveType _: Curve.Type, value: String, scalarCount: Int) throws -> Proof<HashToCurveImpl<Curve>> {
     let scalarHexCharacterCount = Curve.orderByteCount * 2
     var startIndex = value.index(value.startIndex, offsetBy: 0)

--- a/Tests/_CryptoExtrasTests/ARC/ARCTests.swift
+++ b/Tests/_CryptoExtrasTests/ARC/ARCTests.swift
@@ -15,6 +15,7 @@ import Crypto
 @testable import _CryptoExtras
 import XCTest
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 class ARCTests: XCTestCase {
     func endToEndWorkflow<Curve: SupportedCurveDetailsImpl>(CurveType _: Curve.Type) throws {
         let ciphersuite = ARC.Ciphersuite(HashToCurveImpl<Curve>.self)

--- a/Tests/_CryptoExtrasTests/ECToolbox/HashToCurveTests.swift
+++ b/Tests/_CryptoExtrasTests/ECToolbox/HashToCurveTests.swift
@@ -34,6 +34,7 @@ struct HashToCurveTestVector: Codable {
     let msg: String
 }
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 class HashToCurveTests: XCTestCase {
 
     func testVector<C: SupportedCurveDetailsImpl>(vectorFileName file: String, with h2c: HashToCurveImpl<C>.Type) throws {

--- a/Tests/_CryptoExtrasTests/OPRFs/ECVOPRFTests.swift
+++ b/Tests/_CryptoExtrasTests/OPRFs/ECVOPRFTests.swift
@@ -50,6 +50,7 @@ enum Result: String {
     case invalidOPRFOutput = "invalidOPRFOutput"
 }
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 class ECVOPRFTests: XCTestCase {
     func testSuite<G: SupportedCurveDetailsImpl>(suite: OPRFSuite, C: G.Type, modeValue: Int, v8DraftCompatible: Bool) throws {
         switch modeValue {

--- a/Tests/_CryptoExtrasTests/ZKPs/ZKPToolbox.swift
+++ b/Tests/_CryptoExtrasTests/ZKPs/ZKPToolbox.swift
@@ -15,6 +15,7 @@ import Crypto
 @testable import _CryptoExtras
 import XCTest
 
+@available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, *)
 class ZKPToolboxTests: XCTestCase {
     typealias H2G = HashToCurveImpl<P384>
     typealias Group = H2G.G


### PR DESCRIPTION
Motivation

We should have proper availability annotations.

Modifications

Propagate the availability annotations we need.

Result

Compiles correctly on non-macOS platforms.