### PR TITLE
Add `MLDSA{65,87}.Errors` from CryptoKit 2025

### DIFF
--- a/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift
@@ -119,7 +119,7 @@ extension MLDSA65 {
             /// - Throws: `CryptoKitError.incorrectKeySize` if the seed is not 32 bytes long.
             init(seedRepresentation: some DataProtocol) throws {
                 guard seedRepresentation.count == MLDSA.seedByteCount else {
-                    throw CryptoKitError.incorrectKeySize
+                    throw MLDSA65.Errors.invalidInputLength
                 }
 
                 self.key = .init()
@@ -252,7 +252,7 @@ extension MLDSA65 {
             /// - Throws: `CryptoKitError.incorrectKeySize` if the raw representation is not the correct size.
             init(rawRepresentation: some DataProtocol) throws {
                 guard rawRepresentation.count == MLDSA65.InternalPublicKey.Backing.byteCount else {
-                    throw CryptoKitError.incorrectKeySize
+                    throw MLDSA65.Errors.invalidInputLength
                 }
 
                 self.key = .init()
@@ -325,6 +325,18 @@ extension MLDSA65 {
 extension MLDSA65 {
     /// The size of the signature in bytes.
     private static let signatureByteCount = Int(MLDSA65_SIGNATURE_BYTES)
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+extension MLDSA65 {
+    /// Errors that CryptoKit encounters in using module lattice digital signature algorithms.
+    public enum Errors: Error, Sendable, Hashable {
+        /// The input’s length is invalid.
+        case invalidInputLength
+
+        /// The public key doesn’t match the expected value during initialization.
+        case publicKeyMismatchDuringInitialization
+    }
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
@@ -421,7 +433,7 @@ extension MLDSA87 {
             /// - Throws: `CryptoKitError.incorrectKeySize` if the seed is not 32 bytes long.
             init(seedRepresentation: some DataProtocol) throws {
                 guard seedRepresentation.count == MLDSA.seedByteCount else {
-                    throw CryptoKitError.incorrectKeySize
+                    throw MLDSA87.Errors.invalidInputLength
                 }
 
                 self.key = .init()
@@ -554,7 +566,7 @@ extension MLDSA87 {
             /// - Throws: `CryptoKitError.incorrectKeySize` if the raw representation is not the correct size.
             init(rawRepresentation: some DataProtocol) throws {
                 guard rawRepresentation.count == MLDSA87.InternalPublicKey.Backing.byteCount else {
-                    throw CryptoKitError.incorrectKeySize
+                    throw MLDSA87.Errors.invalidInputLength
                 }
 
                 self.key = .init()
@@ -627,6 +639,18 @@ extension MLDSA87 {
 extension MLDSA87 {
     /// The size of the signature in bytes.
     private static let signatureByteCount = Int(MLDSA87_SIGNATURE_BYTES)
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+extension MLDSA87 {
+    /// Errors that CryptoKit encounters in using module lattice digital signature algorithms.
+    public enum Errors: Error, Sendable, Hashable {
+        /// The input’s length is invalid.
+        case invalidInputLength
+
+        /// The public key doesn’t match the expected value during initialization.
+        case publicKeyMismatchDuringInitialization
+    }
 }
 
 enum MLDSA {

--- a/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift.gyb
+++ b/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift.gyb
@@ -123,7 +123,7 @@ extension MLDSA${parameter_set} {
             /// - Throws: `CryptoKitError.incorrectKeySize` if the seed is not 32 bytes long.
             init(seedRepresentation: some DataProtocol) throws {
                 guard seedRepresentation.count == MLDSA.seedByteCount else {
-                    throw CryptoKitError.incorrectKeySize
+                    throw MLDSA${parameter_set}.Errors.invalidInputLength
                 }
 
                 self.key = .init()
@@ -256,7 +256,7 @@ extension MLDSA${parameter_set} {
             /// - Throws: `CryptoKitError.incorrectKeySize` if the raw representation is not the correct size.
             init(rawRepresentation: some DataProtocol) throws {
                 guard rawRepresentation.count == MLDSA${parameter_set}.InternalPublicKey.Backing.byteCount else {
-                    throw CryptoKitError.incorrectKeySize
+                    throw MLDSA${parameter_set}.Errors.invalidInputLength
                 }
 
                 self.key = .init()
@@ -329,6 +329,18 @@ extension MLDSA${parameter_set} {
 extension MLDSA${parameter_set} {
     /// The size of the signature in bytes.
     private static let signatureByteCount = Int(MLDSA${parameter_set}_SIGNATURE_BYTES)
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+extension MLDSA${parameter_set} {
+    /// Errors that CryptoKit encounters in using module lattice digital signature algorithms.
+    public enum Errors: Error, Sendable, Hashable {
+        /// The input’s length is invalid.
+        case invalidInputLength
+
+        /// The public key doesn’t match the expected value during initialization.
+        case publicKeyMismatchDuringInitialization
+    }
 }
 % end
 


### PR DESCRIPTION
Add `MLDSA{65,87}.Errors` enum from the CryptoKit 2025 API.

### Checklist
- [X] I've run tests to see all new and existing tests pass
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [X] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

The new CryptoKit API for ML-DSA includes a public [`Errors` enum](https://developer.apple.com/documentation/cryptokit/mldsa65/errors) for both parameter sets.
This PR adds the enums and uses errors when appropriate.

### Modifications:

Add `MLDSA{65,87}.Errors`, use it when appropriate in the BoringSSL implementations.

### Result:

The Swift Crypto and CryptoKit APIs are now on par.