### PR TITLE
[WIP] Align Sendable annotations with CryptoKit

### DIFF
--- a/Sources/Crypto/AEADs/AES/GCM/AES-GCM.swift
+++ b/Sources/Crypto/AEADs/AES/GCM/AES-GCM.swift
@@ -30,7 +30,7 @@ extension AES {
     /// The Advanced Encryption Standard (AES) Galois Counter Mode (GCM) cipher
     /// suite.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public enum GCM: Cipher {
+    public enum GCM: Cipher, Sendable {
         static let tagByteCount = 16
         static let defaultNonceByteCount = 12
         
@@ -112,7 +112,7 @@ extension AES.GCM {
     /// The receiver uses another instance of the same cipher, like the
     /// ``open(_:using:)`` method, to open the box.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public struct SealedBox: AEADSealedBox {
+    public struct SealedBox: AEADSealedBox, Sendable {
         private let combinedRepresentation: Data
         private let nonceByteCount: Int
         

--- a/Sources/Crypto/AEADs/ChachaPoly/ChaChaPoly.swift
+++ b/Sources/Crypto/AEADs/ChachaPoly/ChaChaPoly.swift
@@ -27,7 +27,7 @@ import Foundation
 
 /// An implementation of the ChaCha20-Poly1305 cipher.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public enum ChaChaPoly: Cipher {
+public enum ChaChaPoly: Cipher, Sendable {
     static let tagByteCount = 16
     static let keyBitsCount = 256
     static let nonceByteCount = 12
@@ -111,7 +111,7 @@ extension ChaChaPoly {
     /// ``open(_:using:)`` method, to open the box.
     @frozen
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public struct SealedBox: AEADSealedBox {
+    public struct SealedBox: AEADSealedBox, Sendable {
         /// A combined element composed of the tag, the nonce, and the
         /// ciphertext.
         ///

--- a/Sources/Crypto/AEADs/Nonces.swift
+++ b/Sources/Crypto/AEADs/Nonces.swift
@@ -28,7 +28,7 @@ extension AES.GCM {
     /// that nonces are unique per call to encryption APIs in order to protect the
     /// integrity of the encryption.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public struct Nonce: ContiguousBytes, Sequence {
+    public struct Nonce: ContiguousBytes, Sequence, Sendable {
         let bytes: Data
 
         /// Creates a new random nonce.
@@ -92,7 +92,7 @@ extension ChaChaPoly {
     /// that nonces are unique per call to encryption APIs in order to protect the
     /// integrity of the encryption.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public struct Nonce: ContiguousBytes, Sequence {
+    public struct Nonce: ContiguousBytes, Sequence, Sendable {
         let bytes: Data
 
         /// Creates a new random nonce.

--- a/Sources/Crypto/Digests/BoringSSL/Digest_boring.swift
+++ b/Sources/Crypto/Digests/BoringSSL/Digest_boring.swift
@@ -144,7 +144,7 @@ extension SHA512: BoringSSLBackedHashFunction {
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-struct OpenSSLDigestImpl<H: BoringSSLBackedHashFunction> {
+struct OpenSSLDigestImpl<H: BoringSSLBackedHashFunction>: Sendable {
     private var context: DigestContext<H>
 
     init() {

--- a/Sources/Crypto/Digests/Digest.swift
+++ b/Sources/Crypto/Digests/Digest.swift
@@ -18,7 +18,7 @@ import Foundation
 
 /// A type that represents the output of a hash.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public protocol Digest: Hashable, ContiguousBytes, CustomStringConvertible, Sequence where Element == UInt8 {
+public protocol Digest: Hashable, ContiguousBytes, CustomStringConvertible, Sequence, Sendable where Element == UInt8 {
     /// The number of bytes in the digest.
     static var byteCount: Int { get }
 }

--- a/Sources/Crypto/Digests/Digests.swift
+++ b/Sources/Crypto/Digests/Digests.swift
@@ -241,7 +241,7 @@ extension Insecure {
 // MARK: - SHA1Digest + DigestPrivate
 /// The output of a SHA1 hash.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public struct SHA1Digest: DigestPrivate {
+public struct SHA1Digest: DigestPrivate, Sendable {
     let bytes: (UInt64, UInt64, UInt64)
     
     init?(bufferPointer: UnsafeRawBufferPointer) {
@@ -312,7 +312,7 @@ extension Insecure {
 // MARK: - MD5Digest + DigestPrivate
 /// The output of a MD5 hash.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public struct MD5Digest: DigestPrivate {
+public struct MD5Digest: DigestPrivate, Sendable {
     let bytes: (UInt64, UInt64)
     
     init?(bufferPointer: UnsafeRawBufferPointer) {

--- a/Sources/Crypto/Digests/HashFunctions.swift
+++ b/Sources/Crypto/Digests/HashFunctions.swift
@@ -43,7 +43,7 @@ import Foundation
 /// incorporate a secret cryptographic key into the digest computation. Only a
 /// user that has the key can generate a valid MAC.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public protocol HashFunction {
+public protocol HashFunction: Sendable {
     /// The number of bytes that represents the hash function’s internal state.
     static var blockByteCount: Int { get }
     #if !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API

--- a/Sources/Crypto/Digests/HashFunctions_SHA2.swift
+++ b/Sources/Crypto/Digests/HashFunctions_SHA2.swift
@@ -27,7 +27,7 @@
 /// instance, calling the ``update(data:)`` method repeatedly with blocks of
 /// data, and then calling the ``finalize()`` method to get the result.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public struct SHA256: HashFunctionImplementationDetails {
+public struct SHA256: HashFunctionImplementationDetails, Sendable {
     /// The number of bytes that represents the hash function’s internal state.
     public static var blockByteCount: Int {
         get { 64 }
@@ -110,7 +110,7 @@ public struct SHA256: HashFunctionImplementationDetails {
 /// instance, calling the ``update(data:)`` method repeatedly with blocks of
 /// data, and then calling the ``finalize()`` method to get the result.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public struct SHA384: HashFunctionImplementationDetails {
+public struct SHA384: HashFunctionImplementationDetails, Sendable {
     /// The number of bytes that represents the hash function’s internal state.
     public static var blockByteCount: Int {
         get { 128 }
@@ -194,7 +194,7 @@ public struct SHA384: HashFunctionImplementationDetails {
 /// instance, calling the ``update(data:)`` method repeatedly with blocks of
 /// data, and then calling the ``finalize()`` method to get the result.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public struct SHA512: HashFunctionImplementationDetails {
+public struct SHA512: HashFunctionImplementationDetails, Sendable {
     /// The number of bytes that represents the hash function’s internal state.
     public static var blockByteCount: Int {
         get { 128 }

--- a/Sources/Crypto/HPKE/Ciphersuite/HPKE-AEAD.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/HPKE-AEAD.swift
@@ -21,7 +21,7 @@ import Foundation
 extension HPKE {
     /// The authenticated encryption with associated data (AEAD) algorithms to use in HPKE.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public enum AEAD: CaseIterable, Hashable {
+    public enum AEAD: CaseIterable, Hashable, Sendable {
 		/// An Advanced Encryption Standard cipher in Galois/Counter Mode with a key length of 128 bits.
         case AES_GCM_128
 		/// An Advanced Encryption Standard cipher in Galois/Counter Mode with a key length of 256 bits.

--- a/Sources/Crypto/HPKE/Ciphersuite/HPKE-Ciphersuite.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/HPKE-Ciphersuite.swift
@@ -26,7 +26,7 @@ extension HPKE {
     /// mechanism (KEM) for sharing the symmetric key. The sender and recipient of encrypted messages need to use the
     /// same cipher suite.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public struct Ciphersuite {
+    public struct Ciphersuite: Sendable {
 		/// A cipher suite for HPKE that uses NIST P-256 elliptic curve key agreement, SHA-2 key derivation
         /// with a 256-bit digest, and the Advanced Encryption Standard cipher in Galois/Counter Mode with a key length of 256 bits.
         public static let P256_SHA256_AES_GCM_256 = Ciphersuite(kem: .P256_HKDF_SHA256, kdf: .HKDF_SHA256, aead: .AES_GCM_256)

--- a/Sources/Crypto/HPKE/Ciphersuite/HPKE-KDF.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/HPKE-KDF.swift
@@ -20,7 +20,7 @@ import Foundation
 extension HPKE {
     /// The key derivation functions to use in HPKE.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public enum KDF: CaseIterable, Hashable {
+    public enum KDF: CaseIterable, Hashable, Sendable {
 		/// An HMAC-based key derivation function that uses SHA-2 hashing with a 256-bit digest.
         case HKDF_SHA256
 		/// An HMAC-based key derivation function that uses SHA-2 hashing with a 384-bit digest.

--- a/Sources/Crypto/HPKE/Ciphersuite/KEM/Conformances/DHKEM.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/KEM/Conformances/DHKEM.swift
@@ -18,7 +18,7 @@ import Foundation
 
 /// A type that ``HPKE`` uses to encode the public key.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public protocol HPKEPublicKeySerialization {
+public protocol HPKEPublicKeySerialization: Sendable {
 	/// Creates a public key from an encoded representation.
 	///
 	/// - Parameters:
@@ -57,7 +57,7 @@ public protocol HPKEDiffieHellmanPrivateKeyGeneration: HPKEDiffieHellmanPrivateK
 extension HPKE {
 	/// A container for Diffie-Hellman key encapsulation mechanisms (KEMs).
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public enum DHKEM {
+    public enum DHKEM: Sendable {
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
         struct PublicKey<DHPK: HPKEDiffieHellmanPublicKey>: KEMPublicKey where DHPK == DHPK.EphemeralPrivateKey.PublicKey {
             let kem: HPKE.KEM

--- a/Sources/Crypto/HPKE/Ciphersuite/KEM/HPKE-KEM.swift
+++ b/Sources/Crypto/HPKE/Ciphersuite/KEM/HPKE-KEM.swift
@@ -20,7 +20,7 @@ import Foundation
 extension HPKE {
 	/// The key encapsulation mechanisms to use in HPKE.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public enum KEM: CaseIterable, Hashable {
+    public enum KEM: CaseIterable, Hashable, Sendable {
 		/// A key encapsulation mechanism using NIST P-256 elliptic curve key agreement
 		/// and SHA-2 hashing with a 256-bit digest.
         case P256_HKDF_SHA256

--- a/Sources/Crypto/HPKE/HPKE.swift
+++ b/Sources/Crypto/HPKE/HPKE.swift
@@ -46,7 +46,7 @@ import Foundation
 /// ### Handling errors
 ///  - ``Errors``
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public enum HPKE {}
+public enum HPKE: Sendable {}
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension HPKE {
@@ -59,7 +59,7 @@ extension HPKE {
     /// same order as the `Sender`, using the same encryption mode, cipher suite, and key schedule information
     ///  (`info`), as well as the `Sender`'s ``encapsulatedKey``.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public struct Sender {
+    public struct Sender: Sendable {
         private var context: Context
         /// The encapsulated symmetric key that the recipient uses to decrypt messages.
         public let encapsulatedKey: Data
@@ -197,7 +197,7 @@ extension HPKE {
     /// (`info` data).
     /// Use a separate `Recipient` instance for each stream of messages.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public struct Recipient {
+    public struct Recipient: Sendable {
         
         private var context: Context
 

--- a/Sources/Crypto/Insecure/Insecure.swift
+++ b/Sources/Crypto/Insecure/Insecure.swift
@@ -20,5 +20,5 @@
 /// but the framework provides them for backward compatibility with older
 /// services that require them. For new services, avoid these algorithms.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public enum Insecure {}
+public enum Insecure: Sendable {}
 #endif // Linux or !SwiftPM

--- a/Sources/Crypto/Insecure/Insecure_HashFunctions.swift
+++ b/Sources/Crypto/Insecure/Insecure_HashFunctions.swift
@@ -33,7 +33,7 @@ extension Insecure {
     /// that require it. For new services, prefer one of the secure hashes, like
     /// ``SHA512``.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public struct SHA1: HashFunctionImplementationDetails {
+    public struct SHA1: HashFunctionImplementationDetails, Sendable {
         /// The number of bytes that represents the hash function’s internal
         /// state.
         public static var blockByteCount: Int {
@@ -122,7 +122,7 @@ extension Insecure {
     /// that require it. For new services, prefer one of the secure hashes, like
     /// ``SHA512``.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public struct MD5: HashFunctionImplementationDetails {
+    public struct MD5: HashFunctionImplementationDetails, Sendable {
         /// The number of bytes that represents the hash function’s internal
         /// state.
         public static var blockByteCount: Int {

--- a/Sources/Crypto/KEM/KEM.swift
+++ b/Sources/Crypto/KEM/KEM.swift
@@ -18,10 +18,10 @@ import Foundation
 
 /// A Key Encapsulation Mechanism
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public enum KEM {
+public enum KEM: Sendable {
     /// The result of an encapsulation operation
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public struct EncapsulationResult {
+    public struct EncapsulationResult: Sendable {
         /// The shared secret
         public let sharedSecret: SymmetricKey
         /// The encapsulated secret
@@ -36,7 +36,7 @@ public enum KEM {
 
 /// A Key Encapsulation Mechanism's Public Key
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public protocol KEMPublicKey {
+public protocol KEMPublicKey: Sendable {
     /// Encapsulates the generated shared secret
     /// - Returns: The shared secret and its encapsulated version
     func encapsulate() throws -> KEM.EncapsulationResult
@@ -44,7 +44,7 @@ public protocol KEMPublicKey {
 
 /// A Key Encapsulation Mechanism's Private Key
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public protocol KEMPrivateKey {
+public protocol KEMPrivateKey: Sendable {
     associatedtype PublicKey: KEMPublicKey
     
     /// Generate a new random Private Key

--- a/Sources/Crypto/Key Agreement/DH.swift
+++ b/Sources/Crypto/Key Agreement/DH.swift
@@ -18,9 +18,9 @@ import Foundation
 
 /// A Diffie-Hellman Key Agreement Key
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public protocol DiffieHellmanKeyAgreement {
+public protocol DiffieHellmanKeyAgreement: Sendable {
     /// The public key share type to perform the DH Key Agreement
-    associatedtype PublicKey
+    associatedtype PublicKey: Sendable
     var publicKey: PublicKey { get }
 
     /// Performs a Diffie-Hellman Key Agreement.
@@ -49,7 +49,7 @@ public protocol DiffieHellmanKeyAgreement {
 /// ``HMAC``, or for opening and closing a sealed box with a cipher like
 /// ``ChaChaPoly`` or ``AES``.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public struct SharedSecret: ContiguousBytes {
+public struct SharedSecret: ContiguousBytes, Sendable {
     var ss: SecureBytes
 
     /// Invokes the given closure with a buffer pointer covering the raw bytes

--- a/Sources/Crypto/Key Agreement/ECDH.swift
+++ b/Sources/Crypto/Key Agreement/ECDH.swift
@@ -39,11 +39,11 @@ extension P256 {
     /// A mechanism used to create or verify a cryptographic signature using
     /// the NIST P-256 elliptic curve digital signature algorithm (ECDSA).
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public enum Signing {
+    public enum Signing: Sendable {
             
         /// A P-256 public key used to verify cryptographic signatures.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PublicKey: NISTECPublicKey {
+        public struct PublicKey: NISTECPublicKey, Sendable {
             var impl: NISTCurvePublicKeyImpl<P256>
 
             /// Creates a P-256 public key for signing from a collection of bytes.
@@ -143,7 +143,7 @@ extension P256 {
 
         /// A P-256 private key used to create cryptographic signatures.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PrivateKey: NISTECPrivateKey {
+        public struct PrivateKey: NISTECPrivateKey, Sendable {
             let impl: NISTCurvePrivateKeyImpl<P256>
 
             /// Creates a random P-256 private key for signing.
@@ -258,11 +258,11 @@ extension P256 {
     /// performing NIST P-256 elliptic curve Diffie Hellman (ECDH) key
     /// exchange.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public enum KeyAgreement {
+    public enum KeyAgreement: Sendable {
             
         /// A P-256 public key used for key agreement.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PublicKey: NISTECPublicKey {
+        public struct PublicKey: NISTECPublicKey, Sendable {
             var impl: NISTCurvePublicKeyImpl<P256>
 
             /// Creates a P-256 public key for key agreement from a collection of bytes.
@@ -362,7 +362,7 @@ extension P256 {
 
         /// A P-256 private key used for key agreement.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PrivateKey: NISTECPrivateKey {
+        public struct PrivateKey: NISTECPrivateKey, Sendable {
             let impl: NISTCurvePrivateKeyImpl<P256>
 
             /// Creates a random P-256 private key for key agreement.
@@ -476,11 +476,11 @@ extension P384 {
     /// A mechanism used to create or verify a cryptographic signature using
     /// the NIST P-384 elliptic curve digital signature algorithm (ECDSA).
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public enum Signing {
+    public enum Signing: Sendable {
             
         /// A P-384 public key used to verify cryptographic signatures.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PublicKey: NISTECPublicKey {
+        public struct PublicKey: NISTECPublicKey, Sendable {
             var impl: NISTCurvePublicKeyImpl<P384>
 
             /// Creates a P-384 public key for signing from a collection of bytes.
@@ -580,7 +580,7 @@ extension P384 {
 
         /// A P-384 private key used to create cryptographic signatures.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PrivateKey: NISTECPrivateKey {
+        public struct PrivateKey: NISTECPrivateKey, Sendable {
             let impl: NISTCurvePrivateKeyImpl<P384>
 
             /// Creates a random P-384 private key for signing.
@@ -695,11 +695,11 @@ extension P384 {
     /// performing NIST P-384 elliptic curve Diffie Hellman (ECDH) key
     /// exchange.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public enum KeyAgreement {
+    public enum KeyAgreement: Sendable {
             
         /// A P-384 public key used for key agreement.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PublicKey: NISTECPublicKey {
+        public struct PublicKey: NISTECPublicKey, Sendable {
             var impl: NISTCurvePublicKeyImpl<P384>
 
             /// Creates a P-384 public key for key agreement from a collection of bytes.
@@ -799,7 +799,7 @@ extension P384 {
 
         /// A P-384 private key used for key agreement.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PrivateKey: NISTECPrivateKey {
+        public struct PrivateKey: NISTECPrivateKey, Sendable {
             let impl: NISTCurvePrivateKeyImpl<P384>
 
             /// Creates a random P-384 private key for key agreement.
@@ -913,11 +913,11 @@ extension P521 {
     /// A mechanism used to create or verify a cryptographic signature using
     /// the NIST P-521 elliptic curve digital signature algorithm (ECDSA).
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public enum Signing {
+    public enum Signing: Sendable {
             
         /// A P-521 public key used to verify cryptographic signatures.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PublicKey: NISTECPublicKey {
+        public struct PublicKey: NISTECPublicKey, Sendable {
             var impl: NISTCurvePublicKeyImpl<P521>
 
             /// Creates a P-521 public key for signing from a collection of bytes.
@@ -1017,7 +1017,7 @@ extension P521 {
 
         /// A P-521 private key used to create cryptographic signatures.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PrivateKey: NISTECPrivateKey {
+        public struct PrivateKey: NISTECPrivateKey, Sendable {
             let impl: NISTCurvePrivateKeyImpl<P521>
 
             /// Creates a random P-521 private key for signing.
@@ -1132,11 +1132,11 @@ extension P521 {
     /// performing NIST P-521 elliptic curve Diffie Hellman (ECDH) key
     /// exchange.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public enum KeyAgreement {
+    public enum KeyAgreement: Sendable {
             
         /// A P-521 public key used for key agreement.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PublicKey: NISTECPublicKey {
+        public struct PublicKey: NISTECPublicKey, Sendable {
             var impl: NISTCurvePublicKeyImpl<P521>
 
             /// Creates a P-521 public key for key agreement from a collection of bytes.
@@ -1236,7 +1236,7 @@ extension P521 {
 
         /// A P-521 private key used for key agreement.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PrivateKey: NISTECPrivateKey {
+        public struct PrivateKey: NISTECPrivateKey, Sendable {
             let impl: NISTCurvePrivateKeyImpl<P521>
 
             /// Creates a random P-521 private key for key agreement.

--- a/Sources/Crypto/Key Derivation/HKDF.swift
+++ b/Sources/Crypto/Key Derivation/HKDF.swift
@@ -35,7 +35,7 @@ import Android
 /// ``expand(pseudoRandomKey:info:outputByteCount:)`` using that key material to
 /// generate a symmetric key of the length you specify.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public struct HKDF<H: HashFunction> {
+public struct HKDF<H: HashFunction>: Sendable {
     /// Derives a symmetric encryption key from a main key or passcode using
     /// HKDF key derivation with information and salt you specify.
     ///

--- a/Sources/Crypto/Key Wrapping/AESWrap.swift
+++ b/Sources/Crypto/Key Wrapping/AESWrap.swift
@@ -29,7 +29,7 @@ extension AES {
     /// An implementation of AES Key Wrapping in accordance with the IETF RFC
     /// 3394 specification.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public enum KeyWrap {
+    public enum KeyWrap: Sendable {
         /// Wraps a key using the AES wrap algorithm.
         ///
         /// Wrap is an implementation of the AES key wrap algorithm as specified

--- a/Sources/Crypto/Keys/EC/BoringSSL/Ed25519_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/Ed25519_boring.swift
@@ -23,7 +23,7 @@ import Foundation
 extension Curve25519.Signing {
     @usableFromInline
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    struct OpenSSLCurve25519PrivateKeyImpl {
+    struct OpenSSLCurve25519PrivateKeyImpl: Sendable {
         var _privateKey: SecureBytes
         @usableFromInline var _publicKey: [UInt8]
 
@@ -95,7 +95,7 @@ extension Curve25519.Signing {
 
     @usableFromInline
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    struct OpenSSLCurve25519PublicKeyImpl {
+    struct OpenSSLCurve25519PublicKeyImpl: Sendable {
         @usableFromInline
         var keyBytes: [UInt8]
 

--- a/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
@@ -60,7 +60,7 @@ extension P521: OpenSSLSupportedNISTCurve {
 
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-struct OpenSSLNISTCurvePrivateKeyImpl<Curve: OpenSSLSupportedNISTCurve> {
+struct OpenSSLNISTCurvePrivateKeyImpl<Curve: OpenSSLSupportedNISTCurve>: Sendable {
     @usableFromInline
     var key: BoringSSLECPrivateKeyWrapper<Curve>
 
@@ -91,7 +91,7 @@ struct OpenSSLNISTCurvePrivateKeyImpl<Curve: OpenSSLSupportedNISTCurve> {
 
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-struct OpenSSLNISTCurvePublicKeyImpl<Curve: OpenSSLSupportedNISTCurve> {
+struct OpenSSLNISTCurvePublicKeyImpl<Curve: OpenSSLSupportedNISTCurve>: Sendable {
     @usableFromInline
     var key: BoringSSLECPublicKeyWrapper<Curve>
 
@@ -141,7 +141,7 @@ struct OpenSSLNISTCurvePublicKeyImpl<Curve: OpenSSLSupportedNISTCurve> {
 /// allows some helper operations.
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-class BoringSSLECPrivateKeyWrapper<Curve: OpenSSLSupportedNISTCurve> {
+class BoringSSLECPrivateKeyWrapper<Curve: OpenSSLSupportedNISTCurve>: @unchecked Sendable {
     @usableFromInline
     var key: OpaquePointer
 
@@ -346,7 +346,7 @@ class BoringSSLECPrivateKeyWrapper<Curve: OpenSSLSupportedNISTCurve> {
 /// allows some helper operations.
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-class BoringSSLECPublicKeyWrapper<Curve: OpenSSLSupportedNISTCurve> {
+class BoringSSLECPublicKeyWrapper<Curve: OpenSSLSupportedNISTCurve>: @unchecked Sendable {
     @usableFromInline
     var key: OpaquePointer
 

--- a/Sources/Crypto/Keys/EC/BoringSSL/X25519Keys_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/X25519Keys_boring.swift
@@ -25,7 +25,7 @@ extension Curve25519.KeyAgreement {
 
     @usableFromInline
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    struct OpenSSLCurve25519PublicKeyImpl {
+    struct OpenSSLCurve25519PublicKeyImpl: Sendable {
         @usableFromInline
         var keyBytes: [UInt8]
 
@@ -53,7 +53,7 @@ extension Curve25519.KeyAgreement {
 
     @usableFromInline
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    struct OpenSSLCurve25519PrivateKeyImpl {
+    struct OpenSSLCurve25519PrivateKeyImpl: Sendable {
         var key: SecureBytes
 
         @usableFromInline

--- a/Sources/Crypto/Keys/EC/Curve25519.swift
+++ b/Sources/Crypto/Keys/EC/Curve25519.swift
@@ -16,5 +16,5 @@
 #else
 /// An elliptic curve that enables X25519 key agreement and Ed25519 signatures.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public enum Curve25519 {}
+public enum Curve25519: Sendable {}
 #endif // Linux or !SwiftPM

--- a/Sources/Crypto/Keys/EC/Ed25519Keys.swift
+++ b/Sources/Crypto/Keys/EC/Ed25519Keys.swift
@@ -28,7 +28,7 @@ extension Curve25519 {
     /// A mechanism used to create or verify a cryptographic signature using
     /// Ed25519.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public enum Signing {
+    public enum Signing: Sendable {
         #if !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
         typealias Curve25519PrivateKeyImpl = Curve25519.Signing.CoreCryptoCurve25519PrivateKeyImpl
         typealias Curve25519PublicKeyImpl = Curve25519.Signing.CoreCryptoCurve25519PublicKeyImpl
@@ -39,7 +39,7 @@ extension Curve25519 {
 
         /// A Curve25519 private key used to create cryptographic signatures.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PrivateKey: ECPrivateKey {
+        public struct PrivateKey: ECPrivateKey, Sendable {
             private var baseKey: Curve25519.Signing.Curve25519PrivateKeyImpl
             
             /// Creates a random Curve25519 private key for signing.
@@ -75,7 +75,7 @@ extension Curve25519 {
 
         /// A Curve25519 public key used to verify cryptographic signatures.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PublicKey {
+        public struct PublicKey: Sendable {
             private var baseKey: Curve25519.Signing.Curve25519PublicKeyImpl
 
             /// Creates a Curve25519 public key from a data representation.

--- a/Sources/Crypto/Keys/EC/NISTCurvesKeys.swift
+++ b/Sources/Crypto/Keys/EC/NISTCurvesKeys.swift
@@ -54,13 +54,13 @@ protocol NISTECPrivateKey: ECPrivateKey where PK: NISTECPublicKey {
 
 /// An elliptic curve that enables NIST P-256 signatures and key agreement.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public enum P256 { }
+public enum P256: Sendable { }
 
 /// An elliptic curve that enables NIST P-384 signatures and key agreement.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public enum P384 { }
+public enum P384: Sendable { }
 
 /// An elliptic curve that enables NIST P-521 signatures and key agreement.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public enum P521 { }
+public enum P521: Sendable { }
 #endif // Linux or !SwiftPM

--- a/Sources/Crypto/Keys/EC/X25519Keys.swift
+++ b/Sources/Crypto/Keys/EC/X25519Keys.swift
@@ -28,7 +28,7 @@ extension Curve25519 {
     /// A mechanism used to create a shared secret between two users by
     /// performing X25519 key agreement.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public enum KeyAgreement {
+    public enum KeyAgreement: Sendable {
         #if !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
         typealias Curve25519PrivateKeyImpl = Curve25519.KeyAgreement.CoreCryptoCurve25519PrivateKeyImpl
         typealias Curve25519PublicKeyImpl = Curve25519.KeyAgreement.CoreCryptoCurve25519PublicKeyImpl
@@ -39,7 +39,7 @@ extension Curve25519 {
 
         /// A Curve25519 public key used for key agreement.
         @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-        public struct PublicKey: ECPublicKey {
+        public struct PublicKey: ECPublicKey, Sendable {
             fileprivate var baseKey: Curve25519PublicKeyImpl
 
             /// Creates a Curve25519 public key for key agreement from a

--- a/Sources/Crypto/Keys/Symmetric/SymmetricKeys.swift
+++ b/Sources/Crypto/Keys/Symmetric/SymmetricKeys.swift
@@ -24,7 +24,7 @@ import Foundation
 /// need a key with a non-standard length, use the ``init(bitCount:)``
 /// initializer to create a `SymmetricKeySize` instance with a custom bit count.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public struct SymmetricKeySize {
+public struct SymmetricKeySize: Sendable {
     /// The number of bits in the key.
     public let bitCount: Int
 
@@ -65,7 +65,7 @@ public struct SymmetricKeySize {
 /// open and close a sealed box (``ChaChaPoly/SealedBox`` or
 /// ``AES/GCM/SealedBox``) using a cipher like ``ChaChaPoly`` or ``AES``.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public struct SymmetricKey: ContiguousBytes {
+public struct SymmetricKey: ContiguousBytes, Sendable {
     let sb: SecureBytes
 
     /// Invokes the given closure with a buffer pointer covering the raw bytes

--- a/Sources/Crypto/Message Authentication Codes/HMAC/HMAC.swift
+++ b/Sources/Crypto/Message Authentication Codes/HMAC/HMAC.swift
@@ -30,7 +30,7 @@ import Foundation
 /// ``AES`` or ``ChaChaPoly`` to put the data into a sealed box (an instance of
 /// ``AES/GCM/SealedBox`` or ``ChaChaPoly/SealedBox``).
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public struct HMAC<H: HashFunction>: MACAlgorithm {
+public struct HMAC<H: HashFunction>: MACAlgorithm, Sendable {
     /// An alias for the symmetric key type used to compute or verify a message
     /// authentication code.
     public typealias Key = SymmetricKey
@@ -195,7 +195,7 @@ public struct HMAC<H: HashFunction>: MACAlgorithm {
 
 /// A hash-based message authentication code.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public struct HashedAuthenticationCode<H: HashFunction>: MessageAuthenticationCode {
+public struct HashedAuthenticationCode<H: HashFunction>: MessageAuthenticationCode, Sendable {
     let digest: H.Digest
     
     /// The number of bytes in the message authentication code.

--- a/Sources/Crypto/Message Authentication Codes/MessageAuthenticationCode.swift
+++ b/Sources/Crypto/Message Authentication Codes/MessageAuthenticationCode.swift
@@ -18,7 +18,7 @@ import Foundation
 
 /// A type that represents a message authentication code.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public protocol MessageAuthenticationCode: Hashable, ContiguousBytes, CustomStringConvertible, Sequence where Element == UInt8 {
+public protocol MessageAuthenticationCode: Hashable, ContiguousBytes, CustomStringConvertible, Sequence, Sendable where Element == UInt8 {
     /// The number of bytes in the message authentication code.
     var byteCount: Int { get }
 }

--- a/Sources/Crypto/PRF/AES.swift
+++ b/Sources/Crypto/PRF/AES.swift
@@ -16,7 +16,7 @@
 #else
 /// A container for Advanced Encryption Standard (AES) ciphers.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-public enum AES {
+public enum AES: Sendable {
     static let blockSizeByteCount = 16
 }
 

--- a/Sources/Crypto/Signatures/ECDSA.swift
+++ b/Sources/Crypto/Signatures/ECDSA.swift
@@ -40,7 +40,7 @@ extension P256.Signing {
 
     /// A P-256 elliptic curve digital signature algorithm (ECDSA) signature.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public struct ECDSASignature: ContiguousBytes, NISTECDSASignature {
+    public struct ECDSASignature: ContiguousBytes, NISTECDSASignature, Sendable {
         
         /// A raw data representation of a P-256 digital signature.
         public var rawRepresentation: Data
@@ -210,7 +210,7 @@ extension P384.Signing {
 
     /// A P-384 elliptic curve digital signature algorithm (ECDSA) signature.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public struct ECDSASignature: ContiguousBytes, NISTECDSASignature {
+    public struct ECDSASignature: ContiguousBytes, NISTECDSASignature, Sendable {
         
         /// A raw data representation of a P-384 digital signature.
         public var rawRepresentation: Data
@@ -380,7 +380,7 @@ extension P521.Signing {
 
     /// A P-521 elliptic curve digital signature algorithm (ECDSA) signature.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public struct ECDSASignature: ContiguousBytes, NISTECDSASignature {
+    public struct ECDSASignature: ContiguousBytes, NISTECDSASignature, Sendable {
         
         /// A raw data representation of a P-521 digital signature.
         public var rawRepresentation: Data

--- a/Sources/Crypto/Util/SecureBytes.swift
+++ b/Sources/Crypto/Util/SecureBytes.swift
@@ -20,7 +20,7 @@ import Foundation
 private let emptyStorage:SecureBytes.Backing = SecureBytes.Backing.createEmpty()
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-struct SecureBytes {
+struct SecureBytes: Sendable {
     @usableFromInline
     var backing: Backing
 
@@ -267,9 +267,10 @@ extension SecureBytes {
         internal var capacity: Int
     }
 
+    // Unchecked sendable here because we're inheriting from ManagedBuffer
     @usableFromInline
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    internal class Backing: ManagedBuffer<BackingHeader, UInt8> {
+    internal class Backing: ManagedBuffer<BackingHeader, UInt8>, @unchecked Sendable {
 
         @usableFromInline
         class func createEmpty() -> Backing {


### PR DESCRIPTION
Align Sendable annotations with CryptoKit

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [ ] I've run tests to see all new and existing tests pass
- [ ] I've followed the code style of the rest of the project
- [ ] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

Currently the Sendable annotations don't match with what's in CryptoKit. Which means when compiling a project in Swift 6 mode that uses Crypto types, it compiles on macOS but doesn't compile on Linux

### Modifications:

Add the same Sendable annotations to Crypto as found on CryptoKit

### Result:

Code compiles the same on all platforms
