### PR TITLE
Update ARC API to reflect latest draft

### DIFF
--- a/Sources/_CryptoExtras/ARC/ARCCredential.swift
+++ b/Sources/_CryptoExtras/ARC/ARCCredential.swift
@@ -25,10 +25,9 @@ extension ARC {
         let ciphersuite: Ciphersuite<H2G>
         let generatorG: Group.Element
         let generatorH: Group.Element
-        let presentationLimit: Int
-        var presentationNonces: [Data: Set<Int>]
+        var presentationState: PresentationState
 
-        init(credentialResponse: CredentialResponse<H2G>, credentialRequest: CredentialRequest<H2G>, clientSecrets: ClientSecrets<Group.Scalar>, serverPublicKey: ServerPublicKey<H2G>, ciphersuite: Ciphersuite<H2G>, generatorG: Group.Element, generatorH: Group.Element,  presentationLimit: Int) throws {
+        init(credentialResponse: CredentialResponse<H2G>, credentialRequest: CredentialRequest<H2G>, clientSecrets: ClientSecrets<Group.Scalar>, serverPublicKey: ServerPublicKey<H2G>, ciphersuite: Ciphersuite<H2G>, generatorG: Group.Element, generatorH: Group.Element) throws {
             // Verify credential response proof
             guard
                 try credentialResponse.verify(request: credentialRequest, serverPublicKey: serverPublicKey, generatorG: generatorG, generatorH: generatorH)
@@ -39,48 +38,74 @@ extension ARC {
             // Decrypt Enc(U') from the credential response, to get U'
             let UPrime = credentialResponse.encUPrime - credentialResponse.X0Aux - clientSecrets.r1 * credentialResponse.X1Aux - clientSecrets.r2 * credentialResponse.X2Aux
 
-            let presentationNonces = [Data: Set<Int>]()
-            self = Self(m1: clientSecrets.m1, U: credentialResponse.U, UPrime: UPrime, X1: serverPublicKey.X1, presentationLimit: presentationLimit, presentationNonces: presentationNonces, ciphersuite: ciphersuite, generatorG: generatorG, generatorH: generatorH)
+            self = Self(m1: clientSecrets.m1, U: credentialResponse.U, UPrime: UPrime, X1: serverPublicKey.X1, ciphersuite: ciphersuite, generatorG: generatorG, generatorH: generatorH, presentationState: ARC.PresentationState())
         }
 
-        internal init(m1: Group.Scalar, U: Group.Element, UPrime: Group.Element, X1: Group.Element, presentationLimit: Int, presentationNonces: [Data: Set<Int>], ciphersuite: Ciphersuite<H2G>, generatorG: Group.Element, generatorH: Group.Element) {
+        internal init(m1: Group.Scalar, U: Group.Element, UPrime: Group.Element, X1: Group.Element, ciphersuite: Ciphersuite<H2G>, generatorG: Group.Element, generatorH: Group.Element, presentationState: PresentationState) {
             self.m1 = m1
             self.U = U
             self.UPrime = UPrime
             self.X1 = X1
-            self.presentationLimit = presentationLimit
-            self.presentationNonces = presentationNonces
             self.ciphersuite = ciphersuite
             self.generatorG = generatorG
             self.generatorH = generatorH
+            self.presentationState = presentationState
         }
 
-        mutating func makePresentation(presentationContext: Data, a: Group.Scalar = Group.Scalar.random, r: Group.Scalar = Group.Scalar.random, z: Group.Scalar = Group.Scalar.random, optionalNonce: Int? = nil) throws -> (Presentation<H2G>, Int) {
+        mutating func makePresentation(presentationContext: Data, presentationLimit: Int, a: Group.Scalar = Group.Scalar.random, r: Group.Scalar = Group.Scalar.random, z: Group.Scalar = Group.Scalar.random, optionalNonce: Int? = nil) throws -> (Presentation<H2G>, Int) {
+            let nonce = try self.presentationState.update(presentationContext: presentationContext, presentationLimit: presentationLimit, optionalNonce: optionalNonce)
+            let presentation = try Presentation<H2G>(credential: self, a: a, r: r, z: z, presentationContext: presentationContext, nonce: nonce, generatorG: self.generatorG, generatorH: self.generatorH)
+            return (presentation, nonce)
+        }
+    }
+
+    struct PresentationState {
+        typealias PresentationContext = Data
+        typealias PresentationLimit = Int
+        typealias NonceSet = Set<Int>
+        var state: [PresentationContext: (PresentationLimit, NonceSet)]
+
+        init() {
+            self.state = [PresentationContext: (PresentationLimit, NonceSet)]()
+        }
+
+        internal init(state: [PresentationContext: (PresentationLimit, NonceSet)]) {
+            self.state = state
+        }
+
+        mutating func update(presentationContext: Data, presentationLimit: Int, optionalNonce: Int? = nil) throws -> Int {
+            if presentationLimit <= 0 {
+                throw ARC.Errors.invalidPresentationLimit
+            }
             // If optionalNonce is set, use that nonce (eg for test vectors).
             // Otherwise, generate a random nonce that has not yet been used.
-            var nonce = optionalNonce != nil ? optionalNonce! : Int.random(in: 0..<self.presentationLimit)
+            var nonce = optionalNonce != nil ? optionalNonce! : Int.random(in: 0..<presentationLimit)
 
             // Store the nonce in presentationNonces for that presentationContext.
-            if self.presentationNonces[presentationContext] != nil {
-                if self.presentationNonces[presentationContext]!.count >= self.presentationLimit {
+            if self.state[presentationContext] != nil {
+                let presentationContextState = self.state[presentationContext]!
+                if presentationLimit != presentationContextState.0 {
+                    throw ARC.Errors.invalidPresentationLimit
+                }
+                if presentationContextState.1.count >= presentationLimit {
                     throw ARC.Errors.presentationLimitExceeded
                 }
-                while self.presentationNonces[presentationContext]!.contains(nonce) {
+
+                while presentationContextState.1.contains(nonce) {
                     if optionalNonce == nil {
                         // Randomly generated nonce collides with existing nonce for presentationContext
-                        nonce = Int.random(in: 0..<self.presentationLimit)
+                        nonce = Int.random(in: 0..<presentationLimit)
                     } else {
                         // optionalNonce collides with existing nonce for presentationContext
                         throw ARC.Errors.presentationLimitExceeded
                     }
                 }
-                self.presentationNonces[presentationContext]!.insert(nonce)
-            } else {
-                self.presentationNonces[presentationContext] = [nonce]
-            }
 
-            let presentation = try Presentation<H2G>(credential: self, a: a, r: r, z: z, presentationContext: presentationContext, nonce: nonce, generatorG: self.generatorG, generatorH: self.generatorH)
-            return (presentation, nonce)
+                self.state[presentationContext]!.1.insert(nonce)
+            } else {
+                self.state[presentationContext] = (presentationLimit, [nonce])
+            }
+            return nonce
         }
     }
 }

--- a/Sources/_CryptoExtras/ARC/ARCPrecredential.swift
+++ b/Sources/_CryptoExtras/ARC/ARCPrecredential.swift
@@ -38,23 +38,18 @@ extension ARC {
         let generatorG: Group.Element
         let generatorH: Group.Element
         let credentialRequest: CredentialRequest<H2G>
-        let presentationLimit: Int
 
-        init(ciphersuite: Ciphersuite<H2G>, m1: Group.Scalar = Group.Scalar.random, requestContext: Data, r1: Group.Scalar = Group.Scalar.random, r2: Group.Scalar = Group.Scalar.random, serverPublicKey: ServerPublicKey<H2G>, presentationLimit: Int) throws {
-            if presentationLimit <= 0 {
-                throw ARC.Errors.invalidPresentationLimit
-            }
+        init(ciphersuite: Ciphersuite<H2G>, m1: Group.Scalar = Group.Scalar.random, requestContext: Data, r1: Group.Scalar = Group.Scalar.random, r2: Group.Scalar = Group.Scalar.random, serverPublicKey: ServerPublicKey<H2G>) throws {
             let m2 = try H2G.hashToScalar(requestContext, domainSeparationString: Data((ARC.domain + "requestContext").utf8))
             self.clientSecrets = ClientSecrets(m1: m1, m2: m2, r1: r1, r2: r2)
             self.serverPublicKey = serverPublicKey
             self.ciphersuite = ciphersuite
             (self.generatorG, self.generatorH) = ARC.getGenerators(suite: ciphersuite)
             self.credentialRequest = try CredentialRequest(clientSecrets: self.clientSecrets, generatorG: generatorG, generatorH: generatorH)
-            self.presentationLimit = presentationLimit
         }
 
         func makeCredential(credentialResponse: CredentialResponse<H2G>) throws -> Credential<H2G> {
-            return try Credential<H2G>(credentialResponse: credentialResponse, credentialRequest: self.credentialRequest, clientSecrets: self.clientSecrets, serverPublicKey: self.serverPublicKey, ciphersuite: self.ciphersuite, generatorG: self.generatorG, generatorH: self.generatorH, presentationLimit: self.presentationLimit)
+            return try Credential<H2G>(credentialResponse: credentialResponse, credentialRequest: self.credentialRequest, clientSecrets: self.clientSecrets, serverPublicKey: self.serverPublicKey, ciphersuite: self.ciphersuite, generatorG: self.generatorG, generatorH: self.generatorH)
         }
     }
 }

--- a/Tests/_CryptoExtrasTests/ARC/ARCAPITests.swift
+++ b/Tests/_CryptoExtrasTests/ARC/ARCAPITests.swift
@@ -57,7 +57,6 @@ final class ARCAPITests: XCTestCase {
         // [Client] Prepare a credential request using fixed values from test vector.
         let precredential = try publicKey.prepareCredentialRequest(
             requestContext: requestContext,
-            presentationLimit: presentationLimit,
             m1: P384._ARCV1.H2G.G.Scalar(bytes: Data(hexString: vector.CredentialRequest.m1)),
             r1: P384._ARCV1.H2G.G.Scalar(bytes: Data(hexString: vector.CredentialRequest.r1)),
             r2: P384._ARCV1.H2G.G.Scalar(bytes: Data(hexString: vector.CredentialRequest.r2))
@@ -110,6 +109,7 @@ final class ARCAPITests: XCTestCase {
         // [Client] Make a presentation from the credential for a presentation prefix.
         let (presentation, _) = try credential.makePresentation(
             context: presentationContext,
+            presentationLimit: presentationLimit,
             fixedNonce: Int(vector.Presentation1.nonce.dropFirst(2), radix: 16)!,
             a: P384._ARCV1.H2G.G.Scalar(bytes: Data(hexString: vector.Presentation1.a)),
             r: P384._ARCV1.H2G.G.Scalar(bytes: Data(hexString: vector.Presentation1.r)),

--- a/Tests/_CryptoExtrasTests/ARC/ARCTestVectors.swift
+++ b/Tests/_CryptoExtrasTests/ARC/ARCTestVectors.swift
@@ -172,7 +172,7 @@ class ARCTestVectors: XCTestCase {
         let m2 = try scalarFromString(CurveType: Curve.self, value: tv.CredentialRequest.m2)
         let r1 = try scalarFromString(CurveType: Curve.self, value: tv.CredentialRequest.r1)
         let r2 = try scalarFromString(CurveType: Curve.self, value: tv.CredentialRequest.r2)
-        let precredential = try ARC.Precredential(ciphersuite: ciphersuite, m1: m1, requestContext: requestContext, r1: r1, r2: r2, serverPublicKey: server.serverPublicKey, presentationLimit: 2)
+        let precredential = try ARC.Precredential(ciphersuite: ciphersuite, m1: m1, requestContext: requestContext, r1: r1, r2: r2, serverPublicKey: server.serverPublicKey)
         XCTAssertEqual(precredential.credentialRequest.m1Enc.oprfRepresentation.hexString, tv.CredentialRequest.m1_enc)
         XCTAssertEqual(precredential.credentialRequest.m2Enc.oprfRepresentation.hexString, tv.CredentialRequest.m2_enc)
         XCTAssertEqual(precredential.clientSecrets.m2.rawRepresentation.hexString, tv.CredentialRequest.m2)
@@ -212,7 +212,7 @@ class ARCTestVectors: XCTestCase {
         let r_1 = try scalarFromString(CurveType: Curve.self, value: tv.Presentation1.r)
         let z_1 = try scalarFromString(CurveType: Curve.self, value: tv.Presentation1.z)
         let nonce_1 = Int(tv.Presentation1.nonce.replacingOccurrences(of: "0x", with: ""), radix: 16)!
-        let (presentation1, nonce_1_returned) = try credential.makePresentation(presentationContext: presentationContext1, a: a_1, r: r_1, z: z_1, optionalNonce: nonce_1)
+        let (presentation1, nonce_1_returned) = try credential.makePresentation(presentationContext: presentationContext1, presentationLimit: 2, a: a_1, r: r_1, z: z_1, optionalNonce: nonce_1)
         XCTAssertEqual(nonce_1, nonce_1_returned)
         XCTAssertEqual(presentation1.U.oprfRepresentation.hexString, tv.Presentation1.U)
         XCTAssertEqual(presentation1.UPrimeCommit.oprfRepresentation.hexString, tv.Presentation1.U_prime_commit)
@@ -231,7 +231,7 @@ class ARCTestVectors: XCTestCase {
         let r_2 = try scalarFromString(CurveType: Curve.self, value: tv.Presentation2.r)
         let z_2 = try scalarFromString(CurveType: Curve.self, value: tv.Presentation2.z)
         let nonce_2 = Int(tv.Presentation2.nonce.replacingOccurrences(of: "0x", with: ""), radix: 16)!
-        let (presentation2, nonce_2_returned) = try credential.makePresentation(presentationContext: presentationContext1, a: a_2, r: r_2, z: z_2, optionalNonce: nonce_2)
+        let (presentation2, nonce_2_returned) = try credential.makePresentation(presentationContext: presentationContext1, presentationLimit: 2, a: a_2, r: r_2, z: z_2, optionalNonce: nonce_2)
         XCTAssertEqual(nonce_2, nonce_2_returned)
         XCTAssertEqual(presentation2.U.oprfRepresentation.hexString, tv.Presentation2.U)
         XCTAssertEqual(presentation2.UPrimeCommit.oprfRepresentation.hexString, tv.Presentation2.U_prime_commit)


### PR DESCRIPTION
### Motivation

The latest draft of the ARC spec[0] includes moving where the presentation limit is used. Before it was baked in when a client constructed a credential request, but now it has moved to when a client makes a presentation from a finalized credential. This PR updates the internals and API surface to reflect this change.

### Modifications

- Defer passing the presentation limit until a presentation is made.

### Result

Align more closely with the published draft.

### API breakage

It's expected that this will result in an _breaking_ API changes:

```diff
- P384._ARCV1.PublicKey.prepareCredentialRequest(requestContext:presentationLimit:)
+ P384._ARCV1.PublicKey.prepareCredentialRequest(requestContext:)
```

```diff
- P384._ARCV1.Credential.makePresentation(context:)
+ P384._ARCV1.Credential.makePresentation(context:presentationLimit:)
```

As this is behind an underscored namespace, we deem this an acceptable break.

[0]: https://datatracker.ietf.org/doc/draft-yun-cfrg-arc/