### PR TITLE
Add Sequence conformance to AES._CBC.IV (#389)

### DIFF
--- a/Sources/_CryptoExtras/AES/AES_CBC.swift
+++ b/Sources/_CryptoExtras/AES/AES_CBC.swift
@@ -147,7 +147,7 @@ extension AES {
 extension AES._CBC {
     /// An initialization vector.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public struct IV: Sendable {
+    public struct IV: Sendable, Sequence {
         // AES CBC uses a 128-bit IV.
         var ivBytes: (
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
@@ -191,6 +191,12 @@ extension AES._CBC {
 
             withUnsafeMutableBytes(of: &self.ivBytes) { bytesPtr in
                 bytesPtr.copyBytes(from: ivBytes)
+            }
+        }
+        
+        public func makeIterator() -> Array<UInt8>.Iterator {
+            withUnsafeBytes(of: ivBytes) { unsafeRawBufferPointer in
+                Array(unsafeRawBufferPointer).makeIterator()
             }
         }
     }

--- a/Sources/_CryptoExtras/AES/AES_CBC.swift
+++ b/Sources/_CryptoExtras/AES/AES_CBC.swift
@@ -149,6 +149,7 @@ extension AES._CBC {
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public struct IV: Sendable, Sequence {
         // AES CBC uses a 128-bit IV.
+        @usableFromInline
         var ivBytes: (
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
@@ -194,6 +195,7 @@ extension AES._CBC {
             }
         }
         
+        @inlinable
         public func makeIterator() -> some IteratorProtocol<UInt8> {
             withUnsafeBytes(of: ivBytes) { unsafeRawBufferPointer in
                 Array(unsafeRawBufferPointer).makeIterator()

--- a/Sources/_CryptoExtras/AES/AES_CBC.swift
+++ b/Sources/_CryptoExtras/AES/AES_CBC.swift
@@ -194,7 +194,7 @@ extension AES._CBC {
             }
         }
         
-        public func makeIterator() -> Array<UInt8>.Iterator {
+        public func makeIterator() -> some IteratorProtocol<UInt8> {
             withUnsafeBytes(of: ivBytes) { unsafeRawBufferPointer in
                 Array(unsafeRawBufferPointer).makeIterator()
             }

--- a/Tests/_CryptoExtrasTests/AES_CBCTests.swift
+++ b/Tests/_CryptoExtrasTests/AES_CBCTests.swift
@@ -158,6 +158,14 @@ final class CBCTests: XCTestCase {
             }
         }
     }
+    
+    func testToDataConversion() throws {
+        let randomBytes = (0..<16).map { _ in UInt8.random(in: UInt8.min...UInt8.max) }
+        let dataIn = Data(randomBytes)
+        let iv = try AES._CBC.IV(ivBytes: dataIn)
+        let dataOut = Data(iv)
+        XCTAssertEqual(dataIn, dataOut)
+    }
 }
 
 


### PR DESCRIPTION
Add Sequence conformance to `AES._CBC.IV` where `Element` is `UInt8`.

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [ ] I've run tests to see all new and existing tests pass
> PKCS8DERRepresentationTests do not compile on master branch with Error `'pkcs8DERRepresentation' is only available in iOS 14.0 or newer`. All the other tests pass after my changes.
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

No convenient API for converting `AES._CBC.IV` into `Data`.

### Modifications:

Added `Sequence` conformance to `AES._CBC.IV` similarly how it is done for `AES.GCM._SIV.Nonce`.

### Result:

It will be possible to create `Data` instance with `AES._CBC.IV` passed as init argument.