### PR TITLE
Fix broken Windows tests (#350)

### DIFF
--- a/Tests/CryptoTests/Utils/RFCVector.swift
+++ b/Tests/CryptoTests/Utils/RFCVector.swift
@@ -29,8 +29,22 @@ struct RFCVectorDecoder {
         let bundle = Bundle(for: type(of: bundleType))
         let fileURL = bundle.url(forResource: fileName, withExtension: "txt")
         #else
-        let testsDirectory: String = URL(fileURLWithPath: "\(#file)").pathComponents.dropLast(3).joined(separator: "/")
-        let fileURL: URL? = URL(fileURLWithPath: "\(testsDirectory)/Test Vectors/\(fileName).txt")
+        var fileURL: URL? = URL(fileURLWithPath: "\(#file)")
+        for _ in 0..<3 {
+            fileURL!.deleteLastPathComponent()
+        }
+        #if compiler(>=6.0)
+        if #available(macOS 13, iOS 16, watchOS 9, tvOS 16, visionOS 1, macCatalyst 16, *) {
+            fileURL!.append(path: "Test Vectors", directoryHint: .isDirectory)
+            fileURL!.append(path: "\(fileName).txt", directoryHint: .notDirectory)
+        } else {
+            fileURL! = fileURL!.appendingPathComponent("Test Vectors", isDirectory: true)
+            fileURL! = fileURL!.appendingPathComponent("\(fileName).txt", isDirectory: false)
+        }
+        #else
+        fileURL! = fileURL!.appendingPathComponent("Test Vectors", isDirectory: true)
+        fileURL! = fileURL!.appendingPathComponent("\(fileName).txt", isDirectory: false)
+        #endif
         #endif
 
         let rfcVectorData = try Data(contentsOf: fileURL!)

--- a/Tests/CryptoTests/Utils/Wycheproof.swift
+++ b/Tests/CryptoTests/Utils/Wycheproof.swift
@@ -25,8 +25,22 @@ extension XCTestCase {
         let bundle = Bundle(for: type(of: bundleType))
         let fileURL = bundle.url(forResource: jsonName, withExtension: "json")
         #else
-        let testsDirectory: String = URL(fileURLWithPath: "\(#file)").pathComponents.dropLast(3).joined(separator: "/")
-        let fileURL: URL? = URL(fileURLWithPath: "\(testsDirectory)/Test Vectors/\(jsonName).json")
+        var fileURL = URL(fileURLWithPath: "\(#file)")
+        for _ in 0..<3 {
+            fileURL.deleteLastPathComponent()
+        }
+        #if compiler(>=6.0)
+        if #available(macOS 13, iOS 16, watchOS 9, tvOS 16, visionOS 1, macCatalyst 16, *) {
+            fileURL.append(path: "Test Vectors", directoryHint: .isDirectory)
+            fileURL.append(path: "\(jsonName).json", directoryHint: .notDirectory)
+        } else {
+            fileURL = fileURL.appendingPathComponent("Test Vectors", isDirectory: true)
+            fileURL = fileURL.appendingPathComponent("\(jsonName).json", isDirectory: false)
+        }
+        #else
+        fileURL = fileURL.appendingPathComponent("Test Vectors", isDirectory: true)
+        fileURL = fileURL.appendingPathComponent("\(jsonName).json", isDirectory: false)
+        #endif
         #endif
 
         let data = try orFail(file: file, line: line) { try Data(contentsOf: unwrap(fileURL, file: file, line: line)) }

--- a/Tests/_CryptoExtrasTests/Utils/RFCVector.swift
+++ b/Tests/_CryptoExtrasTests/Utils/RFCVector.swift
@@ -25,8 +25,22 @@ struct RFCVectorDecoder {
     private var index: Int?
 
     init(bundleType: AnyObject, fileName: String) throws {
-        let testsDirectory: String = URL(fileURLWithPath: "\(#file)").pathComponents.dropLast(3).joined(separator: "/")
-        let fileURL: URL? = URL(fileURLWithPath: "\(testsDirectory)/_CryptoExtrasVectors/\(fileName).txt")
+        var fileURL: URL? = URL(fileURLWithPath: "\(#file)")
+        for _ in 0..<3 {
+            fileURL!.deleteLastPathComponent()
+        }
+        #if compiler(>=6.0)
+        if #available(macOS 13, iOS 16, watchOS 9, tvOS 16, visionOS 1, macCatalyst 16, *) {
+            fileURL!.append(path: "_CryptoExtrasVectors", directoryHint: .isDirectory)
+            fileURL!.append(path: "\(fileName).txt", directoryHint: .notDirectory)
+        } else {
+            fileURL! = fileURL!.appendingPathComponent("_CryptoExtrasVectors", isDirectory: true)
+            fileURL! = fileURL!.appendingPathComponent("\(fileName).txt", isDirectory: false)
+        }
+        #else
+        fileURL! = fileURL!.appendingPathComponent("_CryptoExtrasVectors", isDirectory: true)
+        fileURL! = fileURL!.appendingPathComponent("\(fileName).txt", isDirectory: false)
+        #endif
 
         let rfcVectorData = try Data(contentsOf: fileURL!)
         self.rfcVectorData = String(decoding: rfcVectorData, as: Unicode.UTF8.self)

--- a/Tests/_CryptoExtrasTests/Utils/Wycheproof.swift
+++ b/Tests/_CryptoExtrasTests/Utils/Wycheproof.swift
@@ -21,10 +21,24 @@ struct WycheproofTest<T: Codable>: Codable {
 
 extension XCTestCase {
     func wycheproofTest<T: Codable>(jsonName: String, file: StaticString = #file, line: UInt = #line, testFunction: (T) throws -> Void) throws {
-        let testsDirectory: String = URL(fileURLWithPath: "\(#file)").pathComponents.dropLast(3).joined(separator: "/")
-        let fileURL: URL? = URL(fileURLWithPath: "\(testsDirectory)/_CryptoExtrasVectors/\(jsonName).json")
+        var fileURL = URL(fileURLWithPath: "\(#file)")
+        for _ in 0..<3 {
+            fileURL.deleteLastPathComponent()
+        }
+        #if compiler(>=6.0)
+        if #available(macOS 13, iOS 16, watchOS 9, tvOS 16, visionOS 1, macCatalyst 16, *) {
+            fileURL.append(path: "_CryptoExtrasVectors", directoryHint: .isDirectory)
+            fileURL.append(path: "\(jsonName).json", directoryHint: .notDirectory)
+        } else {
+            fileURL = fileURL.appendingPathComponent("_CryptoExtrasVectors", isDirectory: true)
+            fileURL = fileURL.appendingPathComponent("\(jsonName).json", isDirectory: false)
+        }
+        #else
+        fileURL = fileURL.appendingPathComponent("_CryptoExtrasVectors", isDirectory: true)
+        fileURL = fileURL.appendingPathComponent("\(jsonName).json", isDirectory: false)
+        #endif
 
-        let data = try Data(contentsOf: fileURL!)
+        let data = try Data(contentsOf: fileURL)
 
         let decoder = JSONDecoder()
         let wpTest = try decoder.decode(WycheproofTest<T>.self, from: data)


### PR DESCRIPTION
The test runners for Windows were failing to load the paths from disk for test vectors. This patch cleans up the loading logic.

(cherry picked from commit 1f483f42403f0198e6191414b654e02d52fdde1c)