### PR TITLE
Work around Swift compiler issue with consuming and TSAN

### DIFF
--- a/Sources/CryptoBoringWrapper/EC/EllipticCurvePoint.swift
+++ b/Sources/CryptoBoringWrapper/EC/EllipticCurvePoint.swift
@@ -69,6 +69,10 @@ package struct EllipticCurvePoint: @unchecked Sendable {
         try self.multiply(by: rhs, on: group, context: context)
     }
 
+    // This enhancement can only be present on 6.1 or later because of the
+    // absence of https://github.com/swiftlang/swift/pull/76186 in older
+    // compilers.
+    #if compiler(>=6.1)
     @usableFromInline
     package consuming func multiplying(
         by rhs: ArbitraryPrecisionInteger,
@@ -78,6 +82,18 @@ package struct EllipticCurvePoint: @unchecked Sendable {
         try self.multiply(by: rhs, on: group, context: context)
         return self
     }
+    #else
+    @usableFromInline
+    package func multiplying(
+        by rhs: ArbitraryPrecisionInteger,
+        on group: BoringSSLEllipticCurveGroup,
+        context: FiniteFieldArithmeticContext? = nil
+    ) throws -> EllipticCurvePoint {
+        var `self` = self
+        try self.multiply(by: rhs, on: group, context: context)
+        return self
+    }
+    #endif
 
     @usableFromInline
     package static func multiplying(
@@ -110,6 +126,10 @@ package struct EllipticCurvePoint: @unchecked Sendable {
         try self.add(rhs, on: group, context: context)
     }
 
+    // This enhancement can only be present on 6.1 or later because of the
+    // absence of https://github.com/swiftlang/swift/pull/76186 in older
+    // compilers.
+    #if compiler(>=6.1)
     @usableFromInline
     package consuming func adding(
         _ rhs: consuming EllipticCurvePoint,
@@ -119,7 +139,23 @@ package struct EllipticCurvePoint: @unchecked Sendable {
         try self.add(rhs, on: group, context: context)
         return self
     }
+    #else
+    @usableFromInline
+    package func adding(
+        _ rhs: consuming EllipticCurvePoint,
+        on group: BoringSSLEllipticCurveGroup,
+        context: FiniteFieldArithmeticContext? = nil
+    ) throws -> EllipticCurvePoint {
+        var `self` = self
+        try self.add(rhs, on: group, context: context)
+        return self
+    }
+    #endif
 
+    // This enhancement can only be present on 6.1 or later because of the
+    // absence of https://github.com/swiftlang/swift/pull/76186 in older
+    // compilers.
+    #if compiler(>=6.1)
     @usableFromInline
     package static func adding(
         _ lhs: consuming EllipticCurvePoint,
@@ -130,6 +166,19 @@ package struct EllipticCurvePoint: @unchecked Sendable {
         try lhs.add(rhs, on: group, context: context)
         return lhs
     }
+    #else
+    @usableFromInline
+    package static func adding(
+        _ lhs: EllipticCurvePoint,
+        _ rhs: EllipticCurvePoint,
+        on group: BoringSSLEllipticCurveGroup,
+        context: FiniteFieldArithmeticContext? = nil
+    ) throws -> EllipticCurvePoint {
+        var lhs = lhs
+        try lhs.add(rhs, on: group, context: context)
+        return lhs
+    }
+    #endif
 
     @usableFromInline
     package mutating func invert(
@@ -150,6 +199,10 @@ package struct EllipticCurvePoint: @unchecked Sendable {
         try self.invert(on: group, context: context)
     }
 
+    // This enhancement can only be present on 6.1 or later because of the
+    // absence of https://github.com/swiftlang/swift/pull/76186 in older
+    // compilers.
+    #if compiler(>=6.1)
     @usableFromInline
     package consuming func inverting(
         on group: BoringSSLEllipticCurveGroup,
@@ -158,7 +211,22 @@ package struct EllipticCurvePoint: @unchecked Sendable {
         try self.invert(on: group, context: context)
         return self
     }
+    #else
+    @usableFromInline
+    package func inverting(
+        on group: BoringSSLEllipticCurveGroup,
+        context: FiniteFieldArithmeticContext? = nil
+    ) throws -> EllipticCurvePoint {
+        var `self` = self
+        try self.invert(on: group, context: context)
+        return self
+    }
+    #endif
 
+    // This enhancement can only be present on 6.1 or later because of the
+    // absence of https://github.com/swiftlang/swift/pull/76186 in older
+    // compilers.
+    #if compiler(>=6.1)
     @usableFromInline
     package static func inverting(
         _ point: consuming EllipticCurvePoint,
@@ -168,6 +236,18 @@ package struct EllipticCurvePoint: @unchecked Sendable {
         try point.invert(on: group, context: context)
         return point
     }
+    #else
+    @usableFromInline
+    package static func inverting(
+        _ point: EllipticCurvePoint,
+        on group: BoringSSLEllipticCurveGroup,
+        context: FiniteFieldArithmeticContext? = nil
+    ) throws -> EllipticCurvePoint {
+        var point = point
+        try point.invert(on: group, context: context)
+        return point
+    }
+    #endif
 
     @usableFromInline
     package mutating func subtract(
@@ -190,6 +270,10 @@ package struct EllipticCurvePoint: @unchecked Sendable {
         try self.subtract(rhs, on: group, context: context)
     }
 
+    // This enhancement can only be present on 6.1 or later because of the
+    // absence of https://github.com/swiftlang/swift/pull/76186 in older
+    // compilers.
+    #if compiler(>=6.1)
     @usableFromInline
     package consuming func subtracting(
         _ rhs: consuming EllipticCurvePoint,
@@ -199,7 +283,23 @@ package struct EllipticCurvePoint: @unchecked Sendable {
         try self.subtract(rhs, on: group, context: context)
         return self
     }
+    #else
+    @usableFromInline
+    package func subtracting(
+        _ rhs: EllipticCurvePoint,
+        on group: BoringSSLEllipticCurveGroup,
+        context: FiniteFieldArithmeticContext? = nil
+    ) throws -> EllipticCurvePoint {
+        var `self` = self
+        try self.subtract(rhs, on: group, context: context)
+        return self
+    }
+    #endif
 
+    // This enhancement can only be present on 6.1 or later because of the
+    // absence of https://github.com/swiftlang/swift/pull/76186 in older
+    // compilers.
+    #if compiler(>=6.1)
     @usableFromInline
     package static func subtracting(
         _ rhs: consuming EllipticCurvePoint,
@@ -210,6 +310,19 @@ package struct EllipticCurvePoint: @unchecked Sendable {
         try lhs.subtract(rhs, on: group, context: context)
         return lhs
     }
+    #else
+    @usableFromInline
+    package static func subtracting(
+        _ rhs: EllipticCurvePoint,
+        from lhs: EllipticCurvePoint,
+        on group: BoringSSLEllipticCurveGroup,
+        context: FiniteFieldArithmeticContext? = nil
+    ) throws -> EllipticCurvePoint {
+        var lhs = lhs
+        try lhs.subtract(rhs, on: group, context: context)
+        return lhs
+    }
+    #endif
 
     @usableFromInline
     package init<MessageBytes: ContiguousBytes, DSTBytes: ContiguousBytes>(

--- a/Sources/_CryptoExtras/Util/Data+Extensions.swift
+++ b/Sources/_CryptoExtras/Util/Data+Extensions.swift
@@ -15,9 +15,14 @@
 import Foundation
 
 extension Data {
+    // This enhancement can only be present on 6.1 or later because of the
+    // absence of https://github.com/swiftlang/swift/pull/76186 in older
+    // compilers.
+    #if compiler(>=6.1)
     // This overload reduces allocations when used in a chain of infix operations.
     static func + (lhs: consuming Data, rhs: consuming Data) -> Data {
         lhs.append(contentsOf: rhs)
         return lhs
     }
+    #endif
 }


### PR DESCRIPTION
This patch works around the absence of a fix for
https://github.com/swiftlang/swift/pull/76186 on older Swift compilers.
