### PR TITLE
Add missing availability guards required when development mode enabled

### DIFF
--- a/Sources/Crypto/ASN1/ASN1.swift
+++ b/Sources/Crypto/ASN1/ASN1.swift
@@ -127,6 +127,7 @@ extension ASN1 {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension ASN1.ASN1ParserNode: Hashable { }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
@@ -335,6 +336,7 @@ extension ASN1 {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension ASN1.ASN1ParseResult: Hashable { }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1BitString.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1BitString.swift
@@ -58,6 +58,7 @@ extension ASN1 {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension ASN1.ASN1BitString: Hashable { }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Identifier.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Identifier.swift
@@ -138,6 +138,7 @@ extension ASN1.ASN1Identifier {
     internal static let generalizedTime = try! ASN1.ASN1Identifier(rawIdentifier: 0x18)
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension ASN1.ASN1Identifier: Hashable { }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Integer.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Integer.swift
@@ -170,6 +170,7 @@ extension IntegerBytesCollection: RandomAccessCollection {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension IntegerBytesCollection.Index: Equatable { }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1OctetString.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1OctetString.swift
@@ -51,6 +51,7 @@ extension ASN1 {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension ASN1.ASN1OctetString: Hashable { }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ObjectIdentifier.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ObjectIdentifier.swift
@@ -133,6 +133,7 @@ extension ASN1 {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension ASN1.ASN1ObjectIdentifier: Hashable {}
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)

--- a/Sources/Crypto/CryptoKitErrors.swift
+++ b/Sources/Crypto/CryptoKitErrors.swift
@@ -34,6 +34,7 @@ public enum CryptoKitError: Error {
     case invalidParameter
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension CryptoKitError: Equatable, Hashable {}
 
 /// Errors from decoding ASN.1 content.

--- a/Sources/Crypto/HPKE/Ciphersuite/KEM/Conformances/HPKE-KEM-Curve25519.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/KEM/Conformances/HPKE-KEM-Curve25519.swift
@@ -16,6 +16,7 @@
 #else
 import Foundation
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension Curve25519.KeyAgreement.PrivateKey: HPKEDiffieHellmanPrivateKeyGeneration {}
 
 

--- a/Sources/Crypto/Signatures/ECDSA.swift
+++ b/Sources/Crypto/Signatures/ECDSA.swift
@@ -131,6 +131,7 @@ extension P256.Signing {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P256.Signing: NISTSigning {}
 
 // MARK: - P256 + PrivateKey
@@ -300,6 +301,7 @@ extension P384.Signing {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P384.Signing: NISTSigning {}
 
 // MARK: - P384 + PrivateKey
@@ -469,6 +471,7 @@ extension P521.Signing {
     }
 }
 
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension P521.Signing: NISTSigning {}
 
 // MARK: - P521 + PrivateKey

--- a/Sources/Crypto/Util/SecureBytes.swift
+++ b/Sources/Crypto/Util/SecureBytes.swift
@@ -144,9 +144,11 @@ extension SecureBytes: BidirectionalCollection {
 }
 
 // MARK: - RandomAccessCollection conformance
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension SecureBytes: RandomAccessCollection { }
 
 // MARK: - MutableCollection conformance
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension SecureBytes: MutableCollection { }
 
 // MARK: - RangeReplaceableCollection conformance
@@ -224,9 +226,11 @@ extension SecureBytes: DataProtocol {
 }
 
 // MARK: - MutableDataProtocol conformance
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension SecureBytes: MutableDataProtocol { }
 
 // MARK: - Index conformances
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension SecureBytes.Index: Hashable { }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)


### PR DESCRIPTION
### Motivation

When developing code that uses the BoringSSL backend on macOS, developers set a `development` boolean flag in the Package.swift. We recently switched from declaring minimum platform versions to annotating symbols with availability annotations. However, when `development = true`, it flushes out some annotations that were missing in the first pass. The result is that `main` currently doesn't build on macOS with this flag set.

### Modifications

- Add missing availability guards required when development mode enabled.

### Result:

Code builds macOS with `development = true` in Package.swift.