### PR TITLE
Use more efficient serialization and deserialization for ARC types

### DIFF
--- a/Sources/_CryptoExtras/Util/IntegerEncoding.swift
+++ b/Sources/_CryptoExtras/Util/IntegerEncoding.swift
@@ -1,0 +1,88 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Foundation
+
+enum IntegerDecodingError: Error, Equatable {
+    case incorrectNumberOfBytes(expected: Int, actual: Int)
+}
+
+extension FixedWidthInteger {
+    /// Create an new value from a collection of its big endian bytes.
+    ///
+    /// - Parameter bytes: Big endian bytes.
+    ///
+    /// - Throws: A decoding error if the collection did not contain the exact number of bytes.
+    init(bigEndianBytes bytes: some Collection<UInt8>) throws {
+        guard bytes.count == Self.bitWidth / 8 else {
+            throw IntegerDecodingError.incorrectNumberOfBytes(expected: Self.bitWidth / 8, actual: bytes.count)
+        }
+
+        self = 0
+        var index = bytes.startIndex
+        for _ in 0..<(Self.bitWidth / 8) {
+            self <<= 8
+            self |= Self(bytes[index])
+            bytes.formIndex(after: &index)
+        }
+    }
+
+    fileprivate init(bigEndianContiguousBytes bytes: some ContiguousBytes) throws {
+        self = try bytes.withUnsafeBytes { try Self(bigEndianBytes: $0 ) }
+    }
+
+    /// Create an new value from its big endian bytes representation.
+    ///
+    /// - Parameter bytes: Big endian bytes.
+    ///
+    /// - Throws: A decoding error if the collection did not contain the exact number of bytes.
+    init(bigEndianBytes bytes: Data) throws {
+        self = try Self(bigEndianContiguousBytes: bytes)
+    }
+
+    /// The big endian bytes that represent this value.
+    var bigEndianBytes: Data { Data(bigEndianBytesOf: self) }
+}
+
+extension Data {
+    /// Creates a new instance initialized with the big endian bytes representation of the given integer.
+    init(bigEndianBytesOf integer: some FixedWidthInteger) {
+        self.init()
+        self.append(bigEndianBytesOf: integer)
+    }
+
+    /// Appends the big endian bytes of the given integer.
+    mutating func append<T: FixedWidthInteger>(bigEndianBytesOf integer: T) {
+        let previousCount = self.count
+        let newCount = previousCount + T.bitWidth / 8
+        self.reserveCapacity(newCount)
+        self.count = newCount
+        self.withUnsafeMutableBytes {
+            $0.storeBytes(of: integer.bigEndian, toByteOffset: previousCount, as: T.self)
+        }
+    }
+
+    /// Removes and returns the first k bytes.
+    mutating func popFirst(_ k: Int) -> Self {
+        let prefix = self.prefix(k)
+        self.removeFirst(k)
+        return prefix
+    }
+
+    /// Removes and returns the first k bytes, decoded as a value of the given type from its big endian bytes.
+    mutating func popFirst<T: FixedWidthInteger>(bigEndian: T.Type) throws -> T {
+        let value = try T(bigEndianBytes: self.prefix(T.bitWidth / 8))
+        self.removeFirst(T.bitWidth / 8)
+        return value
+    }
+}

--- a/Tests/_CryptoExtrasTests/Util/IntegerEncodingTests.swift
+++ b/Tests/_CryptoExtrasTests/Util/IntegerEncodingTests.swift
@@ -1,0 +1,153 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2024 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+@testable import _CryptoExtras
+import XCTest
+
+final class IntegerEncodingTests: XCTestCase {
+    func testIntegerDecoding() throws {
+        func test<T: FixedWidthInteger>(
+            decoding bytes: [UInt8],
+            as: T.Type,
+            expect expectedResult: Swift.Result<T, IntegerDecodingError>,
+            file: StaticString = #filePath, line: UInt = #line
+        ) {
+            let actualResult = Swift.Result { try T(bigEndianBytes: bytes) }
+            switch (actualResult, expectedResult) {
+            case (.success(let actual), .success(let expected)):
+                XCTAssertEqual(actual, expected, file: file, line: line)
+            case (.success(let actual), .failure(let error)):
+                XCTFail("Expected error: \(error), got \(actual)", file: file, line: line)
+            case (.failure(let error), .success(let expected)):
+                XCTFail("Decode failed; expected: \(expected), got error: \(error)", file: file, line: line)
+            case (.failure(let actualError), .failure(let expectedError)):
+                guard let typedError = actualError as? IntegerDecodingError else {
+                    XCTFail("Expected error but not this one: \(actualError)", file: file, line: line)
+                    return
+                }
+                XCTAssertEqual(typedError, expectedError, file: file, line: line)
+            }
+        }
+
+        test(decoding: [0,0], as: UInt16.self, expect: .success(0))
+        test(decoding: [0,1], as: UInt16.self, expect: .success(1))
+        test(decoding: [1,0], as: UInt16.self, expect: .success(256))
+        test(decoding: [1,1], as: UInt16.self, expect: .success(257))
+        test(decoding: [0xff,0xff], as: UInt16.self, expect: .success(UInt16.max))
+
+        test(decoding: [], as: UInt16.self, expect: .failure(.incorrectNumberOfBytes(expected: 2, actual: 0)))
+        test(decoding: [0], as: UInt16.self, expect: .failure(.incorrectNumberOfBytes(expected: 2, actual: 1)))
+        test(decoding: [0,0,0], as: UInt16.self, expect: .failure(.incorrectNumberOfBytes(expected: 2, actual: 3)))
+        test(decoding: [0,0,0,0], as: UInt16.self, expect: .failure(.incorrectNumberOfBytes(expected: 2, actual: 4)))
+
+        test(decoding: [0,0], as: Int16.self, expect: .success(0))
+        test(decoding: [0,1], as: Int16.self, expect: .success(1))
+        test(decoding: [1,0], as: Int16.self, expect: .success(256))
+        test(decoding: [1,1], as: Int16.self, expect: .success(257))
+        test(decoding: [0xff,0xff], as: Int16.self, expect: .success(-1))
+        test(decoding: [0x80,0x00], as: Int16.self, expect: .success(Int16.min))
+        test(decoding: [0x7f,0xff], as: Int16.self, expect: .success(Int16.max))
+
+        test(decoding: [], as: Int16.self, expect: .failure(.incorrectNumberOfBytes(expected: 2, actual: 0)))
+        test(decoding: [0], as: Int16.self, expect: .failure(.incorrectNumberOfBytes(expected: 2, actual: 1)))
+        test(decoding: [0,0,0], as: Int16.self, expect: .failure(.incorrectNumberOfBytes(expected: 2, actual: 3)))
+        test(decoding: [0,0,0,0], as: Int16.self, expect: .failure(.incorrectNumberOfBytes(expected: 2, actual: 4)))
+    }
+
+    func testIntegerEncoding() throws {
+        func test<T: FixedWidthInteger>(encoding value: T, expect bytes: [UInt8], file: StaticString = #filePath, line: UInt = #line) {
+            XCTAssertEqual(value.bigEndianBytes, Data(bytes), file: file, line: line)
+        }
+
+        test(encoding: UInt16.zero, expect: [0,0])
+        test(encoding: UInt16(1), expect: [0,1])
+        test(encoding: UInt16(256), expect: [1,0])
+        test(encoding: UInt16(257), expect: [1,1])
+        test(encoding: UInt16.max, expect: [0xff,0xff])
+
+        test(encoding: Int16.zero, expect: [0,0])
+        test(encoding: Int16(1), expect: [0,1])
+        test(encoding: Int16(256), expect: [1,0])
+        test(encoding: Int16(257), expect: [1,1])
+        test(encoding: Int16(-1), expect: [0xff,0xff])
+        test(encoding: Int16.min, expect: [0x80,0x00])
+        test(encoding: Int16.max, expect: [0x7f,0xff])
+    }
+
+    func testIntegerEncodingDataAppend() throws {
+        var bytes = Data()
+
+        bytes.append(bigEndianBytesOf: Int32(1))
+        bytes.append(bigEndianBytesOf: Int16(2))
+        bytes.append(bigEndianBytesOf: Int8(3))
+        bytes.append(bigEndianBytesOf: Int64(4))
+
+        XCTAssertEqual(bytes.hexString, Data([0,0,0,1] + [0,2] + [3] + [0,0,0,0,0,0,0,4]).hexString)
+    }
+
+    func testIntegerDecodingFromDataSubsequence() throws {
+        let data = Data([0,0,0,1] + [0,2] + [3] + [0,0,0,0,0,0,0,4])
+
+        var bytes = data[...]
+
+        XCTAssertEqual(bytes.count, 15)
+
+        XCTAssertEqual(try Int32(bigEndianBytes: bytes[..<bytes.startIndex.advanced(by: 4)]), 1)
+        bytes.removeFirst(4)
+
+        XCTAssertEqual(try Int16(bigEndianBytes: bytes[..<bytes.startIndex.advanced(by: 2)]), 2)
+        bytes.removeFirst(2)
+
+        XCTAssertEqual(try Int8(bigEndianBytes: bytes[..<bytes.startIndex.advanced(by: 1)]), 3)
+        bytes.removeFirst(1)
+
+        XCTAssertEqual(try Int64(bigEndianBytes: bytes[..<bytes.startIndex.advanced(by: 8)]), 4)
+        bytes.removeFirst(8)
+
+        XCTAssert(bytes.isEmpty)
+    }
+
+    func testIntegerDecodingUsingDataPopFirstK() throws {
+        var bytes = Data([0,0,0,1] + [0,2] + [3] + [0,0,0,0,0,0,0,4])
+
+        XCTAssertEqual(bytes.count, 15)
+
+        XCTAssertEqual(try Int32(bigEndianBytes: bytes.popFirst(4)), 1)
+        XCTAssertEqual(try Int16(bigEndianBytes: bytes.popFirst(2)), 2)
+        XCTAssertEqual(try Int8(bigEndianBytes: bytes.popFirst(1)), 3)
+        XCTAssertEqual(try Int64(bigEndianBytes: bytes.popFirst(8)), 4)
+
+        XCTAssert(bytes.isEmpty)
+    }
+
+    func testIntegerDecodingUsingDataPopFirst() throws {
+        var bytes = Data([0,0,0,1] + [0,2] + [3] + [0,0,0,0,0,0,0,4])
+
+        XCTAssertEqual(bytes.count, 15)
+
+        XCTAssertEqual(try bytes.popFirst(bigEndian: Int32.self), 1)
+        XCTAssertEqual(try bytes.popFirst(bigEndian: Int16.self), 2)
+        XCTAssertEqual(try bytes.popFirst(bigEndian: Int8.self), 3)
+        XCTAssertEqual(try bytes.popFirst(bigEndian: Int64.self), 4)
+
+        XCTAssert(bytes.isEmpty)
+    }
+
+    func testIntegerDecodingUsingDataPopFirstTooFewBytes() throws {
+        var bytes = Data([0])
+
+        XCTAssertThrowsError(try bytes.popFirst(bigEndian: Int16.self))
+        XCTAssertThrowsError(try bytes.popFirst(bigEndian: Int32.self))
+        XCTAssertThrowsError(try bytes.popFirst(bigEndian: Int64.self))
+    }
+}


### PR DESCRIPTION
### Motivation

The use of `Data.subdata(in:)` results in needless copies when decoding fields from bytes. Additionally, the use of a long chain of `Data.append(_:)` without a call to `Data.init(capacity:)` or `Data.reserveCapacity(_:)` can result in needless reallocations.

### Modifications

- Remove unused `EncodeInt` and `DecodeInt` functions. They were unused before this PR but are there from when ARC credential serialization included the presentation limit. `DecodeInt` also happened to be incorrect and would crash when called with a slice.
- Add some useful utility methods for popping bytes from a view without copying.
- Add some generic functions for encoding and decoding `FixedWidthInteger` types along with tests for concrete types over `Data` and slices.
- In ARC decoding, replace the use of `Data.subdata(in:)` with code that uses the `Data.Subsequence` slice (which happens to be `Data` since the type is self-slicing).
- In ARC encoding, reserve enough capacity in the resulting `Data` when the sizes are known to reduce allocations.

## Results

More performant serialization and deserialization for ARC types.