### PR TITLE
build: Make swift-crypto build on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@
 
 cmake_minimum_required(VERSION 3.15.1)
 
+if(POLICY CMP0157)
+  cmake_policy(SET CMP0157 NEW)
+endif()
+
 project(SwiftCrypto
   LANGUAGES ASM C CXX Swift)
 
@@ -45,6 +49,18 @@ if(CMAKE_SYSTEM_NAME STREQUAL Darwin AND NOT CMAKE_CROSSCOMPILING)
   set(CMAKE_AR "/usr/bin/ar")
   set(CMAKE_C_ARCHIVE_CREATE "<CMAKE_AR> crs <TARGET> <LINK_FLAGS> <OBJECTS>")
   set(CMAKE_RANLIB "/usr/bin/ranlib")
+endif()
+
+set(CMAKE_CXX_STANDARD 17)
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+  # We need to ensure that we don't include the min/max macros from the Windows SDK.
+  add_compile_definitions(NOMINMAX)
+  # We can only link against the DLL version of the MSVC runtime library for now.
+  set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreadedDLL")
+  if(CMAKE_Swift_COMPILER_VERSION VERSION_EQUAL 0.0.0 OR CMAKE_Swift_COMPILER_VERSION VERSION_GREATER_EQUAL 6.2)
+    # We need to set the static library prefix to "lib" so that we can link against the static libraries.
+    set(CMAKE_STATIC_LIBRARY_PREFIX_Swift "lib")
+  endif()
 endif()
 
 if(NOT CMAKE_SYSTEM_NAME STREQUAL Darwin)

--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -334,6 +334,27 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Linux|Android|FreeBSD" AND CMAKE_SYSTEM_PROCES
     gen/bcm/vpaes-armv8-linux.S
     gen/crypto/chacha-armv8-linux.S
     gen/crypto/chacha20_poly1305_armv8-linux.S)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Windows" AND CMAKE_SYSTEM_PROCESSOR MATCHES "AMD64|amd64|x86_64")
+  target_sources(CCryptoBoringSSL PRIVATE
+)
+elseif(CMAKE_SYSTEM_NAME MATCHES "Windows" AND CMAKE_SYSTEM_PROCESSOR MATCHES "ARM64|arm64|aarch64")
+  target_sources(CCryptoBoringSSL PRIVATE
+    gen/bcm/aesv8-armv8-win.S
+    gen/bcm/aesv8-gcm-armv8-win.S
+    gen/bcm/armv8-mont-win.S
+    gen/bcm/bn-armv8-win.S
+    gen/bcm/ghash-neon-armv8-win.S
+    gen/bcm/ghashv8-armv8-win.S
+    gen/bcm/p256-armv8-asm-win.S
+    gen/bcm/p256_beeu-armv8-asm-win.S
+    gen/bcm/sha1-armv8-win.S
+    gen/bcm/sha256-armv8-win.S
+    gen/bcm/sha512-armv8-win.S
+    gen/bcm/vpaes-armv8-win.S
+    gen/crypto/chacha-armv8-win.S
+    gen/crypto/chacha20_poly1305_armv8-win.S)
+else()
+   message(FATAL_ERROR "platform sources are not defined here for ${CMAKE_SYSTEM_NAME} on ${CMAKE_SYSTEM_PROCESSOR}")
 endif()
 
 target_include_directories(CCryptoBoringSSL PUBLIC


### PR DESCRIPTION
Make swift-crypto build on Windows

- [X] I've run tests to see all new and existing tests pass
- [X] I've followed the code style of the rest of the project
- [X] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [X] I've updated the documentation if necessary

- [N/A] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

Currently, swift-crypto on the main branch does not build on Windows.

* Add the Windows Arm64 assembly files to the CMake build.
* Add appropriate CMake options for swift-crypto to build on Windows.

swift-crypto can be built on Windows from main

Fixes #369

---------

Co-authored-by: Cory Benfield <lukasa@apple.com>

(cherry picked from commit 993467897d0c6250bfb542e3334f4050ca745f72) (#370)