### PR TITLE
Add AES CMAC support

### DIFF
--- a/Sources/_CryptoExtras/AES/CMAC.swift
+++ b/Sources/_CryptoExtras/AES/CMAC.swift
@@ -22,7 +22,12 @@ import Foundation
 
 @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
 extension AES {
+    /// A cipher-based message authentication code.
+    /// 
+    /// CMAC uses AES to implement a MAC.  CMAC is useful in contexts where access to
+    /// a hash function is not guaranteed, but a block cipher will be available.
     public struct CMAC: @unchecked Sendable {
+        // Unchecked sendable because this is CoW.
         fileprivate var backing: Backing
 
         /// Creates a message authentication code generator.
@@ -54,7 +59,7 @@ extension AES {
         /// Adds data to be authenticated by MAC function. This can be called one or more times to append additional data.
         ///
         /// - Parameters:
-        ///   - data: The data to be authenticated.
+        ///   - bufferPointer: The data to be authenticated.
         public mutating func update(bufferPointer: UnsafeRawBufferPointer) {
             self.cowIfNeeded()
             self.backing.update(bufferPointer)

--- a/Sources/_CryptoExtras/AES/CMAC.swift
+++ b/Sources/_CryptoExtras/AES/CMAC.swift
@@ -23,7 +23,7 @@ import Foundation
 @available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
 extension AES {
     /// A cipher-based message authentication code.
-    /// 
+    ///
     /// CMAC uses AES to implement a MAC.  CMAC is useful in contexts where access to
     /// a hash function is not guaranteed, but a block cipher will be available.
     public struct CMAC: @unchecked Sendable {

--- a/Sources/_CryptoExtras/AES/CMAC.swift
+++ b/Sources/_CryptoExtras/AES/CMAC.swift
@@ -77,7 +77,7 @@ extension AES {
         ///
         /// - Parameter data: The data to update the MAC
         public mutating func update<D: DataProtocol>(data: D) {
-            data.regions.forEach { memoryRegion in
+            for memoryRegion in data.regions {
                 memoryRegion.withUnsafeBytes { bp in
                     self.update(bufferPointer: bp)
                 }

--- a/Sources/_CryptoExtras/AES/CMAC.swift
+++ b/Sources/_CryptoExtras/AES/CMAC.swift
@@ -1,0 +1,182 @@
+@_implementationOnly import CCryptoBoringSSL
+import Crypto
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+@available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
+extension AES {
+    public struct CMAC: @unchecked Sendable {
+        fileprivate var backing: Backing
+
+        /// Creates a message authentication code generator.
+        /// 
+        /// Defaults the output size to 128 bits.
+        ///
+        /// - Parameters:
+        ///   - key: The symmetric key used to secure the computation.
+        public init(key: SymmetricKey) throws {
+            try self.init(key: key, outputSize: 16)
+        }
+
+        /// Creates a message authentication code generator.
+        ///
+        /// - Parameters:
+        ///   - key: The symmetric key used to secure the computation.
+        ///   - outputSize: The number of bytes of MAC to generate. Must be in the range 0 to 16 inclusive.
+        public init(key: SymmetricKey, outputSize: Int) throws {
+            guard [128, 192, 256].contains(key.bitCount) else {
+                throw CryptoError.incorrectKeySize
+            }
+            guard (0...16).contains(outputSize) else {
+                throw CryptoKitError.incorrectParameterSize
+            }
+
+            self.backing = Backing(key: key, outputSize: outputSize)
+        }
+
+        /// Adds data to be authenticated by MAC function. This can be called one or more times to append additional data.
+        ///
+        /// - Parameters:
+        ///   - data: The data to be authenticated.
+        public mutating func update(bufferPointer: UnsafeRawBufferPointer) {
+            self.cowIfNeeded()
+            self.backing.update(bufferPointer)
+        }
+
+        /// Finalizes the message authentication computation and returns the
+        /// computed code.
+        ///
+        /// - Returns: The message authentication code.
+        public consuming func finalize() -> AES.CMAC.MAC {
+            // The combination of "consuming" and "cowifneeded" should
+            // produce an environment where, if users may choose to
+            // keep using the MAC, they can, but if they aren't we'll
+            // avoid an unnecessary CoW.
+            self.cowIfNeeded()
+            return self.backing.finalize()
+        }
+
+        /// Updates the MAC with data.
+        ///
+        /// - Parameter data: The data to update the MAC
+        public mutating func update<D: DataProtocol>(data: D) {
+            data.regions.forEach { memoryRegion in
+                memoryRegion.withUnsafeBytes { bp in
+                    self.update(bufferPointer: bp)
+                }
+            }
+        }
+
+        private mutating func cowIfNeeded() {
+            if !isKnownUniquelyReferenced(&self.backing) {
+                self.backing = Backing(copying: self.backing)
+            }
+        }
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
+extension AES.CMAC {
+    /// A cipher-based message authentication code.
+    public struct MAC: MessageAuthenticationCode {
+        fileprivate let underlyingData: Data
+
+        init(underlyingData: Data) {
+            self.underlyingData = underlyingData
+        }
+
+        /// The number of bytes in the message authentication code.
+        public var byteCount: Int {
+            return self.underlyingData.count
+        }
+
+        /// Invokes the given closure with a buffer pointer covering the raw bytes
+        /// of the code.
+        ///
+        /// - Parameters:
+        ///   - body: A closure that takes a raw buffer pointer to the bytes of the
+        ///       code.
+        public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
+            try self.underlyingData.withUnsafeBytes(body)
+        }
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
+extension AES.CMAC {
+    fileprivate final class Backing {
+        private let key: SymmetricKey
+        private let context: OpaquePointer
+        private let outputSize: Int
+
+        init(key: SymmetricKey, outputSize: Int) {
+            self.key = key
+            self.context = CCryptoBoringSSL_CMAC_CTX_new()
+            self.outputSize = outputSize
+
+            let rc = self.key.withUnsafeBytes { keyPtr in
+                CCryptoBoringSSL_CMAC_Init(
+                    self.context,
+                    keyPtr.baseAddress,
+                    keyPtr.count,
+                    key.aesEVP,
+                    nil
+                )
+            }
+            precondition(rc == 1)
+        }
+
+        init(copying other: Backing) {
+            self.key = other.key
+            self.context = CCryptoBoringSSL_CMAC_CTX_new()
+            self.outputSize = other.outputSize
+            let rc = CCryptoBoringSSL_CMAC_CTX_copy(self.context, other.context)
+            precondition(rc == 1)
+
+            // Ensure we don't lose `other` at this time.
+            withExtendedLifetime(other) { }
+        }
+
+        deinit {
+            CCryptoBoringSSL_CMAC_CTX_free(self.context)
+        }
+
+        func update(_ bytes: UnsafeRawBufferPointer) {
+            let rc = CCryptoBoringSSL_CMAC_Update(self.context, bytes.baseAddress, bytes.count)
+            precondition(rc == 1)
+        }
+
+        func finalize() -> AES.CMAC.MAC {
+            let bytes = withUnsafeTemporaryAllocation(byteCount: 16, alignment: 1) { bytes in
+                precondition(bytes.count >= 16)
+                var count = 16
+                let rc = CCryptoBoringSSL_CMAC_Final(self.context, bytes.baseAddress, &count)
+                precondition(count == 16)
+                precondition(rc == 1)
+
+                return Data(UnsafeRawBufferPointer(rebasing: bytes.prefix(self.outputSize)))
+            }
+            return AES.CMAC.MAC(underlyingData: bytes)
+        }
+    }
+}
+
+@available(iOS 13.0, macOS 10.15, watchOS 6.0, tvOS 13.0, *)
+extension SymmetricKey {
+    fileprivate var aesEVP: OpaquePointer {
+        switch self.bitCount {
+        case 128:
+            CCryptoBoringSSL_EVP_aes_128_cbc()
+        case 192:
+            CCryptoBoringSSL_EVP_aes_192_cbc()
+        case 256:
+            CCryptoBoringSSL_EVP_aes_256_cbc()
+        default:
+            fatalError("Should be unreachable")
+        }
+    }
+}

--- a/Sources/_CryptoExtras/AES/CMAC.swift
+++ b/Sources/_CryptoExtras/AES/CMAC.swift
@@ -26,7 +26,7 @@ extension AES {
         fileprivate var backing: Backing
 
         /// Creates a message authentication code generator.
-        /// 
+        ///
         /// Defaults the output size to 128 bits.
         ///
         /// - Parameters:
@@ -104,7 +104,7 @@ extension AES.CMAC {
 
         /// The number of bytes in the message authentication code.
         public var byteCount: Int {
-            return self.underlyingData.count
+            self.underlyingData.count
         }
 
         /// Invokes the given closure with a buffer pointer covering the raw bytes
@@ -151,7 +151,7 @@ extension AES.CMAC {
             precondition(rc == 1)
 
             // Ensure we don't lose `other` at this time.
-            withExtendedLifetime(other) { }
+            withExtendedLifetime(other) {}
         }
 
         deinit {

--- a/Sources/_CryptoExtras/AES/CMAC.swift
+++ b/Sources/_CryptoExtras/AES/CMAC.swift
@@ -1,3 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
 @_implementationOnly import CCryptoBoringSSL
 import Crypto
 

--- a/Sources/_CryptoExtras/CMakeLists.txt
+++ b/Sources/_CryptoExtras/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(_CryptoExtras
   "AES/BoringSSL/AES_CFB_boring.swift"
   "AES/BoringSSL/AES_CTR_boring.swift"
   "AES/BoringSSL/AES_GCM_SIV_boring.swift"
+  "AES/CMAC.swift"
   "ARC/ARC+API.swift"
   "ARC/ARC.swift"
   "ARC/ARCCredential.swift"

--- a/Tests/_CryptoExtrasTests/CMACTests.swift
+++ b/Tests/_CryptoExtrasTests/CMACTests.swift
@@ -1,3 +1,16 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
 import Crypto
 import _CryptoExtras
 import Foundation

--- a/Tests/_CryptoExtrasTests/CMACTests.swift
+++ b/Tests/_CryptoExtrasTests/CMACTests.swift
@@ -1,0 +1,175 @@
+import Crypto
+import _CryptoExtras
+import Foundation
+import XCTest
+
+final class CMACTests: XCTestCase {
+    // Borrowed from CryptoKit
+    func testVector1() throws {
+        let key = try Array(hexString: "a60269f095ad3c3bafae907c6f215de0")
+        let mac = try Array(hexString: "172084c3fe99fde4af29aa8e6e5fe1")
+        let msg = try Array(hexString: "cead1c5af16ca89bc0821775f8cba8c25620a03dfd27d6f1186f75f1c0bcfe4a20")
+
+        var authenticator = try AES.CMAC(key: SymmetricKey(data: key), outputSize: 15)
+        authenticator.update(data: msg)
+        XCTAssert(authenticator.finalize() == mac)
+    }
+
+    // rfc4493 example vectors
+    // https://datatracker.ietf.org/doc/html/rfc4493#page-11
+    let exampleVector1 = ""
+
+    let exampleVector2 = """
+    6bc1bee22e409f96e93d7e117393172a
+    """
+
+    let exampleVector3 = """
+    6bc1bee22e409f96e93d7e117393172a\
+    ae2d8a571e03ac9c9eb76fac45af8e51\
+    30c81c46a35ce411
+    """
+
+    let exampleVector4 = """
+    6bc1bee22e409f96e93d7e117393172a\
+    ae2d8a571e03ac9c9eb76fac45af8e51\
+    30c81c46a35ce411e5fbc1191a0a52ef\
+    f69f2445df4f9b17ad2b417be66c3710
+    """
+
+    func testExampleVector1() throws {
+        let key = try Array(hexString: "2b7e151628aed2a6abf7158809cf4f3c")
+        let mac = try Array(hexString: "bb1d6929e95937287fa37d129b756746")
+        let msg = try Array(hexString: exampleVector1)
+
+        var authenticator = try AES.CMAC(key: SymmetricKey(data: key), outputSize: 16)
+        authenticator.update(data: msg)
+        XCTAssert(authenticator.finalize() == mac)
+    }
+
+    func testExampleVector2() throws {
+        let key = try Array(hexString: "2b7e151628aed2a6abf7158809cf4f3c")
+        let mac = try Array(hexString: "070a16b46b4d4144f79bdd9dd04a287c")
+        let msg = try Array(hexString: exampleVector2)
+
+        var authenticator = try AES.CMAC(key: SymmetricKey(data: key), outputSize: 16)
+        authenticator.update(data: msg)
+        XCTAssert(authenticator.finalize() == mac)
+    }
+
+    func testExampleVector2PerByte() throws {
+        let key = try Array(hexString: "2b7e151628aed2a6abf7158809cf4f3c")
+        let mac = try Array(hexString: "070a16b46b4d4144f79bdd9dd04a287c")
+        let msg = try Array(hexString: exampleVector2)
+
+        var authenticator = try AES.CMAC(key: SymmetricKey(data: key), outputSize: 16)
+        for byte in msg {
+            authenticator.update(data: [byte])
+        }
+        XCTAssert(authenticator.finalize() == mac)
+    }
+
+    func testExampleVector3() throws {
+        let key = try Array(hexString: "2b7e151628aed2a6abf7158809cf4f3c")
+        let mac = try Array(hexString: "dfa66747de9ae63030ca32611497c827")
+        let msg = try Array(hexString: exampleVector3)
+
+        var authenticator = try AES.CMAC(key: SymmetricKey(data: key), outputSize: 16)
+        authenticator.update(data: msg)
+        XCTAssert(authenticator.finalize() == mac)
+    }
+
+    func testExampleVector3PerByte() throws {
+        let key = try Array(hexString: "2b7e151628aed2a6abf7158809cf4f3c")
+        let mac = try Array(hexString: "dfa66747de9ae63030ca32611497c827")
+        let msg = try Array(hexString: exampleVector3)
+
+        var authenticator = try AES.CMAC(key: SymmetricKey(data: key), outputSize: 16)
+        for byte in msg {
+            authenticator.update(data: [byte])
+        }
+        XCTAssert(authenticator.finalize() == mac)
+    }
+
+    // rfc4493 example vector 4
+    // https://datatracker.ietf.org/doc/html/rfc4493#page-11
+    func testExampleVector4() throws {
+        let key = try Array(hexString: "2b7e151628aed2a6abf7158809cf4f3c")
+        let mac = try Array(hexString: "51f0bebf7e3b9d92fc49741779363cfe")
+        let msg = try Array(hexString: exampleVector4)
+
+        var authenticator = try AES.CMAC(key: SymmetricKey(data: key), outputSize: 16)
+        authenticator.update(data: msg)
+        XCTAssert(authenticator.finalize() == mac)
+    }
+
+    // rfc4493 example vector 4
+    // https://datatracker.ietf.org/doc/html/rfc4493#page-11
+    func testExampleVector4PerByte() throws {
+        let key = try Array(hexString: "2b7e151628aed2a6abf7158809cf4f3c")
+        let mac = try Array(hexString: "51f0bebf7e3b9d92fc49741779363cfe")
+        let msg = try Array(hexString: exampleVector4)
+
+        var authenticator = try AES.CMAC(key: SymmetricKey(data: key), outputSize: 16)
+        for byte in msg {
+            authenticator.update(data: [byte])
+        }
+        XCTAssert(authenticator.finalize() == mac)
+    }
+
+    func testWycheproof() throws {
+        try wycheproofTest(jsonName: "aes_cmac_test") { (group: TestGroup) in
+            for test in group.tests {
+                precondition(test.flags.isEmpty)
+
+                do {
+                    var authenticator = try AES.CMAC(key: test.computedKey, outputSize: test.computedTag.count)
+                    authenticator.update(data: test.computedMsg)
+                    let result = authenticator.finalize()
+
+                    switch test.result {
+                    case "valid":
+                        XCTAssertTrue(result == test.computedTag, "Unexpected invalid test \(test.tcId) (\(test.comment))")
+                    case "invalid":
+                        XCTAssertFalse(result == test.computedTag, "Unexpected valid test \(test.tcId) (\(test.comment))")
+                    default:
+                        fatalError("Unexpected result type")
+                    }
+                } catch {
+                    XCTAssertTrue(test.result == "invalid", "Unexpected invalid test \(test.tcId) (\(test.comment))")
+                    XCTAssertTrue(test.comment == "invalid key size", "Unexpected invalid test \(test.tcId) (\(test.comment))")
+                }
+            }
+        }
+    }
+}
+
+struct TestGroup: Codable {
+    var keySize: Int
+    var tagSize: Int
+    var type: String
+    var tests: [Test]
+}
+
+extension TestGroup {
+    struct Test: Codable {
+        var tcId: Int
+        var comment: String
+        var key: String
+        var msg: String
+        var tag: String
+        var result: String
+        var flags: [String]
+
+        var computedKey: SymmetricKey {
+            SymmetricKey(hexEncoded: self.key)
+        }
+
+        var computedMsg: Data {
+            try! Data(hexString: self.msg)
+        }
+
+        var computedTag: Data {
+            try! Data(hexString: self.tag)
+        }
+    }
+}

--- a/Tests/_CryptoExtrasTests/CMACTests.swift
+++ b/Tests/_CryptoExtrasTests/CMACTests.swift
@@ -12,9 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 import Crypto
-import _CryptoExtras
 import Foundation
 import XCTest
+import _CryptoExtras
 
 final class CMACTests: XCTestCase {
     // Borrowed from CryptoKit
@@ -33,21 +33,21 @@ final class CMACTests: XCTestCase {
     let exampleVector1 = ""
 
     let exampleVector2 = """
-    6bc1bee22e409f96e93d7e117393172a
-    """
+        6bc1bee22e409f96e93d7e117393172a
+        """
 
     let exampleVector3 = """
-    6bc1bee22e409f96e93d7e117393172a\
-    ae2d8a571e03ac9c9eb76fac45af8e51\
-    30c81c46a35ce411
-    """
+        6bc1bee22e409f96e93d7e117393172a\
+        ae2d8a571e03ac9c9eb76fac45af8e51\
+        30c81c46a35ce411
+        """
 
     let exampleVector4 = """
-    6bc1bee22e409f96e93d7e117393172a\
-    ae2d8a571e03ac9c9eb76fac45af8e51\
-    30c81c46a35ce411e5fbc1191a0a52ef\
-    f69f2445df4f9b17ad2b417be66c3710
-    """
+        6bc1bee22e409f96e93d7e117393172a\
+        ae2d8a571e03ac9c9eb76fac45af8e51\
+        30c81c46a35ce411e5fbc1191a0a52ef\
+        f69f2445df4f9b17ad2b417be66c3710
+        """
 
     func testExampleVector1() throws {
         let key = try Array(hexString: "2b7e151628aed2a6abf7158809cf4f3c")
@@ -141,15 +141,24 @@ final class CMACTests: XCTestCase {
 
                     switch test.result {
                     case "valid":
-                        XCTAssertTrue(result == test.computedTag, "Unexpected invalid test \(test.tcId) (\(test.comment))")
+                        XCTAssertTrue(
+                            result == test.computedTag,
+                            "Unexpected invalid test \(test.tcId) (\(test.comment))"
+                        )
                     case "invalid":
-                        XCTAssertFalse(result == test.computedTag, "Unexpected valid test \(test.tcId) (\(test.comment))")
+                        XCTAssertFalse(
+                            result == test.computedTag,
+                            "Unexpected valid test \(test.tcId) (\(test.comment))"
+                        )
                     default:
                         fatalError("Unexpected result type")
                     }
                 } catch {
                     XCTAssertTrue(test.result == "invalid", "Unexpected invalid test \(test.tcId) (\(test.comment))")
-                    XCTAssertTrue(test.comment == "invalid key size", "Unexpected invalid test \(test.tcId) (\(test.comment))")
+                    XCTAssertTrue(
+                        test.comment == "invalid key size",
+                        "Unexpected invalid test \(test.tcId) (\(test.comment))"
+                    )
                 }
             }
         }

--- a/Tests/_CryptoExtrasTests/Utils/BytesUtil.swift
+++ b/Tests/_CryptoExtrasTests/Utils/BytesUtil.swift
@@ -41,7 +41,11 @@ extension Array where Element == UInt8 {
     init(hexString: String) throws {
         self.init()
         
-        guard hexString.count.isMultiple(of: 2), !hexString.isEmpty else {
+        if hexString.count == 0 {
+            return
+        }
+
+        if hexString.count % 2 != 0 {
             throw ByteHexEncodingErrors.incorrectString
         }
 

--- a/Tests/_CryptoExtrasVectors/aes_cmac_test.json
+++ b/Tests/_CryptoExtrasVectors/aes_cmac_test.json
@@ -1,0 +1,2842 @@
+{
+  "algorithm" : "AES-CMAC",
+  "generatorVersion" : "0.8r12",
+  "numberOfTests" : 308,
+  "header" : [
+    "Test vectors of type MacTest are intended for testing the",
+    "generation and verification of MACs."
+  ],
+  "notes" : {
+  },
+  "schema" : "mac_test_schema.json",
+  "testGroups" : [
+    {
+      "keySize" : 128,
+      "tagSize" : 128,
+      "type" : "MacTest",
+      "tests" : [
+        {
+          "tcId" : 1,
+          "comment" : "empty message",
+          "key" : "e34f15c7bd819930fe9d66e0c166e61c",
+          "msg" : "",
+          "tag" : "d47afca1d857a5933405b1eb7a5cb7af",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 2,
+          "comment" : "short message",
+          "key" : "e1e726677f4893890f8c027f9d8ef80d",
+          "msg" : "3f",
+          "tag" : "15f856bbed3b321952a584b3c4437a63",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 3,
+          "comment" : "short message",
+          "key" : "b151f491c4c006d1f28214aa3da9a985",
+          "msg" : "27d9",
+          "tag" : "bdbbebac982dd62b9f682618a6a604e9",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 4,
+          "comment" : "short message",
+          "key" : "c36ff15f72777ee21deec07b63c1a0cd",
+          "msg" : "50b428",
+          "tag" : "be0c3ede157568af394023eb9a7cc983",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 5,
+          "comment" : "short message",
+          "key" : "32b9c5c78c3a0689a86052420fa1e8fc",
+          "msg" : "0b9262ec",
+          "tag" : "57e1506856c55dd32cd9ca821adb6c81",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 6,
+          "comment" : "short message",
+          "key" : "43151bbaef367277ebfc97509d0aa49c",
+          "msg" : "eaa91273e7",
+          "tag" : "e01adc3be6a7621824232c4285dd35b9",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 7,
+          "comment" : "short message",
+          "key" : "481440298525cc261f8159159aedf62d",
+          "msg" : "6123c556c5cc",
+          "tag" : "a281e0d2d5378dfdcc1310fd9782ca56",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 8,
+          "comment" : "short message",
+          "key" : "9ca26eb88731efbf7f810d5d95e196ac",
+          "msg" : "7e48f06183aa40",
+          "tag" : "fc81761f2f7b4ce13b53d36e32677332",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 9,
+          "comment" : "short message",
+          "key" : "48f0d03e41cc55c4b58f737b5acdea32",
+          "msg" : "f4a133aa6d5985a0",
+          "tag" : "1f1cd0327c02e6d00086915937dd61d9",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 10,
+          "comment" : "short message",
+          "key" : "1c958849f31996b28939ce513087d1be",
+          "msg" : "b0d2fee11b8e2f86b7",
+          "tag" : "555f462151f7dd16de698d639fb26760",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 11,
+          "comment" : "short message",
+          "key" : "39de0ebea97c09b2301a90009a423253",
+          "msg" : "81e5c33b4c620852f044",
+          "tag" : "9b004f15b7f6f366374954e64bc58f5f",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 12,
+          "comment" : "short message",
+          "key" : "91656d8fc0aced60ddb1c4006d0dde53",
+          "msg" : "7b3e440fe566790064b2ec",
+          "tag" : "76672ed16c29be449e0c80785cc38e89",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 13,
+          "comment" : "short message",
+          "key" : "af7d5134720b5386158d51ea126e7cf9",
+          "msg" : "7cc6fcc925c20f3c83b5567c",
+          "tag" : "2dc5c88cf3b80ab6c0199f40be904abc",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 14,
+          "comment" : "short message",
+          "key" : "4ed56753de6f75a032ebabca3ce27971",
+          "msg" : "0c8c0f5619d9f8da5339281285",
+          "tag" : "eab4366d97e99a0850f077329ad058c0",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 15,
+          "comment" : "short message",
+          "key" : "beba50c936b696c15e25046dffb23a64",
+          "msg" : "821ea8532fbabffb6e3d212e9b46",
+          "tag" : "22f33cab09c173f75d3401fe44efeead",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 16,
+          "comment" : "short message",
+          "key" : "501d81ebf912ddb87fbe3b7aac1437bc",
+          "msg" : "2368e3c3636b5e8e94d2081adbf798",
+          "tag" : "aeb784a3825168ddd61f72d0202125e6",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 17,
+          "comment" : "",
+          "key" : "e09eaa5a3f5e56d279d5e7a03373f6ea",
+          "msg" : "ef4eab37181f98423e53e947e7050fd0",
+          "tag" : "40facf0e2fb51b73a7472681b033d6dc",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 18,
+          "comment" : "",
+          "key" : "831e664c9e3f0c3094c0b27b9d908eb2",
+          "msg" : "26603bb76dd0a0180791c4ed4d3b058807",
+          "tag" : "a8144c8b24f2aa47d9c160cff4ab1716",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 19,
+          "comment" : "",
+          "key" : "549bd282ee21b4d7c3b1d02e3ee20ef7",
+          "msg" : "d84bf73c5eecbd38444f1a73556e2fa3253f4c54d6916545",
+          "tag" : "7ed458afe02f4a513f59715b664b1bbe",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 20,
+          "comment" : "",
+          "key" : "9bd3902ed0996c869b572272e76f3889",
+          "msg" : "a7ba19d49ee1ea02f098aa8e30c740d893a4456ccc294040484ed8a00a55f93e",
+          "tag" : "45082218c2d05eef32247feb1133d0a3",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 21,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "96dd6e5a882cbd564c39ae7d1c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 22,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "43802eb1931f0032afe984443738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 23,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7acfbbca7a2ea68b966fc5399f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 24,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "95dd6e5a882cbd564c39ae7d1c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 25,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "40802eb1931f0032afe984443738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 26,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "79cfbbca7a2ea68b966fc5399f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 27,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "17dd6e5a882cbd564c39ae7d1c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 28,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "c2802eb1931f0032afe984443738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 29,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "fbcfbbca7a2ea68b966fc5399f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 30,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dc6e5a882cbd564c39ae7d1c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 31,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42812eb1931f0032afe984443738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 32,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcebbca7a2ea68b966fc5399f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 33,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6eda882cbd564c39ae7d1c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 34,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802e31931f0032afe984443738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 35,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbb4a7a2ea68b966fc5399f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 36,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a892cbd564c39ae7d1c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 37,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1921f0032afe984443738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 38,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca7b2ea68b966fc5399f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 39,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a8a2cbd564c39ae7d1c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 40,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1911f0032afe984443738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 41,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca782ea68b966fc5399f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 42,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a882cbdd64c39ae7d1c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 43,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1931f00b2afe984443738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 44,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca7a2ea60b966fc5399f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 45,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a882cbd564d39ae7d1c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 46,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1931f0032aee984443738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 47,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca7a2ea68b976fc5399f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 48,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a882cbd56cc39ae7d1c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 49,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1931f00322fe984443738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 50,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca7a2ea68b166fc5399f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 51,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a882cbd564c19ae7d1c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 52,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1931f0032afc984443738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 53,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca7a2ea68b964fc5399f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 54,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a882cbd564c39af7d1c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 55,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1931f0032afe985443738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 56,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca7a2ea68b966fc4399f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 57,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a882cbd564c39ae7d1d5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 58,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1931f0032afe984443638cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 59,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca7a2ea68b966fc5399e74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 60,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a882cbd564c39ae7d1e5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 61,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1931f0032afe984443538cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 62,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca7a2ea68b966fc5399d74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 63,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a882cbd564c39ae7d9c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 64,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1931f0032afe98444b738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 65,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca7a2ea68b966fc5391f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 66,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a882cbd564c39ae7d1c5a31ab",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 67,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1931f0032afe984443738cd30",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 68,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca7a2ea68b966fc5399f74809f",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 69,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a882cbd564c39ae7d1c5a31a8",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 70,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1931f0032afe984443738cd33",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 71,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca7a2ea68b966fc5399f74809c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 72,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a882cbd564c39ae7d1c5a31ea",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 73,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1931f0032afe984443738cd71",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 74,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca7a2ea68b966fc5399f7480de",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 75,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a882cbd564c39ae7d1c5a312a",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 76,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1931f0032afe984443738cdb1",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 77,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca7a2ea68b966fc5399f74801e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 78,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "96dd6e5a882cbd564d39ae7d1c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 79,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "43802eb1931f0032aee984443738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 80,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7acfbbca7a2ea68b976fc5399f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 81,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6eda882cbdd64c39ae7d1c5a31aa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 82,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802e31931f00b2afe984443738cd31",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 83,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbb4a7a2ea60b966fc5399f74809e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 84,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "97dd6e5a882cbdd64c39ae7d1c5a312a",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 85,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "42802eb1931f00b2afe984443738cdb1",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 86,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7bcfbbca7a2ea60b966fc5399f74801e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 87,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "682291a577d342a9b3c65182e3a5ce55",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 88,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "bd7fd14e6ce0ffcd50167bbbc8c732ce",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 89,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "8430443585d1597469903ac6608b7f61",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 90,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "00000000000000000000000000000000",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 91,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "00000000000000000000000000000000",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 92,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "00000000000000000000000000000000",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 93,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "ffffffffffffffffffffffffffffffff",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 94,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "ffffffffffffffffffffffffffffffff",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 95,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "ffffffffffffffffffffffffffffffff",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 96,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "175deeda08ac3dd6ccb92efd9cdab12a",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 97,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "c200ae31139f80b22f6904c4b7b84db1",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 98,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "fb4f3b4afaae260b16ef45b91ff4001e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 99,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "",
+          "tag" : "96dc6f5b892dbc574d38af7c1d5b30ab",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 100,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "0001020304050607",
+          "tag" : "43812fb0921e0133aee885453639cc30",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 101,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "7acebacb7b2fa78a976ec4389e75819f",
+          "result" : "invalid",
+          "flags" : []
+        }
+      ]
+    },
+    {
+      "keySize" : 192,
+      "tagSize" : 128,
+      "type" : "MacTest",
+      "tests" : [
+        {
+          "tcId" : 102,
+          "comment" : "empty message",
+          "key" : "3d6bf9edae6d881eade0ff8c7076a4835b71320c1f36b631",
+          "msg" : "",
+          "tag" : "a8dd15fe2ce3495ec5b666744ec29220",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 103,
+          "comment" : "short message",
+          "key" : "915429743435c28997a33b33b6574a953d81dae0e7032e6a",
+          "msg" : "58",
+          "tag" : "e13b3f7f7f510c3a059df7a68c7e2ad5",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 104,
+          "comment" : "short message",
+          "key" : "f0c288ba26b284f9fb321b444a6517b3cdda1a799d55fdff",
+          "msg" : "0f7e",
+          "tag" : "06ef847f5f9dbf03a4f283da8c400220",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 105,
+          "comment" : "short message",
+          "key" : "6b55e4d4fd6847a80a6bfb0dcc0aa93f9fd797fc5c50292e",
+          "msg" : "33f530",
+          "tag" : "dd135053a47ca8f282c299e83b8c57c4",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 106,
+          "comment" : "short message",
+          "key" : "1eb21a9e995a8e45c9e71ecbd6fe615b3e0318007c64b644",
+          "msg" : "3aa73c48",
+          "tag" : "1e93fff846934a6eea0575eecb0f0e1f",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 107,
+          "comment" : "short message",
+          "key" : "710e2d5d4a9f0bc7e50796655e046a18cc5769d7764355da",
+          "msg" : "7e4c690a88",
+          "tag" : "016d4df06c68a6a788a9ea052e1b550d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 108,
+          "comment" : "short message",
+          "key" : "d8c09ea400779b63e774bdacd0cb7b5dd6f736ca23d52acf",
+          "msg" : "e9520280973b",
+          "tag" : "8030ae9f98f5d20c6089f6b1bd87c29e",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 109,
+          "comment" : "short message",
+          "key" : "8e67e9a0863b55bed408866f1cbc05357abe3f9d79f406f2",
+          "msg" : "4880b412287a0b",
+          "tag" : "bcaf50785f062a8fb8dd3c2c4cead2e1",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 110,
+          "comment" : "short message",
+          "key" : "28d8da67806410e5565bcc5a9d7ab9fb357413fa0158378c",
+          "msg" : "004e3f4a4e6db955",
+          "tag" : "c4c2c0876be9eabeb5a956da53846b08",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 111,
+          "comment" : "short message",
+          "key" : "dc968dd89fd602bb7eca6f3a8a13e4f59c08d02a514b1934",
+          "msg" : "41a25354efeb1bc3b8",
+          "tag" : "f33a62caf397f9aff71fe42941ba41d8",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 112,
+          "comment" : "short message",
+          "key" : "7658951c0f620d82afd92756cc2d7983b79da3e56fdd1b78",
+          "msg" : "f0e82fb5c5666f4af49f",
+          "tag" : "4d724d05f3402967eb65ae1e32d5469e",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 113,
+          "comment" : "short message",
+          "key" : "d9574c3a221b986690931faac5258d9d3c52362b2cb9b054",
+          "msg" : "178ea8404ba54ee4e4522c",
+          "tag" : "64a0e0b6757309ab58d74f72c310e473",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 114,
+          "comment" : "short message",
+          "key" : "704409bab28085c44981f28f75dd143a4f747106f63f262e",
+          "msg" : "cda5709e7f115624e74ab031",
+          "tag" : "6ab2074334be14a95b6a241f897a43de",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 115,
+          "comment" : "short message",
+          "key" : "d8d06ef6a53bbff5c8f12d791b8f4c67e574bf440736d1cc",
+          "msg" : "a1171eae1979f48345dd9485a0",
+          "tag" : "7aa57cf98b24897cc9230e3316758e61",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 116,
+          "comment" : "short message",
+          "key" : "71129e781613f39d9ac39fbde2628b44c250c14deb5ef9e2",
+          "msg" : "967593cc64bcbf7f3c58d04cb82b",
+          "tag" : "6cc488b0a40eadbe4bcee2623239d126",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 117,
+          "comment" : "short message",
+          "key" : "850fc859e9f7b89a367611dee6698f33962d8245ca8dc331",
+          "msg" : "586f4f171af116519061a8e0e77940",
+          "tag" : "fb11a360c9776991d73d6e41d07710a2",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 118,
+          "comment" : "",
+          "key" : "f4bfa5aa4f0f4d62cf736cd2969c43d580fdb92f2753bedb",
+          "msg" : "0e239f239705b282ce2200fe20de1165",
+          "tag" : "ab20a6cf60873665b1d6999b05c7f9c6",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 119,
+          "comment" : "",
+          "key" : "cfd3f68873d81a27d2bfce876c79f6e609074dec39e34614",
+          "msg" : "b1973cb25aa87ef9d1a8888b0a0f5c04c6",
+          "tag" : "b95a016b83a0ae4194023333c8a7345a",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 120,
+          "comment" : "",
+          "key" : "648a44468d67bb6744b235ee7a3fcd6ed4bdc29ec5b5fa1a",
+          "msg" : "c59d0d6981cca1be1d5519fc7881e6d230f39f6c12a9e827",
+          "tag" : "a1b96272ae7f9aef567271795f21d1d3",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 121,
+          "comment" : "",
+          "key" : "9d11abc1fcb248a436598e695be12c3c2ed90a18ba09d62c",
+          "msg" : "aa5182cae2a8fb068c0b3fb2be3e57ae523d13dffd1a944587707c2b67447f3f",
+          "tag" : "8597d9a04d1c271d61d42f007b435175",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 122,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ed12390ea0a7ed15d9d37a6eca1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 123,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c81307df60859acb911c7be61be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 124,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f91bde0069a6e389573bf04e7cde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 125,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ee12390ea0a7ed15d9d37a6eca1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 126,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "cb1307df60859acb911c7be61be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 127,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "fa1bde0069a6e389573bf04e7cde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 128,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "6c12390ea0a7ed15d9d37a6eca1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 129,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "491307df60859acb911c7be61be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 130,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "781bde0069a6e389573bf04e7cde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 131,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec13390ea0a7ed15d9d37a6eca1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 132,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91207df60859acb911c7be61be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 133,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81ade0069a6e389573bf04e7cde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 134,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12398ea0a7ed15d9d37a6eca1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 135,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c913075f60859acb911c7be61be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 136,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde8069a6e389573bf04e7cde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 137,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea1a7ed15d9d37a6eca1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 138,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df61859acb911c7be61be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 139,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde0068a6e389573bf04e7cde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 140,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea2a7ed15d9d37a6eca1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 141,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df62859acb911c7be61be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 142,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde006ba6e389573bf04e7cde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 143,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea0a7ed95d9d37a6eca1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 144,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df60859a4b911c7be61be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 145,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde0069a6e309573bf04e7cde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 146,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea0a7ed15d8d37a6eca1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 147,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df60859acb901c7be61be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 148,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde0069a6e389563bf04e7cde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 149,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea0a7ed1559d37a6eca1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 150,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df60859acb111c7be61be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 151,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde0069a6e389d73bf04e7cde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 152,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea0a7ed15d9f37a6eca1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 153,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df60859acb913c7be61be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 154,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde0069a6e389571bf04e7cde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 155,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea0a7ed15d9d37b6eca1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 156,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df60859acb911c7ae61be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 157,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde0069a6e389573bf14e7cde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 158,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea0a7ed15d9d37a6ecb1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 159,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df60859acb911c7be61ae7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 160,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde0069a6e389573bf04e7dde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 161,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea0a7ed15d9d37a6ec81fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 162,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df60859acb911c7be619e7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 163,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde0069a6e389573bf04e7ede688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 164,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea0a7ed15d9d37a6e4a1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 165,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df60859acb911c7be69be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 166,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde0069a6e389573bf04efcde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 167,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea0a7ed15d9d37a6eca1fc991",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 168,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df60859acb911c7be61be7ca91",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 169,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde0069a6e389573bf04e7cde688d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 170,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea0a7ed15d9d37a6eca1fc992",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 171,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df60859acb911c7be61be7ca92",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 172,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde0069a6e389573bf04e7cde688e",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 173,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea0a7ed15d9d37a6eca1fc9d0",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 174,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df60859acb911c7be61be7cad0",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 175,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde0069a6e389573bf04e7cde68cc",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 176,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea0a7ed15d9d37a6eca1fc910",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 177,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df60859acb911c7be61be7ca10",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 178,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde0069a6e389573bf04e7cde680c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 179,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ed12390ea0a7ed15d8d37a6eca1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 180,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c81307df60859acb901c7be61be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 181,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f91bde0069a6e389563bf04e7cde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 182,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12398ea0a7ed95d9d37a6eca1fc990",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 183,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c913075f60859a4b911c7be61be7ca90",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 184,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde8069a6e309573bf04e7cde688c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 185,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ec12390ea0a7ed95d9d37a6eca1fc910",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 186,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c91307df60859a4b911c7be61be7ca10",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 187,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f81bde0069a6e309573bf04e7cde680c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 188,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "13edc6f15f5812ea262c859135e0366f",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 189,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "36ecf8209f7a65346ee38419e418356f",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 190,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "07e421ff96591c76a8c40fb183219773",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 191,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "00000000000000000000000000000000",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 192,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "00000000000000000000000000000000",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 193,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "00000000000000000000000000000000",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 194,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ffffffffffffffffffffffffffffffff",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 195,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "ffffffffffffffffffffffffffffffff",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 196,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "ffffffffffffffffffffffffffffffff",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 197,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "6c92b98e20276d955953faee4a9f4910",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 198,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "4993875fe0051a4b119cfb669b674a10",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 199,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "789b5e80e9266309d7bb70cefc5ee80c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 200,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "",
+          "tag" : "ed13380fa1a6ec14d8d27b6fcb1ec891",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 201,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "0001020304050607",
+          "tag" : "c81206de61849bca901d7ae71ae6cb91",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 202,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f1011121314151617",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "f91adf0168a7e288563af14f7ddf698d",
+          "result" : "invalid",
+          "flags" : []
+        }
+      ]
+    },
+    {
+      "keySize" : 256,
+      "tagSize" : 128,
+      "type" : "MacTest",
+      "tests" : [
+        {
+          "tcId" : 203,
+          "comment" : "empty message",
+          "key" : "7bf9e536b66a215c22233fe2daaa743a898b9acb9f7802de70b40e3d6e43ef97",
+          "msg" : "",
+          "tag" : "736c7b56957db774c5ddf7c7a70ba8a8",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 204,
+          "comment" : "short message",
+          "key" : "e754076ceab3fdaf4f9bcab7d4f0df0cbbafbc87731b8f9b7cd2166472e8eebc",
+          "msg" : "40",
+          "tag" : "9d47482c2d9252bace43a75a8335b8b8",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 205,
+          "comment" : "short message",
+          "key" : "ea3b016bdd387dd64d837c71683808f335dbdc53598a4ea8c5f952473fafaf5f",
+          "msg" : "6601",
+          "tag" : "c7c44e31c466334992d6f9de3c771634",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 206,
+          "comment" : "short message",
+          "key" : "73d4709637857dafab6ad8b2b0a51b06524717fedf100296644f7cfdaae1805b",
+          "msg" : "f1d300",
+          "tag" : "b7086603a85e11fceb8cadea9bd30939",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 207,
+          "comment" : "short message",
+          "key" : "d5c81b399d4c0d1583a13da56de6d2dc45a66e7b47c24ab1192e246dc961dd77",
+          "msg" : "2ae63cbf",
+          "tag" : "ba383a3a15c9df64bba50d611113a024",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 208,
+          "comment" : "short message",
+          "key" : "2521203fa0dddf59d837b2830f87b1aa61f958155df3ca4d1df2457cb4284dc8",
+          "msg" : "af3a015ea1",
+          "tag" : "b457137c548908c629f714fe83b1ed90",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 209,
+          "comment" : "short message",
+          "key" : "665a02bc265a66d01775091da56726b6668bfd903cb7af66fb1b78a8a062e43c",
+          "msg" : "3f56935def3f",
+          "tag" : "b6d6fde93fc85de289b36b446d77b423",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 210,
+          "comment" : "short message",
+          "key" : "facd75b22221380047305bc981f570e2a1af38928ea7e2059e3af5fc6b82b493",
+          "msg" : "57bb86beed156f",
+          "tag" : "8b1ef72d0a612735b08efef981f213c2",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 211,
+          "comment" : "short message",
+          "key" : "505aa98819809ef63b9a368a1e8bc2e922da45b03ce02d9a7966b15006dba2d5",
+          "msg" : "2e4e7ef728fe11af",
+          "tag" : "f79606b83a7706a2a19e068bce818898",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 212,
+          "comment" : "short message",
+          "key" : "f942093842808ba47f64e427f7351dde6b9546e66de4e7d60aa6f328182712cf",
+          "msg" : "852a21d92848e627c7",
+          "tag" : "a5a877f22ac743b7fb9e050d2e3ddb02",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 213,
+          "comment" : "short message",
+          "key" : "64be162b39c6e5f1fed9c32d9f674d9a8cde6eaa2443214d86bd4a1fb53b81b4",
+          "msg" : "195a3b292f93baff0a2c",
+          "tag" : "6ea172e5c4d2fac075ca602de5757a62",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 214,
+          "comment" : "short message",
+          "key" : "b259a555d44b8a20c5489e2f38392ddaa6be9e35b9833b67e1b5fdf6cb3e4c6c",
+          "msg" : "afd73117330c6e8528a6e4",
+          "tag" : "68020bfc9bd73fd80d3ce581ba3b1208",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 215,
+          "comment" : "short message",
+          "key" : "2c6fc62daa77ba8c6881b3dd6989898fef646663cc7b0a3db8228a707b85f2dc",
+          "msg" : "0ff54d6b6759120c2e8a51e3",
+          "tag" : "110edd727a9bf7fa11a6358afe617d9d",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 216,
+          "comment" : "short message",
+          "key" : "abab815d51df29f740e4e2079fb798e0152836e6ab57d1536ae8929e52c06eb8",
+          "msg" : "f0058d412a104e53d820b95a7f",
+          "tag" : "1fa24c6625a0f8e1fc37827ac84d3cc4",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 217,
+          "comment" : "short message",
+          "key" : "3d5da1af83f7287458bff7a7651ea5d8db72259401333f6b82096996dd7eaf19",
+          "msg" : "aacc36972f183057919ff57b49e1",
+          "tag" : "868765a8fa6aa898ddec0f4123e996be",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 218,
+          "comment" : "short message",
+          "key" : "c19bdf314c6cf64381425467f42aefa17c1cc9358be16ce31b1d214859ce86aa",
+          "msg" : "5d066a92c300e9b6ddd63a7c13ae33",
+          "tag" : "b96818b7acaf879c7a7f8271375a6914",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 219,
+          "comment" : "",
+          "key" : "612e837843ceae7f61d49625faa7e7494f9253e20cb3adcea686512b043936cd",
+          "msg" : "cc37fae15f745a2f40e2c8b192f2b38d",
+          "tag" : "4b88e193000c5a4b23e95c7f2b26530b",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 220,
+          "comment" : "",
+          "key" : "73216fafd0022d0d6ee27198b2272578fa8f04dd9f44467fbb6437aa45641bf7",
+          "msg" : "d5247b8f6c3edcbfb1d591d13ece23d2f5",
+          "tag" : "86911c7da51dc0823d6e93d4290d1ad4",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 221,
+          "comment" : "",
+          "key" : "0427a70e257528f3ab70640bba1a5de12cf3885dd4c8e284fbbb55feb35294a5",
+          "msg" : "13937f8544f44270d01175a011f7670e93fa6ba7ef02336e",
+          "tag" : "ccb2c51bfbe2598f9109fc70ed07f0eb",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 222,
+          "comment" : "",
+          "key" : "96e1e4896fb2cd05f133a6a100bc5609a7ac3ca6d81721e922dadd69ad07a892",
+          "msg" : "91a17e4dfcc3166a1add26ff0e7c12056e8a654f28a6de24f4ba739ceb5b5b18",
+          "tag" : "925f177d85ea297ef14b203fe409f9ab",
+          "result" : "valid",
+          "flags" : []
+        },
+        {
+          "tcId" : 223,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6af0a293d8cba0101f0089727691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 224,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d709717c3a4ef8a2ea200b297d2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 225,
+          "comment" : "Flipped bit 0 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "58ee3f3b5f83e290cae26dad29bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 226,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "69f0a293d8cba0101f0089727691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 227,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d409717c3a4ef8a2ea200b297d2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 228,
+          "comment" : "Flipped bit 1 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "5bee3f3b5f83e290cae26dad29bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 229,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "ebf0a293d8cba0101f0089727691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 230,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "5609717c3a4ef8a2ea200b297d2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 231,
+          "comment" : "Flipped bit 7 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "d9ee3f3b5f83e290cae26dad29bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 232,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf1a293d8cba0101f0089727691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 233,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d608717c3a4ef8a2ea200b297d2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 234,
+          "comment" : "Flipped bit 8 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ef3f3b5f83e290cae26dad29bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 235,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a213d8cba0101f0089727691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 236,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d60971fc3a4ef8a2ea200b297d2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 237,
+          "comment" : "Flipped bit 31 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3fbb5f83e290cae26dad29bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 238,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293d9cba0101f0089727691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 239,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c3b4ef8a2ea200b297d2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 240,
+          "comment" : "Flipped bit 32 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5e83e290cae26dad29bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 241,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293dacba0101f0089727691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 242,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c384ef8a2ea200b297d2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 243,
+          "comment" : "Flipped bit 33 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5d83e290cae26dad29bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 244,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293d8cba0901f0089727691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 245,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c3a4ef822ea200b297d2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 246,
+          "comment" : "Flipped bit 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5f83e210cae26dad29bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 247,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293d8cba0101e0089727691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 248,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c3a4ef8a2eb200b297d2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 249,
+          "comment" : "Flipped bit 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5f83e290cbe26dad29bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 250,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293d8cba0109f0089727691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 251,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c3a4ef8a26a200b297d2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 252,
+          "comment" : "Flipped bit 71 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5f83e2904ae26dad29bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 253,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293d8cba0101f2089727691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 254,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c3a4ef8a2ea000b297d2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 255,
+          "comment" : "Flipped bit 77 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5f83e290cac26dad29bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 256,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293d8cba0101f0088727691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 257,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c3a4ef8a2ea200a297d2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 258,
+          "comment" : "Flipped bit 80 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5f83e290cae26cad29bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 259,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293d8cba0101f0089727791b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 260,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c3a4ef8a2ea200b297c2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 261,
+          "comment" : "Flipped bit 96 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5f83e290cae26dad28bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 262,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293d8cba0101f0089727491b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 263,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c3a4ef8a2ea200b297f2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 264,
+          "comment" : "Flipped bit 97 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5f83e290cae26dad2bbba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 265,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293d8cba0101f008972f691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 266,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c3a4ef8a2ea200b29fd2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 267,
+          "comment" : "Flipped bit 103 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5f83e290cae26dada9bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 268,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293d8cba0101f0089727691b7fa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 269,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c3a4ef8a2ea200b297d2acced",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 270,
+          "comment" : "Flipped bit 120 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5f83e290cae26dad29bba32c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 271,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293d8cba0101f0089727691b7f9",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 272,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c3a4ef8a2ea200b297d2accee",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 273,
+          "comment" : "Flipped bit 121 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5f83e290cae26dad29bba32f",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 274,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293d8cba0101f0089727691b7bb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 275,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c3a4ef8a2ea200b297d2accac",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 276,
+          "comment" : "Flipped bit 126 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5f83e290cae26dad29bba36d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 277,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293d8cba0101f0089727691b77b",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 278,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c3a4ef8a2ea200b297d2acc6c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 279,
+          "comment" : "Flipped bit 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5f83e290cae26dad29bba3ad",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 280,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6af0a293d8cba0101e0089727691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 281,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d709717c3a4ef8a2eb200b297d2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 282,
+          "comment" : "Flipped bits 0 and 64 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "58ee3f3b5f83e290cbe26dad29bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 283,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a213d8cba0901f0089727691b7fb",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 284,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d60971fc3a4ef822ea200b297d2accec",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 285,
+          "comment" : "Flipped bits 31 and 63 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3fbb5f83e210cae26dad29bba32d",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 286,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6bf0a293d8cba0901f0089727691b77b",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 287,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d609717c3a4ef822ea200b297d2acc6c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 288,
+          "comment" : "Flipped bits 63 and 127 in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "59ee3f3b5f83e210cae26dad29bba3ad",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 289,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "940f5d6c27345fefe0ff768d896e4804",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 290,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "29f68e83c5b1075d15dff4d682d53313",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 291,
+          "comment" : "all bits of tag flipped",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "a611c0c4a07c1d6f351d9252d6445cd2",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 292,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "00000000000000000000000000000000",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 293,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "00000000000000000000000000000000",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 294,
+          "comment" : "Tag changed to all zero",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "00000000000000000000000000000000",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 295,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "ffffffffffffffffffffffffffffffff",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 296,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "ffffffffffffffffffffffffffffffff",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 297,
+          "comment" : "tag changed to all 1",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "ffffffffffffffffffffffffffffffff",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 298,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "eb702213584b20909f8009f2f611377b",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 299,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "5689f1fcbace78226aa08ba9fdaa4c6c",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 300,
+          "comment" : "msbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "d96ebfbbdf0362104a62ed2da93b23ad",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 301,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "",
+          "tag" : "6af1a392d9caa1111e0188737790b6fa",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 302,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "0001020304050607",
+          "tag" : "d708707d3b4ff9a3eb210a287c2bcded",
+          "result" : "invalid",
+          "flags" : []
+        },
+        {
+          "tcId" : 303,
+          "comment" : "lsbs changed in tag",
+          "key" : "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+          "msg" : "000102030405060708090a0b0c0d0e0f",
+          "tag" : "58ef3e3a5e82e391cbe36cac28baa22c",
+          "result" : "invalid",
+          "flags" : []
+        }
+      ]
+    },
+    {
+      "keySize" : 0,
+      "tagSize" : 128,
+      "type" : "MacTest",
+      "tests" : [
+        {
+          "tcId" : 304,
+          "comment" : "invalid key size",
+          "key" : "",
+          "msg" : "00b9449326d39416",
+          "tag" : "",
+          "result" : "invalid",
+          "flags" : []
+        }
+      ]
+    },
+    {
+      "keySize" : 8,
+      "tagSize" : 128,
+      "type" : "MacTest",
+      "tests" : [
+        {
+          "tcId" : 305,
+          "comment" : "invalid key size",
+          "key" : "0f",
+          "msg" : "4538b79a1397e2aa",
+          "tag" : "",
+          "result" : "invalid",
+          "flags" : []
+        }
+      ]
+    },
+    {
+      "keySize" : 64,
+      "tagSize" : 128,
+      "type" : "MacTest",
+      "tests" : [
+        {
+          "tcId" : 306,
+          "comment" : "invalid key size",
+          "key" : "a88e385af7185148",
+          "msg" : "dc63b7ef08096e4f",
+          "tag" : "",
+          "result" : "invalid",
+          "flags" : []
+        }
+      ]
+    },
+    {
+      "keySize" : 160,
+      "tagSize" : 128,
+      "type" : "MacTest",
+      "tests" : [
+        {
+          "tcId" : 307,
+          "comment" : "invalid key size",
+          "key" : "003a228008d390b645929df73a2b2bdd8298918d",
+          "msg" : "ad1d3c3122ab7ac6",
+          "tag" : "",
+          "result" : "invalid",
+          "flags" : []
+        }
+      ]
+    },
+    {
+      "keySize" : 320,
+      "tagSize" : 128,
+      "type" : "MacTest",
+      "tests" : [
+        {
+          "tcId" : 308,
+          "comment" : "invalid key size",
+          "key" : "94baaac150e2645ae1ec1939c7bcefb73f6edb146fae02289b6c6326ff39bc265d612bef2727fa72",
+          "msg" : "e3f75a886c4a5591",
+          "tag" : "",
+          "result" : "invalid",
+          "flags" : []
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
Motivation

AES CMAC is a standardised albeit somewhat uncommon MAC built on top of the AES block cipher. CMAC pops up in a few places, mostly where it is convenient to assume that you have access to AES, but not to a hash function. For example, AES-SIV is built on CMAC.

Modifications

Add CMAC support
Add tests and test vectors

Result

CMAC is supported