### PR TITLE
Fix cmake build.

### DIFF
--- a/Tests/CryptoTests/SecureBytes/SecureBytesTests.swift
+++ b/Tests/CryptoTests/SecureBytes/SecureBytesTests.swift
@@ -147,7 +147,7 @@ final class SecureBytesTests: XCTestCase {
 
         base.withUnsafeBytes { XCTAssertEqual($0.count, 10) }
         base.withUnsafeMutableBytes { XCTAssertEqual($0.count, 10) }
-        base.backing._withVeryUnsafeMutableBytes { XCTAssertGreaterThanOrEqual($0.count, 16) }
+        base.backing._withVeryUnsafeMutableBytes(base.backing.allocatedCapacity) { XCTAssertGreaterThanOrEqual($0.count, 16) }
     }
 
     func testTheresOnlyOneRegion() {


### PR DESCRIPTION
Fix cmake build.

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I've updated the documentation if necessary **(not necessary)

#### If you've made changes to `gyb` files
- [X] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request **(not necessary)**

### Motivation:

swift-crypto, a swiftpm dependency, is not compiling when bootstrapping swiftpm with cmake. It is however building fine when built with an existing swiftpm.

In #349 we added a new computed property to handle the fact that ManagedBuffer.capacity is unavailable on OpenBSD. In doing this, however we encountered some strange errors about this property being `internal and cannot be referenced from an '@inlinable' function` despite the fact we marked it `@usableFromInline`. Moving the computed property to the nested class extension seemed to help, but in recent versions of swift this caused a different strange compiler error about the computed property having the `wrong linkage`.

### Modifications:

While I don't really understand what is happening here enough to say whether this is a compiler bug or not, this only seems to be triggering from `_copyBytes` and `_withVeryUnsafeMutableBytes` still. We want these to be inlinable, so the next natural workaround seems to be to plumb the capacity references in by argument instead of referencing `self`. This makes the callsites a bit wordy, but it seems to work.

### Result:

swiftpm successfully bootstraps with cmake.