### PR TITLE
perf: Add benchmarks and reduce allocations by ~50% for ARC and VOPRF

### DIFF
--- a/Benchmarks/Benchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/Benchmarks.swift
@@ -1,0 +1,102 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Benchmark
+import Crypto
+import Foundation
+import _CryptoExtras
+
+let benchmarks = {
+    let defaultMetrics: [BenchmarkMetric] = [.mallocCountTotal, .cpuTotal]
+
+    Benchmark(
+        "arc-issue-p384",
+        configuration: Benchmark.Configuration(
+            metrics: defaultMetrics,
+            scalingFactor: .kilo,
+            maxDuration: .seconds(10_000_000),
+            maxIterations: 3
+        )
+    ) { benchmark in
+        let privateKey = P384._ARCV1.PrivateKey()
+        let publicKey = privateKey.publicKey
+        let requestContext = Data("shared request context".utf8)
+        let precredential = try publicKey.prepareCredentialRequest(requestContext: requestContext)
+        let credentialRequest = precredential.credentialRequest
+
+        benchmark.startMeasurement()
+
+        for _ in benchmark.scaledIterations {
+            blackHole(try privateKey.issue(credentialRequest))
+        }
+    }
+
+    Benchmark(
+        "arc-verify-p384",
+        configuration: Benchmark.Configuration(
+            metrics: defaultMetrics,
+            scalingFactor: .kilo,
+            maxDuration: .seconds(10_000_000),
+            maxIterations: 10
+        )
+    ) { benchmark in
+        let privateKey = P384._ARCV1.PrivateKey()
+        let publicKey = privateKey.publicKey
+        let requestContext = Data("shared request context".utf8)
+        let (presentationContext, presentationLimit) = (Data("shared presentation context".utf8), 2)
+        let precredential = try publicKey.prepareCredentialRequest(requestContext: requestContext)
+        let credentialRequest = precredential.credentialRequest
+        let credentialResponse = try privateKey.issue(credentialRequest)
+        var credential = try publicKey.finalize(credentialResponse, for: precredential)
+        let (presentation, nonce) = try credential.makePresentation(
+            context: presentationContext,
+            presentationLimit: presentationLimit
+        )
+
+        benchmark.startMeasurement()
+
+        for _ in benchmark.scaledIterations {
+            blackHole(
+                try privateKey.verify(
+                    presentation,
+                    requestContext: requestContext,
+                    presentationContext: presentationContext,
+                    presentationLimit: presentationLimit,
+                    nonce: nonce
+                )
+            )
+        }
+    }
+
+    Benchmark(
+        "voprf-evaluate-p384",
+        configuration: Benchmark.Configuration(
+            metrics: defaultMetrics,
+            scalingFactor: .kilo,
+            maxDuration: .seconds(10_000_000),
+            maxIterations: 3
+        )
+    ) { benchmark in
+        let privateKey = P384._VOPRF.PrivateKey()
+        let publicKey = privateKey.publicKey
+        let privateInput = Data("This is some input data".utf8)
+        let blindedInput = try publicKey.blind(privateInput)
+        let blindedElement = blindedInput.blindedElement
+
+        benchmark.startMeasurement()
+
+        for _ in benchmark.scaledIterations {
+            blackHole(try privateKey.evaluate(blindedElement))
+        }
+    }
+}

--- a/Benchmarks/Package.swift
+++ b/Benchmarks/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+    name: "swift-crypto-benchmarks",
+    platforms: [.macOS("14")],
+    dependencies: [
+        .package(name: "swift-crypto", path: "../"),
+        .package(url: "https://github.com/ordo-one/package-benchmark", from: "1.22.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "SwiftCryptoBenchmarks",
+            dependencies: [
+                .product(name: "Benchmark", package: "package-benchmark"),
+                .product(name: "Crypto", package: "swift-crypto"),
+                .product(name: "_CryptoExtras", package: "swift-crypto"),
+            ],
+            path: "Benchmarks/",
+            plugins: [
+                .plugin(name: "BenchmarkPlugin", package: "package-benchmark")
+            ]
+        )
+    ]
+)

--- a/Sources/CryptoBoringWrapper/EC/EllipticCurvePoint.swift
+++ b/Sources/CryptoBoringWrapper/EC/EllipticCurvePoint.swift
@@ -115,12 +115,16 @@ package final class EllipticCurvePoint {
     }
 
     @usableFromInline
-    package func multiplying(
+    package consuming func multiplying(
         by rhs: ArbitraryPrecisionInteger,
         on group: BoringSSLEllipticCurveGroup,
         context: FiniteFieldArithmeticContext? = nil
     ) throws -> EllipticCurvePoint {
-        try EllipticCurvePoint(multiplying: self, by: rhs, on: group, context: context)
+        guard isKnownUniquelyReferenced(&self) else {
+            return try EllipticCurvePoint(multiplying: self, by: rhs, on: group, context: context)
+        }
+        try self.multiply(by: rhs, on: group, context: context)
+        return self
     }
 
     @usableFromInline
@@ -162,12 +166,16 @@ package final class EllipticCurvePoint {
     }
 
     @usableFromInline
-    package func adding(
-        _ rhs: EllipticCurvePoint,
+    package consuming func adding(
+        _ rhs: consuming EllipticCurvePoint,
         on group: BoringSSLEllipticCurveGroup,
         context: FiniteFieldArithmeticContext? = nil
     ) throws -> EllipticCurvePoint {
-        try EllipticCurvePoint(adding: self, rhs, on: group, context: context)
+        guard isKnownUniquelyReferenced(&self) else {
+            return try EllipticCurvePoint(adding: self, rhs, on: group, context: context)
+        }
+        try self.add(rhs, on: group, context: context)
+        return self
     }
 
     @usableFromInline
@@ -239,12 +247,16 @@ package final class EllipticCurvePoint {
     }
 
     @usableFromInline
-    package func subtracting(
-        _ rhs: EllipticCurvePoint,
+    package consuming func subtracting(
+        _ rhs: consuming EllipticCurvePoint,
         on group: BoringSSLEllipticCurveGroup,
         context: FiniteFieldArithmeticContext? = nil
     ) throws -> EllipticCurvePoint {
-        try EllipticCurvePoint(subtracting: rhs, from: self, on: group, context: context)
+        guard isKnownUniquelyReferenced(&self) else {
+            return try EllipticCurvePoint(subtracting: rhs, from: self, on: group, context: context)
+        }
+        try self.subtract(rhs, on: group, context: context)
+        return self
     }
 
     @usableFromInline

--- a/Sources/CryptoBoringWrapper/EC/EllipticCurvePoint.swift
+++ b/Sources/CryptoBoringWrapper/EC/EllipticCurvePoint.swift
@@ -54,6 +54,17 @@ package final class EllipticCurvePoint {
     }
 
     @usableFromInline
+    package init(_generatorOf groupPtr: OpaquePointer) throws {
+        guard
+            let generatorPtr = CCryptoBoringSSL_EC_GROUP_get0_generator(groupPtr),
+            let pointPtr = CCryptoBoringSSL_EC_POINT_dup(generatorPtr, groupPtr)
+        else {
+            throw CryptoBoringWrapperError.internalBoringSSLError()
+        }
+        self._basePoint = pointPtr
+    }
+
+    @usableFromInline
     package convenience init(
         multiplying scalar: ArbitraryPrecisionInteger,
         on group: BoringSSLEllipticCurveGroup

--- a/Sources/CryptoBoringWrapper/Util/FiniteFieldArithmeticContext.swift
+++ b/Sources/CryptoBoringWrapper/Util/FiniteFieldArithmeticContext.swift
@@ -32,7 +32,7 @@ import Foundation
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 package class FiniteFieldArithmeticContext {
     private var fieldSize: ArbitraryPrecisionInteger
-    private var bnCtx: OpaquePointer
+    package var bnCtx: OpaquePointer
 
     @usableFromInline
     package init(fieldSize: ArbitraryPrecisionInteger) throws {

--- a/Sources/_CryptoExtras/CMakeLists.txt
+++ b/Sources/_CryptoExtras/CMakeLists.txt
@@ -53,6 +53,7 @@ add_library(_CryptoExtras
   "RSA/RSA_security.swift"
   "Util/BoringSSLHelpers.swift"
   "Util/CryptoKitErrors_boring.swift"
+  "Util/Data+Extensions.swift"
   "Util/DigestType.swift"
   "Util/Error.swift"
   "Util/I2OSP.swift"

--- a/Sources/_CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
+++ b/Sources/_CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
@@ -215,12 +215,12 @@ struct OpenSSLCurvePoint<C: OpenSSLSupportedNISTCurve>: GroupElement {
         return Self(ecPoint: point)
     }
 
-    static func + (left: Self, right: Self) -> Self {
+    static func + (left: consuming Self, right: consuming Self) -> Self {
         // Force-try: Protocol requires non-throwing.
         try! Self(ecPoint: left.ecPoint.adding(right.ecPoint, on: C.group, context: C.__ffac))
     }
 
-    static func - (left: Self, right: Self) -> Self {
+    static func - (left: consuming Self, right: consuming Self) -> Self {
         // Force-try: Protocol requires non-throwing.
         try! Self(ecPoint: left.ecPoint.subtracting(right.ecPoint, on: C.group, context: C.__ffac))
     }
@@ -230,7 +230,7 @@ struct OpenSSLCurvePoint<C: OpenSSLSupportedNISTCurve>: GroupElement {
         try! Self(ecPoint: left.ecPoint.inverting(on: C.group, context: C.__ffac))
     }
 
-    static func * (left: Scalar, right: Self) -> Self {
+    static func * (left: consuming Scalar, right: consuming Self) -> Self {
         // Force-try: Protocol requires non-throwing.
         try! Self(ecPoint: right.ecPoint.multiplying(by: left.openSSLScalar, on: C.group, context: C.__ffac))
     }

--- a/Sources/_CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
+++ b/Sources/_CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
@@ -39,6 +39,9 @@ protocol OpenSSLSupportedNISTCurve {
     // TODO: could this be moved to the group or to the HashFunction?
     @inlinable
     static var hashToFieldByteCount: Int { get }
+
+    @inlinable
+    static var __ffac: FiniteFieldArithmeticContext { get }
 }
 
 /// NOTE: This conformance applies to this type from the Crypto module even if it comes from the SDK.
@@ -61,6 +64,11 @@ extension P256: OpenSSLSupportedNISTCurve {
 
     @inlinable
     static var hashToFieldByteCount: Int { 48 }
+
+    @TaskLocal
+    @usableFromInline
+    // NOTE: This could be a let when Swift 6.0 is the minimum supported version.
+    static var __ffac = try! FiniteFieldArithmeticContext(fieldSize: P256.group.order)
 }
 
 /// NOTE: This conformance applies to this type from the Crypto module even if it comes from the SDK.
@@ -83,6 +91,11 @@ extension P384: OpenSSLSupportedNISTCurve {
 
     @inlinable
     static var hashToFieldByteCount: Int { 72 }
+
+    @TaskLocal
+    @usableFromInline
+    // NOTE: This could be a let when Swift 6.0 is the minimum supported version.
+    static var __ffac = try! FiniteFieldArithmeticContext(fieldSize: P384.group.order)
 }
 
 /// NOTE: This conformance applies to this type from the Crypto module even if it comes from the SDK.
@@ -105,6 +118,11 @@ extension P521: OpenSSLSupportedNISTCurve {
 
     @inlinable
     static var hashToFieldByteCount: Int { 98 }
+
+    @TaskLocal
+    @usableFromInline
+    // NOTE: This could be a let when Swift 6.0 is the minimum supported version.
+    static var __ffac = try! FiniteFieldArithmeticContext(fieldSize: P521.group.order)
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
@@ -126,7 +144,7 @@ struct OpenSSLGroupScalar<C: OpenSSLSupportedNISTCurve>: GroupScalar, CustomStri
                 try ArbitraryPrecisionInteger(bytes: bytes).modulo(C.group.weierstrassCoefficients.field)
             )
         } else {
-            self.init(try ArbitraryPrecisionInteger(bytes: bytes).modulo(C.group.order))
+            self.init(try C.__ffac.residue(ArbitraryPrecisionInteger(bytes: bytes)))
         }
     }
 
@@ -137,28 +155,29 @@ struct OpenSSLGroupScalar<C: OpenSSLSupportedNISTCurve>: GroupScalar, CustomStri
 
     static func + (left: Self, right: Self) -> Self {
         // Force-try: Protocol requires non-throwing and this can only throw if modulus is invalid.
-        try! Self(left.openSSLScalar.add(right.openSSLScalar, modulo: C.group.order))
+        try! Self(C.__ffac.add(left.openSSLScalar, right.openSSLScalar))
+
     }
 
     static func - (left: Self, right: Self) -> Self {
         // Force-try: Protocol requires non-throwing and this can only throw if modulus is invalid.
-        try! Self(left.openSSLScalar.sub(right.openSSLScalar, modulo: C.group.order))
+        try! Self(C.__ffac.subtract(right.openSSLScalar, from: left.openSSLScalar))
     }
 
     static func ^ (left: Self, right: Int) -> Self {
         precondition(right == -1, "Unimplemented arbitrary exponentiation")
         // Force-try: Protocol requires non-throwing and this can only throw if modulus is invalid.
-        return try! Self(left.openSSLScalar.inverse(modulo: C.group.order))
+        return try! Self(C.__ffac.inverse(left.openSSLScalar)!)
     }
 
     static func * (left: Self, right: Self) -> Self {
         // Force-try: Protocol requires non-throwing and this can only throw if modulus is invalid.
-        try! Self(left.openSSLScalar.mul(right.openSSLScalar, modulo: C.group.order))
+        try! Self(C.__ffac.multiply(left.openSSLScalar, right.openSSLScalar))
     }
 
     static prefix func - (left: Self) -> Self {
         // Force-try: Protocol requires non-throwing and this can only throw if modulus is invalid.
-        try! Self(.zero.sub(left.openSSLScalar, modulo: C.group.order))
+        try! Self(C.__ffac.subtract(left.openSSLScalar, from: ArbitraryPrecisionInteger.zero))
     }
 
     static func == (left: Self, right: Self) -> Bool {
@@ -198,40 +217,40 @@ struct OpenSSLCurvePoint<C: OpenSSLSupportedNISTCurve>: GroupElement {
 
     static func + (left: Self, right: Self) -> Self {
         // Force-try: Protocol requires non-throwing.
-        try! Self(ecPoint: left.ecPoint.adding(right.ecPoint, on: C.group))
+        try! Self(ecPoint: left.ecPoint.adding(right.ecPoint, on: C.group, context: C.__ffac))
     }
 
     static func - (left: Self, right: Self) -> Self {
         // Force-try: Protocol requires non-throwing.
-        try! Self(ecPoint: left.ecPoint.subtracting(right.ecPoint, on: C.group))
+        try! Self(ecPoint: left.ecPoint.subtracting(right.ecPoint, on: C.group, context: C.__ffac))
     }
 
     static prefix func - (left: Self) -> Self {
         // Force-try: Protocol requires non-throwing.
-        try! Self(ecPoint: left.ecPoint.inverting(on: C.group))
+        try! Self(ecPoint: left.ecPoint.inverting(on: C.group, context: C.__ffac))
     }
 
     static func * (left: Scalar, right: Self) -> Self {
         // Force-try: Protocol requires non-throwing.
-        try! Self(ecPoint: .multiplying(right.ecPoint, by: left.openSSLScalar, on: C.group))
+        try! Self(ecPoint: right.ecPoint.multiplying(by: left.openSSLScalar, on: C.group, context: C.__ffac))
     }
 
     static func == (left: Self, right: Self) -> Bool {
-        left.ecPoint.isEqual(to: right.ecPoint, on: C.group)
+        left.ecPoint.isEqual(to: right.ecPoint, on: C.group, context: C.__ffac)
     }
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OpenSSLCurvePoint {
     var compressedRepresentation: Data {
-        try! self.ecPoint.x962Representation(compressed: true, on: C.group)
+        try! self.ecPoint.x962Representation(compressed: true, on: C.group, context: C.__ffac)
     }
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, *)
 extension OpenSSLCurvePoint: OPRFGroupElement {
     init(oprfRepresentation data: Data) throws {
-        let point = try EllipticCurvePoint(x962Representation: data, on: C.group)
+        let point = try EllipticCurvePoint(x962Representation: data, on: C.group, context: C.__ffac)
         self.init(ecPoint: point)
     }
 

--- a/Sources/_CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
+++ b/Sources/_CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
@@ -47,8 +47,8 @@ extension P256: OpenSSLSupportedNISTCurve {
     @usableFromInline
     typealias H = SHA256
 
-    @inlinable
-    static var group: BoringSSLEllipticCurveGroup { try! BoringSSLEllipticCurveGroup(.p256) }
+    @usableFromInline
+    static let group: BoringSSLEllipticCurveGroup = try! BoringSSLEllipticCurveGroup(.p256)
 
     @inlinable
     static var cofactor: Int { 1 }
@@ -69,8 +69,8 @@ extension P384: OpenSSLSupportedNISTCurve {
     @usableFromInline
     typealias H = SHA384
 
-    @inlinable
-    static var group: BoringSSLEllipticCurveGroup { try! BoringSSLEllipticCurveGroup(.p384) }
+    @usableFromInline
+    static let group: BoringSSLEllipticCurveGroup = try! BoringSSLEllipticCurveGroup(.p384)
 
     @inlinable
     static var cofactor: Int { 1 }
@@ -91,8 +91,8 @@ extension P521: OpenSSLSupportedNISTCurve {
     @usableFromInline
     typealias H = SHA512
 
-    @inlinable
-    static var group: BoringSSLEllipticCurveGroup { try! BoringSSLEllipticCurveGroup(.p521) }
+    @usableFromInline
+    static let group: BoringSSLEllipticCurveGroup = try! BoringSSLEllipticCurveGroup(.p521)
 
     @inlinable
     static var cofactor: Int { 1 }
@@ -185,9 +185,7 @@ struct OpenSSLCurvePoint<C: OpenSSLSupportedNISTCurve>: GroupElement {
     }
 
     static var generator: Self {
-        // Force-try: Protocol requires non-throwing and this can only throw if group has no generator.
-        // TODO: `BoringSSLEllipticCurveGroup.generator` should probably be non-throwing, like `.order`.
-        try! Self(ecPoint: C.group.generator)
+        Self(ecPoint: C.group.generator)
     }
 
     static var random: Self {

--- a/Sources/_CryptoExtras/Util/Data+Extensions.swift
+++ b/Sources/_CryptoExtras/Util/Data+Extensions.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+
+extension Data {
+    // This overload reduces allocations when used in a chain of infix operations.
+    static func + (lhs: consuming Data, rhs: consuming Data) -> Data {
+        lhs.append(contentsOf: rhs)
+        return lhs
+    }
+}


### PR DESCRIPTION
### Motivation

We've recently added some EC operations internally to support some schemes, including ARC and VOPRF. Some of this code is quite allocation-heavy, which could be avoided with some minimally invasive changes.

### Modifications

- Add package benchmarks for ARC and VOPRF.
- Make use of the `consuming` keyword in some targeted places to reduce allocations in arithmetic- and append-chains.
- Use a Thread-/Task-local FiniteFieldArithmeticContext for EC operations, and thread this through as a `BN_CTX` to BoringSSL functions when available.
- Replace EC static computed properties with stored properties for things that are statically knowable about the EC group.

### Result

This has resulted in a 50% reduction in allocations for ARC issuance and VOPRF evaluation, and a 34% reduction in ARC verification.

```none
SwiftCryptoBenchmarks
============================================================================================================================

----------------------------------------------------------------------------------------------------------------------------
arc-issue-p384 metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│             Malloc (total) *             │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│                  alpha                   │       945 │       945 │       945 │       945 │       945 │       945 │       945 │         3 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│                   beta                   │       464 │       464 │       464 │       464 │       464 │       464 │       464 │         3 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│                    Δ                     │      -481 │      -481 │      -481 │      -481 │      -481 │      -481 │      -481 │         0 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│              Improvement %               │        51 │        51 │        51 │        51 │        51 │        51 │        51 │         0 │
╘══════════════════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

----------------------------------------------------------------------------------------------------------------------------
arc-verify-p384 metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│             Malloc (total) *             │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│                  alpha                   │       410 │       410 │       410 │       415 │       415 │       415 │       415 │        10 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│                   beta                   │       271 │       271 │       271 │       275 │       275 │       275 │       275 │        10 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│                    Δ                     │      -139 │      -139 │      -139 │      -140 │      -140 │      -140 │      -140 │         0 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│              Improvement %               │        34 │        34 │        34 │        34 │        34 │        34 │        34 │         0 │
╘══════════════════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛

----------------------------------------------------------------------------------------------------------------------------
voprf-evaluate-p384 metrics
----------------------------------------------------------------------------------------------------------------------------

╒══════════════════════════════════════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╤═══════════╕
│             Malloc (total) *             │        p0 │       p25 │       p50 │       p75 │       p90 │       p99 │      p100 │   Samples │
╞══════════════════════════════════════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╪═══════════╡
│                  alpha                   │       331 │       331 │       331 │       331 │       331 │       331 │       331 │         3 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│                   beta                   │       168 │       168 │       168 │       168 │       168 │       168 │       168 │         3 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│                    Δ                     │      -163 │      -163 │      -163 │      -163 │      -163 │      -163 │      -163 │         0 │
├──────────────────────────────────────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┼───────────┤
│              Improvement %               │        49 │        49 │        49 │        49 │        49 │        49 │        49 │         0 │
╘══════════════════════════════════════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╧═══════════╛
```