### PR TITLE
Enable Windows CI on main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,14 @@ jobs:
       linux_6_1_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
       linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_6_0_enabled: true
+      windows_6_1_enabled: true
+      windows_nightly_next_enabled: true
+      windows_nightly_main_enabled: true
+      windows_6_0_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_6_1_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   cxx-interop:
     name: Cxx interop


### PR DESCRIPTION
This PR enables Windows CI on `main`, as well as on PRs.