### PR TITLE
CMake Build: Disable CMP0157

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,10 +14,6 @@
 
 cmake_minimum_required(VERSION 3.15.1)
 
-if(POLICY CMP0157)
-  cmake_policy(SET CMP0157 NEW)
-endif()
-
 project(SwiftCrypto
   LANGUAGES ASM C CXX Swift)
 


### PR DESCRIPTION
There is a bug in CMake CMP0157 where if library A depends on a non-Swift library B, which in turns depends on a Swift library C, library A will depend on a swiftmodule for B. B doesn't have a swiftmodule, so the build fails.

Currently hitting the following error on Windows CI:
`ninja: error: 'swift/CCryptoBoringSSL.swiftmodule', needed by 'lib/libCCryptoBoringSSLShims.lib', missing and no known rule to make it`

Disabling CMP0157 for now.