### PR TITLE
Catch the WWDC-25 branch up to the tip of main

### DIFF
--- a/Sources/_CryptoExtras/RSA/RSA.swift
+++ b/Sources/_CryptoExtras/RSA/RSA.swift
@@ -183,7 +183,7 @@ extension _RSA.Signing {
             }
         }
         
-        /// Construct an RSA public key from a PEM representation.
+        /// Construct an RSA private key from a PEM representation.
         ///
         /// This constructor supports key sizes of 1024 bits or more. Users should validate that key sizes are appropriate
         /// for their use-case.
@@ -208,7 +208,7 @@ extension _RSA.Signing {
             }
         }
         
-        /// Construct an RSA public key from a DER representation.
+        /// Construct an RSA private key from a DER representation.
         ///
         /// This constructor supports key sizes of 1024 bits or more. Users should validate that key sizes are appropriate
         /// for their use-case.


### PR DESCRIPTION
To keep the WWDC-25 branch from rotting too badly, we'll be doing regular catch-up merges. This is the first.