### PR TITLE
Adopt Swift 6 mode

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.10
+// swift-tools-version:6.0
 //===----------------------------------------------------------------------===//
 //
 // This source file is part of the SwiftCrypto open source project

--- a/Sources/Crypto/Digests/BoringSSL/Digest_boring.swift
+++ b/Sources/Crypto/Digests/BoringSSL/Digest_boring.swift
@@ -144,7 +144,7 @@ extension SHA512: BoringSSLBackedHashFunction {
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-struct OpenSSLDigestImpl<H: BoringSSLBackedHashFunction> {
+struct OpenSSLDigestImpl<H: BoringSSLBackedHashFunction>: @unchecked Sendable {
     private var context: DigestContext<H>
 
     init() {

--- a/Sources/Crypto/KEM/BoringSSL/MLKEM_boring.swift
+++ b/Sources/Crypto/KEM/BoringSSL/MLKEM_boring.swift
@@ -29,7 +29,7 @@ import Foundation
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension MLKEM768 {
     /// A ML-KEM-768 private key.
-    struct InternalPrivateKey: Sendable, KEMPrivateKey {
+    struct InternalPrivateKey: @unchecked Sendable, KEMPrivateKey {
         private var backing: Backing
 
         /// Initialize a ML-KEM-768 private key from a random seed.
@@ -175,7 +175,7 @@ extension MLKEM768 {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension MLKEM768 {
     /// A ML-KEM-768 public key.
-    struct InternalPublicKey: Sendable, KEMPublicKey {
+    struct InternalPublicKey: @unchecked Sendable, KEMPublicKey {
         private var backing: Backing
 
         fileprivate init(privateKeyBacking: InternalPrivateKey.Backing) {
@@ -296,7 +296,7 @@ extension MLKEM768 {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension MLKEM1024 {
     /// A ML-KEM-1024 private key.
-    struct InternalPrivateKey: Sendable, KEMPrivateKey {
+    struct InternalPrivateKey: @unchecked Sendable, KEMPrivateKey {
         private var backing: Backing
 
         /// Initialize a ML-KEM-1024 private key from a random seed.
@@ -442,7 +442,7 @@ extension MLKEM1024 {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension MLKEM1024 {
     /// A ML-KEM-1024 public key.
-    struct InternalPublicKey: Sendable, KEMPublicKey {
+    struct InternalPublicKey: @unchecked Sendable, KEMPublicKey {
         private var backing: Backing
 
         fileprivate init(privateKeyBacking: InternalPrivateKey.Backing) {

--- a/Sources/Crypto/KEM/BoringSSL/MLKEM_boring.swift.gyb
+++ b/Sources/Crypto/KEM/BoringSSL/MLKEM_boring.swift.gyb
@@ -33,7 +33,7 @@ import Foundation
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension MLKEM${parameter_set} {
     /// A ML-KEM-${parameter_set} private key.
-    struct InternalPrivateKey: Sendable, KEMPrivateKey {
+    struct InternalPrivateKey: @unchecked Sendable, KEMPrivateKey {
         private var backing: Backing
 
         /// Initialize a ML-KEM-${parameter_set} private key from a random seed.
@@ -179,7 +179,7 @@ extension MLKEM${parameter_set} {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension MLKEM${parameter_set} {
     /// A ML-KEM-${parameter_set} public key.
-    struct InternalPublicKey: Sendable, KEMPublicKey {
+    struct InternalPublicKey: @unchecked Sendable, KEMPublicKey {
         private var backing: Backing
 
         fileprivate init(privateKeyBacking: InternalPrivateKey.Backing) {
@@ -205,13 +205,6 @@ extension MLKEM${parameter_set} {
         /// - Returns: The shared secret and its encapsulated version.
         func encapsulate() -> KEM.EncapsulationResult {
             self.backing.encapsulate()
-        }
-
-        /// Encapsulate a shared secret using a fixed RNG result.
-        ///
-        /// - Returns: The shared secret and its encapsulated version.
-        func encapsulateWithSeed(_ encapWithSeed: Data) -> KEM.EncapsulationResult {
-            self.backing.encapsulate(encapWithSeed)
         }
 
         /// The size of the public key in bytes.

--- a/Sources/Crypto/KEM/BoringSSL/MLKEM_wrapper.swift
+++ b/Sources/Crypto/KEM/BoringSSL/MLKEM_wrapper.swift
@@ -23,7 +23,7 @@ import Foundation
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-protocol BoringSSLBackedMLKEMPrivateKey {
+protocol BoringSSLBackedMLKEMPrivateKey: Sendable {
     associatedtype InteriorPublicKey: BoringSSLBackedMLKEMPublicKey
 
     static func generatePrivateKey() throws -> Self
@@ -51,7 +51,7 @@ extension BoringSSLBackedMLKEMPrivateKey {
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-protocol BoringSSLBackedMLKEMPublicKey {
+protocol BoringSSLBackedMLKEMPublicKey: Sendable {
     init<Bytes: DataProtocol>(rawRepresentation: Bytes) throws
 
     var rawRepresentation: Data { get }
@@ -62,7 +62,7 @@ protocol BoringSSLBackedMLKEMPublicKey {
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-protocol BoringSSLBackedMLKEMOuterPublicKey {
+protocol BoringSSLBackedMLKEMOuterPublicKey: Sendable {
     init(rawRepresentation: Data) throws
 }
 
@@ -181,7 +181,7 @@ extension MLKEM1024.InternalPublicKey: BoringSSLBackedMLKEMPublicKey {
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-struct OpenSSLMLKEMPublicKeyImpl<Parameters: BoringSSLBackedMLKEMParameters>: BoringSSLBackedMLKEMPublicKey {
+struct OpenSSLMLKEMPublicKeyImpl<Parameters: BoringSSLBackedMLKEMParameters>: BoringSSLBackedMLKEMPublicKey, Sendable {
     private var backing: Parameters.BackingPublicKey
 
     init(backing: Parameters.BackingPublicKey) {
@@ -206,7 +206,7 @@ struct OpenSSLMLKEMPublicKeyImpl<Parameters: BoringSSLBackedMLKEMParameters>: Bo
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-struct OpenSSLMLKEMPrivateKeyImpl<Parameters: BoringSSLBackedMLKEMParameters>: BoringSSLBackedMLKEMPrivateKey {
+struct OpenSSLMLKEMPrivateKeyImpl<Parameters: BoringSSLBackedMLKEMParameters>: BoringSSLBackedMLKEMPrivateKey, Sendable {
     typealias InteriorPublicKey = OpenSSLMLKEMPublicKeyImpl<Parameters>
 
     private var backing: Parameters.BackingPrivateKey

--- a/Sources/Crypto/Keys/EC/BoringSSL/Ed25519_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/Ed25519_boring.swift
@@ -27,7 +27,7 @@ import Foundation
 extension Curve25519.Signing {
     @usableFromInline
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    struct OpenSSLCurve25519PrivateKeyImpl {
+    struct OpenSSLCurve25519PrivateKeyImpl: Sendable {
         var _privateKey: SecureBytes
         @usableFromInline var _publicKey: [UInt8]
 
@@ -99,7 +99,7 @@ extension Curve25519.Signing {
 
     @usableFromInline
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    struct OpenSSLCurve25519PublicKeyImpl {
+    struct OpenSSLCurve25519PublicKeyImpl: Sendable {
         @usableFromInline
         var keyBytes: [UInt8]
 

--- a/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
@@ -64,7 +64,7 @@ extension P521: OpenSSLSupportedNISTCurve {
 
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-struct OpenSSLNISTCurvePrivateKeyImpl<Curve: OpenSSLSupportedNISTCurve> {
+struct OpenSSLNISTCurvePrivateKeyImpl<Curve: OpenSSLSupportedNISTCurve>: Sendable {
     @usableFromInline
     var key: BoringSSLECPrivateKeyWrapper<Curve>
 
@@ -95,7 +95,7 @@ struct OpenSSLNISTCurvePrivateKeyImpl<Curve: OpenSSLSupportedNISTCurve> {
 
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-struct OpenSSLNISTCurvePublicKeyImpl<Curve: OpenSSLSupportedNISTCurve> {
+struct OpenSSLNISTCurvePublicKeyImpl<Curve: OpenSSLSupportedNISTCurve>: Sendable {
     @usableFromInline
     var key: BoringSSLECPublicKeyWrapper<Curve>
 
@@ -145,9 +145,9 @@ struct OpenSSLNISTCurvePublicKeyImpl<Curve: OpenSSLSupportedNISTCurve> {
 /// allows some helper operations.
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-class BoringSSLECPrivateKeyWrapper<Curve: OpenSSLSupportedNISTCurve> {
+class BoringSSLECPrivateKeyWrapper<Curve: OpenSSLSupportedNISTCurve>: @unchecked Sendable {
     @usableFromInline
-    var key: OpaquePointer
+    let key: OpaquePointer
 
     init(compactRepresentable: Bool) throws {
         // We cannot handle allocation failure.
@@ -350,9 +350,9 @@ class BoringSSLECPrivateKeyWrapper<Curve: OpenSSLSupportedNISTCurve> {
 /// allows some helper operations.
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-class BoringSSLECPublicKeyWrapper<Curve: OpenSSLSupportedNISTCurve> {
+class BoringSSLECPublicKeyWrapper<Curve: OpenSSLSupportedNISTCurve>: @unchecked Sendable {
     @usableFromInline
-    var key: OpaquePointer
+    let key: OpaquePointer
 
     init<Bytes: ContiguousBytes>(compactRepresentation bytes: Bytes) throws {
         let group = Curve.group

--- a/Sources/Crypto/Keys/EC/BoringSSL/X25519Keys_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/X25519Keys_boring.swift
@@ -29,7 +29,7 @@ extension Curve25519.KeyAgreement {
 
     @usableFromInline
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    struct OpenSSLCurve25519PublicKeyImpl {
+    struct OpenSSLCurve25519PublicKeyImpl: Sendable {
         @usableFromInline
         var keyBytes: [UInt8]
 
@@ -57,7 +57,7 @@ extension Curve25519.KeyAgreement {
 
     @usableFromInline
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    struct OpenSSLCurve25519PrivateKeyImpl {
+    struct OpenSSLCurve25519PrivateKeyImpl: Sendable {
         var key: SecureBytes
 
         @usableFromInline

--- a/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift
@@ -36,7 +36,7 @@ import Foundation
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension MLDSA65 {
     /// A ML-DSA-65 private key.
-    struct InternalPrivateKey: Sendable {
+    struct InternalPrivateKey: @unchecked Sendable {
         private var backing: Backing
 
         /// Initialize a ML-DSA-65 private key from a random seed.
@@ -193,7 +193,7 @@ extension MLDSA65 {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension MLDSA65 {
     /// A ML-DSA-65 public key.
-    struct InternalPublicKey: Sendable {
+    struct InternalPublicKey: @unchecked Sendable {
         private var backing: Backing
 
         fileprivate init(privateKeyBacking: InternalPrivateKey.Backing) {
@@ -338,7 +338,7 @@ extension MLDSA65 {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension MLDSA87 {
     /// A ML-DSA-87 private key.
-    struct InternalPrivateKey: Sendable {
+    struct InternalPrivateKey: @unchecked Sendable {
         private var backing: Backing
 
         /// Initialize a ML-DSA-87 private key from a random seed.
@@ -495,7 +495,7 @@ extension MLDSA87 {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension MLDSA87 {
     /// A ML-DSA-87 public key.
-    struct InternalPublicKey: Sendable {
+    struct InternalPublicKey: @unchecked Sendable {
         private var backing: Backing
 
         fileprivate init(privateKeyBacking: InternalPrivateKey.Backing) {

--- a/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift.gyb
+++ b/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift.gyb
@@ -40,7 +40,7 @@ import Foundation
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension MLDSA${parameter_set} {
     /// A ML-DSA-${parameter_set} private key.
-    struct InternalPrivateKey: Sendable {
+    struct InternalPrivateKey: @unchecked Sendable {
         private var backing: Backing
 
         /// Initialize a ML-DSA-${parameter_set} private key from a random seed.
@@ -197,7 +197,7 @@ extension MLDSA${parameter_set} {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension MLDSA${parameter_set} {
     /// A ML-DSA-${parameter_set} public key.
-    struct InternalPublicKey: Sendable {
+    struct InternalPublicKey: @unchecked Sendable {
         private var backing: Backing
 
         fileprivate init(privateKeyBacking: InternalPrivateKey.Backing) {

--- a/Sources/Crypto/Signatures/BoringSSL/MLDSA_wrapper.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/MLDSA_wrapper.swift
@@ -23,7 +23,7 @@ import Foundation
 #endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-protocol BoringSSLBackedMLDSAPrivateKey {
+protocol BoringSSLBackedMLDSAPrivateKey: Sendable {
     associatedtype AssociatedPublicKey: BoringSSLBackedMLDSAPublicKey
 
     init() throws
@@ -40,7 +40,7 @@ protocol BoringSSLBackedMLDSAPrivateKey {
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-protocol BoringSSLBackedMLDSAPublicKey {
+protocol BoringSSLBackedMLDSAPublicKey: Sendable {
     init<D: DataProtocol>(rawRepresentation: D) throws
 
     func isValidSignature<S: DataProtocol, D: DataProtocol>(_: S, for data: D) -> Bool

--- a/Sources/CryptoBoringWrapper/EC/EllipticCurve.swift
+++ b/Sources/CryptoBoringWrapper/EC/EllipticCurve.swift
@@ -17,7 +17,7 @@
 /// liveness.
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-package final class BoringSSLEllipticCurveGroup {
+package final class BoringSSLEllipticCurveGroup: @unchecked Sendable {
     @usableFromInline var _group: OpaquePointer
 
     @usableFromInline package let order: ArbitraryPrecisionInteger

--- a/Sources/CryptoBoringWrapper/Util/FiniteFieldArithmeticContext.swift
+++ b/Sources/CryptoBoringWrapper/Util/FiniteFieldArithmeticContext.swift
@@ -34,9 +34,9 @@ import Foundation
 /// ourselves.
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-package class FiniteFieldArithmeticContext {
-    private var fieldSize: ArbitraryPrecisionInteger
-    package var bnCtx: OpaquePointer
+package class FiniteFieldArithmeticContext: @unchecked Sendable {
+    private let fieldSize: ArbitraryPrecisionInteger
+    package let bnCtx: OpaquePointer
 
     @usableFromInline
     package init(fieldSize: ArbitraryPrecisionInteger) throws {

--- a/Sources/_CryptoExtras/ARC/ARCPrecredential.swift
+++ b/Sources/_CryptoExtras/ARC/ARCPrecredential.swift
@@ -20,7 +20,7 @@ import Foundation
 
 @available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, macCatalyst 13.2, visionOS 1.2, *)
 extension ARC {
-    struct ClientSecrets<Scalar> {
+    struct ClientSecrets<Scalar: GroupScalar> {
         let m1: Scalar // secret at request and verification
         let m2: Scalar // secret at request, public at verification (server expected to know value)
         let r1: Scalar // secret blinding factor for m1

--- a/Sources/_CryptoExtras/ARC/ARCServer.swift
+++ b/Sources/_CryptoExtras/ARC/ARCServer.swift
@@ -20,7 +20,7 @@ import Foundation
 
 @available(macOS 10.15, iOS 13.2, tvOS 13.2, watchOS 6.1, macCatalyst 13.2, visionOS 1.2, *)
 extension ARC {
-    struct ServerPrivateKey<Scalar> {
+    struct ServerPrivateKey<Scalar: GroupScalar> {
         let x0: Scalar
         let x1: Scalar
         let x2: Scalar

--- a/Sources/_CryptoExtras/ECToolbox/ECToolbox.swift
+++ b/Sources/_CryptoExtras/ECToolbox/ECToolbox.swift
@@ -57,7 +57,7 @@ protocol HashToGroup {
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-protocol GroupScalar {
+protocol GroupScalar: Sendable {
     init(bytes: Data, reductionIsModOrder: Bool) throws
 
     var rawRepresentation: Data { get }
@@ -80,7 +80,7 @@ protocol GroupScalar {
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-protocol GroupElement {
+protocol GroupElement: Sendable {
     associatedtype Scalar: GroupScalar
 
     static var generator: Self { get }

--- a/Sources/_CryptoExtras/RSA/RSA_boring.swift
+++ b/Sources/_CryptoExtras/RSA/RSA_boring.swift
@@ -200,7 +200,7 @@ extension BoringSSLRSAPublicKey {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension BoringSSLRSAPublicKey {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    fileprivate final class Backing {
+    fileprivate final class Backing: @unchecked Sendable {
         private let pointer: OpaquePointer
 
         fileprivate init(takingOwnershipOf pointer: OpaquePointer) {
@@ -571,7 +571,7 @@ extension BoringSSLRSAPublicKey {
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension BoringSSLRSAPrivateKey {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    fileprivate final class Backing {
+    fileprivate final class Backing: @unchecked Sendable {
         private let pointer: OpaquePointer
 
         fileprivate init(copying other: Backing) {

--- a/Sources/_CryptoExtras/Util/DigestType.swift
+++ b/Sources/_CryptoExtras/Util/DigestType.swift
@@ -17,12 +17,12 @@
 import Crypto
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-struct DigestType {
-    var dispatchTable: OpaquePointer
+struct DigestType: @unchecked Sendable {
+    let dispatchTable: OpaquePointer
 
-    var nid: CInt
+    let nid: CInt
 
-    var digestLength: Int
+    let digestLength: Int
 
     /// The dispatchtable pointer must have static storage and not be lifetime managed,
     /// as it is assumed to last for the duration of the program.


### PR DESCRIPTION
Motivation

The Swift 6 language mode adopts data-race safety by default. While Swift Crypto itself has no concurrent code, it is still useful to force us to ensure that our code is properly Sendable-correct.

Modifications

- @unchecked Sendable on several CoW data types
- Some necessary Sendable constraints on ECToolbox protocols
- Add some missing protocol constraints on ARC types.

Result

Swift 6 clean.