### PR TITLE
Replace all Foundation imports with FoundationEssentials

### DIFF
--- a/Benchmarks/Benchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/Benchmarks.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 import Benchmark
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import _CryptoExtras
 
 let benchmarks = {

--- a/Benchmarks/Benchmarks/Benchmarks.swift
+++ b/Benchmarks/Benchmarks/Benchmarks.swift
@@ -13,12 +13,13 @@
 //===----------------------------------------------------------------------===//
 import Benchmark
 import Crypto
+import _CryptoExtras
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
 import Foundation
 #endif
-import _CryptoExtras
 
 let benchmarks = {
     let defaultMetrics: [BenchmarkMetric] = [.mallocCountTotal, .cpuTotal]

--- a/Sources/Crypto/AEADs/AES/GCM/AES-GCM.swift
+++ b/Sources/Crypto/AEADs/AES/GCM/AES-GCM.swift
@@ -25,7 +25,11 @@ typealias AESGCMImpl = OpenSSLAESGCMImpl
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/AEADs/AES/GCM/BoringSSL/AES-GCM_boring.swift
+++ b/Sources/Crypto/AEADs/AES/GCM/BoringSSL/AES-GCM_boring.swift
@@ -16,7 +16,11 @@
 #else
 @_implementationOnly import CCryptoBoringSSL
 import CryptoBoringWrapper
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 enum OpenSSLAESGCMImpl {

--- a/Sources/Crypto/AEADs/ChachaPoly/BoringSSL/ChaChaPoly_boring.swift
+++ b/Sources/Crypto/AEADs/ChachaPoly/BoringSSL/ChaChaPoly_boring.swift
@@ -17,7 +17,11 @@
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 import CryptoBoringWrapper
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension BoringSSLAEAD {

--- a/Sources/Crypto/AEADs/ChachaPoly/ChaChaPoly.swift
+++ b/Sources/Crypto/AEADs/ChachaPoly/ChaChaPoly.swift
@@ -25,7 +25,11 @@ typealias ChaChaPolyImpl = OpenSSLChaChaPolyImpl
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 

--- a/Sources/Crypto/AEADs/Cipher.swift
+++ b/Sources/Crypto/AEADs/Cipher.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 

--- a/Sources/Crypto/AEADs/Nonces.swift
+++ b/Sources/Crypto/AEADs/Nonces.swift
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 // MARK: - Generated file, do NOT edit
 // any edits of this file WILL be overwritten and thus discarded

--- a/Sources/Crypto/AEADs/Nonces.swift.gyb
+++ b/Sources/Crypto/AEADs/Nonces.swift.gyb
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 // MARK: - Generated file, do NOT edit
 // any edits of this file WILL be overwritten and thus discarded

--- a/Sources/Crypto/ASN1/ASN1.swift
+++ b/Sources/Crypto/ASN1/ASN1.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 // This module implements "just enough" ASN.1. Specifically, we implement exactly enough ASN.1 DER parsing to handle

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Any.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Any.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1BitString.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1BitString.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Boolean.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Boolean.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Identifier.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Identifier.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Integer.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Integer.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 /// A protocol that represents any internal object that can present itself as a INTEGER, or be parsed from

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Null.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Null.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1OctetString.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1OctetString.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Strings.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ASN1Strings.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ArraySliceBigint.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ArraySliceBigint.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 // For temporary purposes we pretend that ArraySlice is our "bigint" type. We don't really need anything else.

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/GeneralizedTime.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/GeneralizedTime.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/ASN1/Basic ASN1 Types/ObjectIdentifier.swift
+++ b/Sources/Crypto/ASN1/Basic ASN1 Types/ObjectIdentifier.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/ASN1/ECDSASignature.swift
+++ b/Sources/Crypto/ASN1/ECDSASignature.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/ASN1/PEMDocument.swift
+++ b/Sources/Crypto/ASN1/PEMDocument.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/ASN1/PKCS8PrivateKey.swift
+++ b/Sources/Crypto/ASN1/PKCS8PrivateKey.swift
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/ASN1/SEC1PrivateKey.swift
+++ b/Sources/Crypto/ASN1/SEC1PrivateKey.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/ASN1/SubjectPublicKeyInfo.swift
+++ b/Sources/Crypto/ASN1/SubjectPublicKeyInfo.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/Digests/Digest.swift
+++ b/Sources/Crypto/Digests/Digest.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 #if hasFeature(Embedded)

--- a/Sources/Crypto/Digests/HashFunctions.swift
+++ b/Sources/Crypto/Digests/HashFunctions.swift
@@ -25,7 +25,11 @@ typealias DigestImpl = OpenSSLDigestImpl
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 /// A type that performs cryptographically secure hashing.

--- a/Sources/Crypto/HPKE/Ciphersuite/HPKE-AEAD.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/HPKE-AEAD.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 

--- a/Sources/Crypto/HPKE/Ciphersuite/HPKE-Ciphersuite.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/HPKE-Ciphersuite.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 

--- a/Sources/Crypto/HPKE/Ciphersuite/HPKE-KDF.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/HPKE-KDF.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/HPKE/Ciphersuite/HPKE-KexKeyDerivation.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/HPKE-KexKeyDerivation.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 

--- a/Sources/Crypto/HPKE/Ciphersuite/HPKE-LabeledExtract.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/HPKE-LabeledExtract.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 

--- a/Sources/Crypto/HPKE/Ciphersuite/HPKE-Utils.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/HPKE-Utils.swift
@@ -19,6 +19,19 @@
 import SwiftSystem
 #else
 #if canImport(FoundationEssentials)
+#if os(Windows)
+import ucrt
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Android)
+import Android
+#elseif canImport(WASILibc)
+import WASILibc
+#endif
 import FoundationEssentials
 #else
 import Foundation

--- a/Sources/Crypto/HPKE/Ciphersuite/HPKE-Utils.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/HPKE-Utils.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 

--- a/Sources/Crypto/HPKE/Ciphersuite/KEM/Conformances/DHKEM.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/KEM/Conformances/DHKEM.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 /// A type that ``HPKE`` uses to encode the public key.

--- a/Sources/Crypto/HPKE/Ciphersuite/KEM/Conformances/HPKE-KEM-Curve25519.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/KEM/Conformances/HPKE-KEM-Curve25519.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 

--- a/Sources/Crypto/HPKE/Ciphersuite/KEM/Conformances/HPKE-NIST-EC-KEMs.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/KEM/Conformances/HPKE-NIST-EC-KEMs.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/HPKE/Ciphersuite/KEM/HPKE-KEM.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/KEM/HPKE-KEM.swift
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/HPKE/HPKE-Errors.swift
+++ b/Sources/Crypto/HPKE/HPKE-Errors.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/HPKE/HPKE.swift
+++ b/Sources/Crypto/HPKE/HPKE.swift
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 /// A container for hybrid public key encryption (HPKE) operations.

--- a/Sources/Crypto/HPKE/Key Schedule/HPKE-Context.swift
+++ b/Sources/Crypto/HPKE/Key Schedule/HPKE-Context.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/HPKE/Key Schedule/HPKE-KeySchedule.swift
+++ b/Sources/Crypto/HPKE/Key Schedule/HPKE-KeySchedule.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/KEM/BoringSSL/MLKEM_boring.swift
+++ b/Sources/Crypto/KEM/BoringSSL/MLKEM_boring.swift
@@ -20,7 +20,11 @@
 @_exported import CryptoKit
 #else
 @_implementationOnly import CCryptoBoringSSL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension MLKEM768 {

--- a/Sources/Crypto/KEM/BoringSSL/MLKEM_boring.swift.gyb
+++ b/Sources/Crypto/KEM/BoringSSL/MLKEM_boring.swift.gyb
@@ -20,7 +20,11 @@
 @_exported import CryptoKit
 #else
 @_implementationOnly import CCryptoBoringSSL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 %{
     parameter_sets = ["768", "1024"]
 }%

--- a/Sources/Crypto/KEM/BoringSSL/MLKEM_wrapper.swift
+++ b/Sources/Crypto/KEM/BoringSSL/MLKEM_wrapper.swift
@@ -16,7 +16,11 @@
 @_exported import CryptoKit
 #else
 @_implementationOnly import CCryptoBoringSSL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 protocol BoringSSLBackedMLKEMPrivateKey {

--- a/Sources/Crypto/KEM/BoringSSL/XWing_boring.swift
+++ b/Sources/Crypto/KEM/BoringSSL/XWing_boring.swift
@@ -16,7 +16,11 @@
 @_exported import CryptoKit
 #else
 @_implementationOnly import CCryptoBoringSSL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 struct OpenSSLXWingPublicKeyImpl: Sendable {

--- a/Sources/Crypto/KEM/KEM-Errors.swift
+++ b/Sources/Crypto/KEM/KEM-Errors.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/KEM/KEM.swift
+++ b/Sources/Crypto/KEM/KEM.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 /// A key encapsulation mechanism.

--- a/Sources/Crypto/KEM/MLKEM.swift
+++ b/Sources/Crypto/KEM/MLKEM.swift
@@ -14,7 +14,11 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 
 #if (!CRYPTO_IN_SWIFTPM_FORCE_BUILD_API) || CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/KEM/MLKEM.swift.gyb
+++ b/Sources/Crypto/KEM/MLKEM.swift.gyb
@@ -14,7 +14,11 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 %{
     MLKEM_VARIANTS = [{"name": "MLKEM768", "ccinfo": "cckem_mlkem768()!"}, {"name": "MLKEM1024", "ccinfo": "cckem_mlkem1024()!"}]
 }%

--- a/Sources/Crypto/KEM/XWing.swift
+++ b/Sources/Crypto/KEM/XWing.swift
@@ -14,7 +14,11 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 
 #if _runtime(_ObjC) && CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
@@ -23,7 +27,11 @@ public import Foundation
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 #if (!CRYPTO_IN_SWIFTPM_FORCE_BUILD_API) || CRYPTOKIT_NO_ACCESS_TO_FOUNDATION

--- a/Sources/Crypto/Key Agreement/DH.swift
+++ b/Sources/Crypto/Key Agreement/DH.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 /// A Diffie-Hellman Key Agreement Key

--- a/Sources/Crypto/Key Agreement/ECDH.swift
+++ b/Sources/Crypto/Key Agreement/ECDH.swift
@@ -29,7 +29,11 @@ typealias NISTCurvePrivateKeyImpl = OpenSSLNISTCurvePrivateKeyImpl
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 // MARK: - Generated file, do NOT edit

--- a/Sources/Crypto/Key Agreement/ECDH.swift.gyb
+++ b/Sources/Crypto/Key Agreement/ECDH.swift.gyb
@@ -25,7 +25,11 @@ typealias NISTCurvePrivateKeyImpl = OpenSSLNISTCurvePrivateKeyImpl
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 // MARK: - Generated file, do NOT edit

--- a/Sources/Crypto/Key Derivation/ANSIx963.swift
+++ b/Sources/Crypto/Key Derivation/ANSIx963.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 @_spi(ANSIKDF)

--- a/Sources/Crypto/Key Derivation/HKDF.swift
+++ b/Sources/Crypto/Key Derivation/HKDF.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 /// A standards-based implementation of an HMAC-based Key Derivation Function

--- a/Sources/Crypto/Key Wrapping/AESWrap.swift
+++ b/Sources/Crypto/Key Wrapping/AESWrap.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 #if (!CRYPTO_IN_SWIFTPM_FORCE_BUILD_API) || CRYPTOKIT_NO_ACCESS_TO_FOUNDATION

--- a/Sources/Crypto/Key Wrapping/BoringSSL/AESWrap_boring.swift
+++ b/Sources/Crypto/Key Wrapping/BoringSSL/AESWrap_boring.swift
@@ -15,7 +15,11 @@
 @_exported import CryptoKit
 #else
 @_implementationOnly import CCryptoBoringSSL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 enum BoringSSLAESWRAPImpl {

--- a/Sources/Crypto/Keys/EC/BoringSSL/Ed25519_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/Ed25519_boring.swift
@@ -16,7 +16,11 @@
 #else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 // For signing and verifying, we use BoringSSL's Ed25519, not the X25519 stuff.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
@@ -17,7 +17,11 @@
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 import CryptoBoringWrapper
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/Keys/EC/BoringSSL/X25519Keys_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/X25519Keys_boring.swift
@@ -16,7 +16,11 @@
 #else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension Curve25519.KeyAgreement {

--- a/Sources/Crypto/Keys/EC/Ed25519Keys.swift
+++ b/Sources/Crypto/Keys/EC/Ed25519Keys.swift
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/Keys/EC/NISTCurvesKeys.swift
+++ b/Sources/Crypto/Keys/EC/NISTCurvesKeys.swift
@@ -14,7 +14,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Sources/Crypto/Keys/EC/X25519Keys.swift
+++ b/Sources/Crypto/Keys/EC/X25519Keys.swift
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/Keys/Symmetric/SymmetricKeys.swift
+++ b/Sources/Crypto/Keys/Symmetric/SymmetricKeys.swift
@@ -18,7 +18,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 /// The sizes that a symmetric cryptographic key can take.

--- a/Sources/Crypto/Message Authentication Codes/HMAC/HMAC.swift
+++ b/Sources/Crypto/Message Authentication Codes/HMAC/HMAC.swift
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 /// A hash-based message authentication algorithm.

--- a/Sources/Crypto/Message Authentication Codes/HMAC/HMAC.swift
+++ b/Sources/Crypto/Message Authentication Codes/HMAC/HMAC.swift
@@ -18,6 +18,19 @@
 public import SwiftSystem
 #else
 #if canImport(FoundationEssentials)
+#if os(Windows)
+import ucrt
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Android)
+import Android
+#elseif canImport(WASILibc)
+import WASILibc
+#endif
 public import FoundationEssentials
 #else
 public import Foundation

--- a/Sources/Crypto/Message Authentication Codes/MACFunctions.swift
+++ b/Sources/Crypto/Message Authentication Codes/MACFunctions.swift
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/Message Authentication Codes/MessageAuthenticationCode.swift
+++ b/Sources/Crypto/Message Authentication Codes/MessageAuthenticationCode.swift
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 #if hasFeature(Embedded)

--- a/Sources/Crypto/Signatures/BoringSSL/ECDSASignature_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/ECDSASignature_boring.swift
@@ -17,7 +17,11 @@
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 import CryptoBoringWrapper
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// A wrapper around BoringSSL's ECDSA_SIG with some lifetime management.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/Signatures/BoringSSL/ECDSA_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/ECDSA_boring.swift
@@ -16,7 +16,11 @@
 #else
 @_implementationOnly import CCryptoBoringSSL
 import CryptoBoringWrapper
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension Data {

--- a/Sources/Crypto/Signatures/BoringSSL/EdDSA_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/EdDSA_boring.swift
@@ -16,7 +16,11 @@
 #else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension Curve25519.Signing.PublicKey {

--- a/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift
@@ -16,14 +16,22 @@
 @_exported import CryptoKit
 #else
 @_implementationOnly import CCryptoBoringSSL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 // MARK: - Generated file, do NOT edit
 // any edits of this file WILL be overwritten and thus discarded
 // see section `gyb` in `README` for details.
 
 @_implementationOnly import CCryptoBoringSSL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension MLDSA65 {

--- a/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift.gyb
+++ b/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift.gyb
@@ -16,14 +16,22 @@
 @_exported import CryptoKit
 #else
 @_implementationOnly import CCryptoBoringSSL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 // MARK: - Generated file, do NOT edit
 // any edits of this file WILL be overwritten and thus discarded
 // see section `gyb` in `README` for details.
 
 @_implementationOnly import CCryptoBoringSSL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 %{
     parameter_sets = ["65", "87"]
 }%

--- a/Sources/Crypto/Signatures/BoringSSL/MLDSA_wrapper.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/MLDSA_wrapper.swift
@@ -16,7 +16,11 @@
 @_exported import CryptoKit
 #else
 @_implementationOnly import CCryptoBoringSSL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 protocol BoringSSLBackedMLDSAPrivateKey {

--- a/Sources/Crypto/Signatures/ECDSA.swift
+++ b/Sources/Crypto/Signatures/ECDSA.swift
@@ -15,7 +15,11 @@
 @_exported import CryptoKit
 #else
 #if !CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #else
 public import SwiftSystem
 #endif

--- a/Sources/Crypto/Signatures/ECDSA.swift.gyb
+++ b/Sources/Crypto/Signatures/ECDSA.swift.gyb
@@ -15,7 +15,11 @@
 @_exported import CryptoKit
 #else
 #if !CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #else
 public import SwiftSystem
 #endif

--- a/Sources/Crypto/Signatures/Ed25519.swift
+++ b/Sources/Crypto/Signatures/Ed25519.swift
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 public import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/Signatures/MLDSA.swift
+++ b/Sources/Crypto/Signatures/MLDSA.swift
@@ -14,7 +14,11 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 
 #if (!CRYPTO_IN_SWIFTPM_FORCE_BUILD_API) || CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 typealias MLDSAPublicKeyImpl = CoreCryptoMLDSAPublicKeyImpl

--- a/Sources/Crypto/Signatures/MLDSA.swift.gyb
+++ b/Sources/Crypto/Signatures/MLDSA.swift.gyb
@@ -14,7 +14,11 @@
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 @_exported import CryptoKit
 #else
+#if canImport(FoundationEssentials)
+public import FoundationEssentials
+#else
 public import Foundation
+#endif
 
 #if (!CRYPTO_IN_SWIFTPM_FORCE_BUILD_API) || CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 typealias MLDSAPublicKeyImpl = CoreCryptoMLDSAPublicKeyImpl

--- a/Sources/Crypto/Signatures/Signature.swift
+++ b/Sources/Crypto/Signatures/Signature.swift
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/Util/BoringSSL/Optional+withUnsafeBytes_boring.swift
+++ b/Sources/Crypto/Util/BoringSSL/Optional+withUnsafeBytes_boring.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 extension Optional where Wrapped: DataProtocol {
     func withUnsafeBytes<ReturnValue>(_ body: (UnsafeRawBufferPointer) throws -> ReturnValue) rethrows -> ReturnValue {

--- a/Sources/Crypto/Util/BoringSSL/SafeCompare_boring.swift
+++ b/Sources/Crypto/Util/BoringSSL/SafeCompare_boring.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// This function performs a safe comparison between two buffers of bytes. It exists as a temporary shim until we refactor
 /// some of the usage sites to pass better data structures to us.

--- a/Sources/Crypto/Util/PrettyBytes.swift
+++ b/Sources/Crypto/Util/PrettyBytes.swift
@@ -14,7 +14,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/Util/SafeCompare.swift
+++ b/Sources/Crypto/Util/SafeCompare.swift
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/Util/SecureBytes.swift
+++ b/Sources/Crypto/Util/SecureBytes.swift
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/Crypto/Util/Zeroization.swift
+++ b/Sources/Crypto/Util/Zeroization.swift
@@ -17,7 +17,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/CryptoBoringWrapper/AEAD/BoringSSLAEAD.swift
+++ b/Sources/CryptoBoringWrapper/AEAD/BoringSSLAEAD.swift
@@ -14,6 +14,7 @@
 
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/CryptoBoringWrapper/AEAD/BoringSSLAEAD.swift
+++ b/Sources/CryptoBoringWrapper/AEAD/BoringSSLAEAD.swift
@@ -14,7 +14,11 @@
 
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// An abstraction over a BoringSSL AEAD
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/CryptoBoringWrapper/Util/ArbitraryPrecisionInteger.swift
+++ b/Sources/CryptoBoringWrapper/Util/ArbitraryPrecisionInteger.swift
@@ -16,7 +16,11 @@
 #else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// A wrapper around the OpenSSL BIGNUM object that is appropriately lifetime managed,
 /// and that provides better Swift types for this object.

--- a/Sources/CryptoBoringWrapper/Util/FiniteFieldArithmeticContext.swift
+++ b/Sources/CryptoBoringWrapper/Util/FiniteFieldArithmeticContext.swift
@@ -15,7 +15,11 @@
 @_exported import CryptoKit
 #else
 @_implementationOnly import CCryptoBoringSSL
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// A context for performing mathematical operations on ArbitraryPrecisionIntegers over a finite field.
 ///

--- a/Sources/_CryptoExtras/AES/AES_CBC.swift
+++ b/Sources/_CryptoExtras/AES/AES_CBC.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension AES {

--- a/Sources/_CryptoExtras/AES/AES_CFB.swift
+++ b/Sources/_CryptoExtras/AES/AES_CFB.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/AES/AES_CTR.swift
+++ b/Sources/_CryptoExtras/AES/AES_CTR.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/AES/AES_GCM_SIV.swift
+++ b/Sources/_CryptoExtras/AES/AES_GCM_SIV.swift
@@ -16,7 +16,11 @@ import Crypto
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 import CryptoBoringWrapper
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// Types associated with the AES GCM SIV algorithm
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/AES/Block Function.swift
+++ b/Sources/_CryptoExtras/AES/Block Function.swift
@@ -16,7 +16,11 @@ import Crypto
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 import CryptoBoringWrapper
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension AES {

--- a/Sources/_CryptoExtras/AES/BoringSSL/AES_CFB_boring.swift
+++ b/Sources/_CryptoExtras/AES/BoringSSL/AES_CFB_boring.swift
@@ -14,6 +14,7 @@
 
 @_implementationOnly import CCryptoBoringSSL
 import Crypto
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/_CryptoExtras/AES/BoringSSL/AES_CFB_boring.swift
+++ b/Sources/_CryptoExtras/AES/BoringSSL/AES_CFB_boring.swift
@@ -14,7 +14,11 @@
 
 @_implementationOnly import CCryptoBoringSSL
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/AES/BoringSSL/AES_CTR_boring.swift
+++ b/Sources/_CryptoExtras/AES/BoringSSL/AES_CTR_boring.swift
@@ -14,6 +14,7 @@
 
 @_implementationOnly import CCryptoBoringSSL
 import Crypto
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/_CryptoExtras/AES/BoringSSL/AES_CTR_boring.swift
+++ b/Sources/_CryptoExtras/AES/BoringSSL/AES_CTR_boring.swift
@@ -14,7 +14,11 @@
 
 @_implementationOnly import CCryptoBoringSSL
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/AES/BoringSSL/AES_GCM_SIV_boring.swift
+++ b/Sources/_CryptoExtras/AES/BoringSSL/AES_GCM_SIV_boring.swift
@@ -18,6 +18,7 @@
 @_implementationOnly import CCryptoBoringSSLShims
 import Crypto
 import CryptoBoringWrapper
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/_CryptoExtras/AES/BoringSSL/AES_GCM_SIV_boring.swift
+++ b/Sources/_CryptoExtras/AES/BoringSSL/AES_GCM_SIV_boring.swift
@@ -18,7 +18,11 @@
 @_implementationOnly import CCryptoBoringSSLShims
 import Crypto
 import CryptoBoringWrapper
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension BoringSSLAEAD {

--- a/Sources/_CryptoExtras/ARC/ARC+API.swift
+++ b/Sources/_CryptoExtras/ARC/ARC+API.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 // MARK: - P384 + ARC(P-384)
 @available(iOS 16.0, macOS 13.0, watchOS 9.0, tvOS 16.0, macCatalyst 16.0, visionOS 2.0, *)

--- a/Sources/_CryptoExtras/ARC/ARC.swift
+++ b/Sources/_CryptoExtras/ARC/ARC.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// Anonymous Rate-Limited Credentials (ARC) using the CMZ14 MACGGM construction, as defined in
 /// https://chris-wood.github.io/draft-arc/draft-yun-cfrg-arc.html

--- a/Sources/_CryptoExtras/ARC/ARCCredential.swift
+++ b/Sources/_CryptoExtras/ARC/ARCCredential.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, macCatalyst 13.2, visionOS 1.2, *)
 extension ARC {

--- a/Sources/_CryptoExtras/ARC/ARCEncoding.swift
+++ b/Sources/_CryptoExtras/ARC/ARCEncoding.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/ARC/ARCPrecredential.swift
+++ b/Sources/_CryptoExtras/ARC/ARCPrecredential.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, macCatalyst 13.2, visionOS 1.2, *)
 extension ARC {

--- a/Sources/_CryptoExtras/ARC/ARCPresentation.swift
+++ b/Sources/_CryptoExtras/ARC/ARCPresentation.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, macCatalyst 13.2, visionOS 1.2, *)
 extension ARC {

--- a/Sources/_CryptoExtras/ARC/ARCRequest.swift
+++ b/Sources/_CryptoExtras/ARC/ARCRequest.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, macCatalyst 13.2, visionOS 1.2, *)
 extension ARC {

--- a/Sources/_CryptoExtras/ARC/ARCResponse.swift
+++ b/Sources/_CryptoExtras/ARC/ARCResponse.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, macCatalyst 13.2, visionOS 1.2, *)
 extension ARC {

--- a/Sources/_CryptoExtras/ARC/ARCServer.swift
+++ b/Sources/_CryptoExtras/ARC/ARCServer.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, macCatalyst 13.2, visionOS 1.2, *)
 extension ARC {

--- a/Sources/_CryptoExtras/ChaCha20CTR/BoringSSL/ChaCha20CTR_boring.swift
+++ b/Sources/_CryptoExtras/ChaCha20CTR/BoringSSL/ChaCha20CTR_boring.swift
@@ -16,6 +16,7 @@
 @_implementationOnly import CCryptoBoringSSLShims
 import Crypto
 import CryptoBoringWrapper
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/_CryptoExtras/ChaCha20CTR/BoringSSL/ChaCha20CTR_boring.swift
+++ b/Sources/_CryptoExtras/ChaCha20CTR/BoringSSL/ChaCha20CTR_boring.swift
@@ -16,7 +16,11 @@
 @_implementationOnly import CCryptoBoringSSLShims
 import Crypto
 import CryptoBoringWrapper
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 enum OpenSSLChaCha20CTRImpl {

--- a/Sources/_CryptoExtras/ChaCha20CTR/ChaCha20CTR.swift
+++ b/Sources/_CryptoExtras/ChaCha20CTR/ChaCha20CTR.swift
@@ -16,7 +16,11 @@
 @_implementationOnly import CCryptoBoringSSLShims
 import Crypto
 import CryptoBoringWrapper
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 typealias ChaCha20CTRImpl = OpenSSLChaCha20CTRImpl

--- a/Sources/_CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
+++ b/Sources/_CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 import Crypto
 import CryptoBoringWrapper
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// NOTE: This protocol is different from `Crypto.OpenSSLSupportedNISTCurve` module and has additional requirements to
 /// support ECToolbox. It is (re-)defined here because its counterpart in the Crypto module is only conditionally

--- a/Sources/_CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
+++ b/Sources/_CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 import Crypto
 import CryptoBoringWrapper
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/_CryptoExtras/ECToolbox/ECToolbox.swift
+++ b/Sources/_CryptoExtras/ECToolbox/ECToolbox.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 #if canImport(Darwin) && !CRYPTO_IN_SWIFTPM
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/H2G/HashToField.swift
+++ b/Sources/_CryptoExtras/H2G/HashToField.swift
@@ -12,6 +12,19 @@
 //
 //===----------------------------------------------------------------------===//
 #if canImport(FoundationEssentials)
+#if os(Windows)
+import ucrt
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Android)
+import Android
+#elseif canImport(WASILibc)
+import WASILibc
+#endif
 import FoundationEssentials
 #else
 import Foundation

--- a/Sources/_CryptoExtras/H2G/HashToField.swift
+++ b/Sources/_CryptoExtras/H2G/HashToField.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/Key Derivation/KDF.swift
+++ b/Sources/_CryptoExtras/Key Derivation/KDF.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// A container for Key Detivation Function algorithms.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/Key Derivation/PBKDF2/BoringSSL/PBKDF2_boring.swift
+++ b/Sources/_CryptoExtras/Key Derivation/PBKDF2/BoringSSL/PBKDF2_boring.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 #if !canImport(CommonCrypto)
 @_implementationOnly import CCryptoBoringSSL

--- a/Sources/_CryptoExtras/Key Derivation/PBKDF2/BoringSSL/PBKDF2_boring.swift
+++ b/Sources/_CryptoExtras/Key Derivation/PBKDF2/BoringSSL/PBKDF2_boring.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/_CryptoExtras/Key Derivation/PBKDF2/BoringSSL/PBKDF2_commoncrypto.swift
+++ b/Sources/_CryptoExtras/Key Derivation/PBKDF2/BoringSSL/PBKDF2_commoncrypto.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/_CryptoExtras/Key Derivation/PBKDF2/BoringSSL/PBKDF2_commoncrypto.swift
+++ b/Sources/_CryptoExtras/Key Derivation/PBKDF2/BoringSSL/PBKDF2_commoncrypto.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 #if canImport(CommonCrypto)
 @_implementationOnly import CommonCrypto

--- a/Sources/_CryptoExtras/Key Derivation/PBKDF2/PBKDF2.swift
+++ b/Sources/_CryptoExtras/Key Derivation/PBKDF2/PBKDF2.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 #if canImport(CommonCrypto)
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/Key Derivation/Scrypt/BoringSSL/Scrypt_boring.swift
+++ b/Sources/_CryptoExtras/Key Derivation/Scrypt/BoringSSL/Scrypt_boring.swift
@@ -17,6 +17,19 @@
 import Crypto
 
 #if canImport(FoundationEssentials)
+#if os(Windows)
+import ucrt
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Android)
+import Android
+#elseif canImport(WASILibc)
+import WASILibc
+#endif
 import FoundationEssentials
 #else
 import Foundation

--- a/Sources/_CryptoExtras/Key Derivation/Scrypt/BoringSSL/Scrypt_boring.swift
+++ b/Sources/_CryptoExtras/Key Derivation/Scrypt/BoringSSL/Scrypt_boring.swift
@@ -15,7 +15,11 @@
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 #if canImport(Android)
 import Android

--- a/Sources/_CryptoExtras/Key Derivation/Scrypt/BoringSSL/Scrypt_boring.swift
+++ b/Sources/_CryptoExtras/Key Derivation/Scrypt/BoringSSL/Scrypt_boring.swift
@@ -15,6 +15,7 @@
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
 import Crypto
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/_CryptoExtras/Key Derivation/Scrypt/Scrypt.swift
+++ b/Sources/_CryptoExtras/Key Derivation/Scrypt/Scrypt.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 fileprivate typealias BackingScrypt = BoringSSLScrypt

--- a/Sources/_CryptoExtras/OPRFs/OPRF.swift
+++ b/Sources/_CryptoExtras/OPRFs/OPRF.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 
 /// (Verifiable Partly-)Oblivious Pseudorandom Functions

--- a/Sources/_CryptoExtras/OPRFs/OPRFClient.swift
+++ b/Sources/_CryptoExtras/OPRFs/OPRFClient.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, macCatalyst 13.2, visionOS 1.2, *)
 extension OPRF {

--- a/Sources/_CryptoExtras/OPRFs/OPRFServer.swift
+++ b/Sources/_CryptoExtras/OPRFs/OPRFServer.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 
 @available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, macCatalyst 13.2, visionOS 1.2, *)

--- a/Sources/_CryptoExtras/OPRFs/VOPRF+API.swift
+++ b/Sources/_CryptoExtras/OPRFs/VOPRF+API.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 // MARK: - P384 + VPORF (P384-SHA384)
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/OPRFs/VOPRFClient.swift
+++ b/Sources/_CryptoExtras/OPRFs/VOPRFClient.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, macCatalyst 13.2, visionOS 1.2, *)
 extension OPRF {

--- a/Sources/_CryptoExtras/OPRFs/VOPRFServer.swift
+++ b/Sources/_CryptoExtras/OPRFs/VOPRFServer.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 
 @available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, macCatalyst 13.2, visionOS 1.2, *)

--- a/Sources/_CryptoExtras/RSA/RSA+BlindSigning.swift
+++ b/Sources/_CryptoExtras/RSA/RSA+BlindSigning.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 import CryptoBoringWrapper
 

--- a/Sources/_CryptoExtras/RSA/RSA.swift
+++ b/Sources/_CryptoExtras/RSA/RSA.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 import CryptoBoringWrapper
 import SwiftASN1

--- a/Sources/_CryptoExtras/RSA/RSA_boring.swift
+++ b/Sources/_CryptoExtras/RSA/RSA_boring.swift
@@ -17,7 +17,11 @@
 @_implementationOnly import CCryptoBoringSSLShims
 import Crypto
 import CryptoBoringWrapper
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 internal struct BoringSSLRSAPublicKey: Sendable {

--- a/Sources/_CryptoExtras/RSA/RSA_boring.swift
+++ b/Sources/_CryptoExtras/RSA/RSA_boring.swift
@@ -18,6 +18,19 @@
 import Crypto
 import CryptoBoringWrapper
 #if canImport(FoundationEssentials)
+#if os(Windows)
+import ucrt
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Android)
+import Android
+#elseif canImport(WASILibc)
+import WASILibc
+#endif
 import FoundationEssentials
 #else
 import Foundation

--- a/Sources/_CryptoExtras/RSA/RSA_boring.swift
+++ b/Sources/_CryptoExtras/RSA/RSA_boring.swift
@@ -17,6 +17,7 @@
 @_implementationOnly import CCryptoBoringSSLShims
 import Crypto
 import CryptoBoringWrapper
+
 #if canImport(FoundationEssentials)
 #if os(Windows)
 import ucrt

--- a/Sources/_CryptoExtras/RSA/RSA_security.swift
+++ b/Sources/_CryptoExtras/RSA/RSA_security.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Sources/_CryptoExtras/Util/BoringSSLHelpers.swift
+++ b/Sources/_CryptoExtras/Util/BoringSSLHelpers.swift
@@ -15,7 +15,11 @@
 // NOTE: This file is unconditionally compiled because RSABSSA is implemented using BoringSSL on all platforms.
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/Util/Data+Extensions.swift
+++ b/Sources/_CryptoExtras/Util/Data+Extensions.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 extension Data {
     // This overload reduces allocations when used in a chain of infix operations.

--- a/Sources/_CryptoExtras/Util/I2OSP.swift
+++ b/Sources/_CryptoExtras/Util/I2OSP.swift
@@ -12,6 +12,19 @@
 //
 //===----------------------------------------------------------------------===//
 #if canImport(FoundationEssentials)
+#if os(Windows)
+import ucrt
+#elseif canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#elseif canImport(Android)
+import Android
+#elseif canImport(WASILibc)
+import WASILibc
+#endif
 import FoundationEssentials
 #else
 import Foundation

--- a/Sources/_CryptoExtras/Util/I2OSP.swift
+++ b/Sources/_CryptoExtras/Util/I2OSP.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 func I2OSP(value: Int, outputByteCount: Int) -> Data {

--- a/Sources/_CryptoExtras/Util/IntegerEncoding.swift
+++ b/Sources/_CryptoExtras/Util/IntegerEncoding.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 enum IntegerDecodingError: Error, Equatable {
     case incorrectNumberOfBytes(expected: Int, actual: Int)

--- a/Sources/_CryptoExtras/Util/PEMDocument.swift
+++ b/Sources/_CryptoExtras/Util/PEMDocument.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/Util/PrettyBytes.swift
+++ b/Sources/_CryptoExtras/Util/PrettyBytes.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 enum ByteHexEncodingErrors: Error {

--- a/Sources/_CryptoExtras/ZKPs/DLEQ.swift
+++ b/Sources/_CryptoExtras/ZKPs/DLEQ.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 
 /// A DLEQ Proof as described in https://cfrg.github.io/draft-irtf-cfrg-voprf/draft-irtf-cfrg-voprf.html#name-generateproof

--- a/Sources/_CryptoExtras/ZKPs/Prover.swift
+++ b/Sources/_CryptoExtras/ZKPs/Prover.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/ZKPs/Verifier.swift
+++ b/Sources/_CryptoExtras/ZKPs/Verifier.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/_CryptoExtras/ZKPs/ZKPToolbox.swift
+++ b/Sources/_CryptoExtras/ZKPs/ZKPToolbox.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Sources/crypto-shasum/main.swift
+++ b/Sources/crypto-shasum/main.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Crypto
 
 let help = """

--- a/Sources/crypto-shasum/main.swift
+++ b/Sources/crypto-shasum/main.swift
@@ -11,11 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
 import Foundation
-#endif
 import Crypto
 
 let help = """

--- a/Tests/CryptoTests/Authenticated Encryption/AES-GCM-Runner.swift
+++ b/Tests/CryptoTests/Authenticated Encryption/AES-GCM-Runner.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Tests/CryptoTests/Authenticated Encryption/ChaChaPoly-Runner.swift
+++ b/Tests/CryptoTests/Authenticated Encryption/ChaChaPoly-Runner.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Tests/CryptoTests/ECDH/BoringSSL/ASN1.swift
+++ b/Tests/CryptoTests/ECDH/BoringSSL/ASN1.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Tests/CryptoTests/ECDH/BoringSSL/ASN1.swift
+++ b/Tests/CryptoTests/ECDH/BoringSSL/ASN1.swift
@@ -11,12 +11,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import XCTest
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
 import Foundation
 #endif
-import XCTest
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 // Skip tests that require @testable imports of CryptoKit.

--- a/Tests/CryptoTests/ECDH/BoringSSL/secpECDH_Runner_boring.swift
+++ b/Tests/CryptoTests/ECDH/BoringSSL/secpECDH_Runner_boring.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Tests/CryptoTests/ECDH/BoringSSL/secpECDH_Runner_boring.swift
+++ b/Tests/CryptoTests/ECDH/BoringSSL/secpECDH_Runner_boring.swift
@@ -11,12 +11,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+import XCTest
+
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
 import Foundation
 #endif
-import XCTest
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 // Skip tests that require @testable imports of CryptoKit.

--- a/Tests/CryptoTests/ECDH/X25519-Runner.swift
+++ b/Tests/CryptoTests/ECDH/X25519-Runner.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Tests/CryptoTests/ECDH/secpECDH_Runner.swift
+++ b/Tests/CryptoTests/ECDH/secpECDH_Runner.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Tests/CryptoTests/HPKE/HPKETests-TestVectors.swift
+++ b/Tests/CryptoTests/HPKE/HPKETests-TestVectors.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Tests/CryptoTests/HPKE/HPKETests.swift
+++ b/Tests/CryptoTests/HPKE/HPKETests.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Tests/CryptoTests/Key Derivation/ECprivateKeysFromSeeds.swift
+++ b/Tests/CryptoTests/Key Derivation/ECprivateKeysFromSeeds.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Tests/CryptoTests/Signatures/ECDSA/ECDSASignatureTests.swift
+++ b/Tests/CryptoTests/Signatures/ECDSA/ECDSASignatureTests.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Tests/CryptoTests/Utils/Boring/CTRDRBG.swift
+++ b/Tests/CryptoTests/Utils/Boring/CTRDRBG.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 #if CRYPTO_IN_SWIFTPM && CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 @_implementationOnly import CCryptoBoringSSL
 import Crypto
 

--- a/Tests/CryptoTests/Utils/Boring/SequenceDRBG.swift
+++ b/Tests/CryptoTests/Utils/Boring/SequenceDRBG.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 #if CRYPTO_IN_SWIFTPM && CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 @_implementationOnly import CCryptoBoringSSL
 import Crypto
 

--- a/Tests/CryptoTests/Utils/PrettyBytes.swift
+++ b/Tests/CryptoTests/Utils/PrettyBytes.swift
@@ -14,7 +14,11 @@
 #if CRYPTOKIT_NO_ACCESS_TO_FOUNDATION
 import SwiftSystem
 #else
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 #endif
 
 enum ByteHexEncodingErrors: Error {

--- a/Tests/CryptoTests/Utils/RFCVector.swift
+++ b/Tests/CryptoTests/Utils/RFCVector.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// This is a not-very-performant decoder of the RFC formatted test vectors.
 ///

--- a/Tests/CryptoTests/Utils/RFCVector.swift
+++ b/Tests/CryptoTests/Utils/RFCVector.swift
@@ -11,11 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
 import Foundation
-#endif
 
 /// This is a not-very-performant decoder of the RFC formatted test vectors.
 ///

--- a/Tests/CryptoTests/Utils/SplitData.swift
+++ b/Tests/CryptoTests/Utils/SplitData.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Dispatch
 
 // A testing utility that creates one contiguous and one discontiguous representation of the given Data.

--- a/Tests/_CryptoExtrasTests/AES Block Function Tests.swift
+++ b/Tests/_CryptoExtrasTests/AES Block Function Tests.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 import Crypto
 import _CryptoExtras

--- a/Tests/_CryptoExtrasTests/AES-GCM-SIV-Runner.swift
+++ b/Tests/_CryptoExtrasTests/AES-GCM-SIV-Runner.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 import Crypto
 import _CryptoExtras

--- a/Tests/_CryptoExtrasTests/AES_CBCTests.swift
+++ b/Tests/_CryptoExtrasTests/AES_CBCTests.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import _CryptoExtras
 import XCTest
 

--- a/Tests/_CryptoExtrasTests/AES_CTRTests.swift
+++ b/Tests/_CryptoExtrasTests/AES_CTRTests.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 @testable import _CryptoExtras
 import XCTest
 

--- a/Tests/_CryptoExtrasTests/ChaCha20CTRTests.swift
+++ b/Tests/_CryptoExtrasTests/ChaCha20CTRTests.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 import Crypto
 import _CryptoExtras

--- a/Tests/_CryptoExtrasTests/TestRSAEncryption.swift
+++ b/Tests/_CryptoExtrasTests/TestRSAEncryption.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 import Crypto
 import _CryptoExtras

--- a/Tests/_CryptoExtrasTests/TestRSASigning.swift
+++ b/Tests/_CryptoExtrasTests/TestRSASigning.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 import Crypto
 import CryptoBoringWrapper

--- a/Tests/_CryptoExtrasTests/Utils/BytesUtil.swift
+++ b/Tests/_CryptoExtrasTests/Utils/BytesUtil.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import XCTest
 
 enum ByteHexEncodingErrors: Error {

--- a/Tests/_CryptoExtrasTests/Utils/RFCVector.swift
+++ b/Tests/_CryptoExtrasTests/Utils/RFCVector.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 
 /// This is a not-very-performant decoder of the RFC formatted test vectors.
 ///

--- a/Tests/_CryptoExtrasTests/Utils/RFCVector.swift
+++ b/Tests/_CryptoExtrasTests/Utils/RFCVector.swift
@@ -11,11 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-#if canImport(FoundationEssentials)
-import FoundationEssentials
-#else
 import Foundation
-#endif
 
 /// This is a not-very-performant decoder of the RFC formatted test vectors.
 ///

--- a/Tests/_CryptoExtrasTests/Utils/SplitData.swift
+++ b/Tests/_CryptoExtrasTests/Utils/SplitData.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
 import Foundation
+#endif
 import Dispatch
 
 // A testing utility that creates one contiguous and one discontiguous representation of the given Data.


### PR DESCRIPTION
### Motivation:

FoundationEssentials produces smaller binaries on most platforms.

### Modifications:

Where FoundationEssentials is available, import that.

### Result:

Improved binary size