### PR TITLE
Use Thread.threadDictionary instead of TaskLocal for thread-local

### DIFF
--- a/Sources/_CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
+++ b/Sources/_CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
@@ -65,10 +65,17 @@ extension P256: OpenSSLSupportedNISTCurve {
     @inlinable
     static var hashToFieldByteCount: Int { 48 }
 
-    @TaskLocal
     @usableFromInline
     // NOTE: This could be a let when Swift 6.0 is the minimum supported version.
-    static var __ffac = try! FiniteFieldArithmeticContext(fieldSize: P256.group.order)
+    static var __ffac: FiniteFieldArithmeticContext {
+        let key = "com.apple.swift-crypto.P256.__ffac"
+        if let value = Thread.current.threadDictionary[key] as? FiniteFieldArithmeticContext {
+            return value
+        }
+        let value = try! FiniteFieldArithmeticContext(fieldSize: P256.group.order)
+        Thread.current.threadDictionary[key] = value
+        return value
+    }
 }
 
 /// NOTE: This conformance applies to this type from the Crypto module even if it comes from the SDK.
@@ -92,10 +99,17 @@ extension P384: OpenSSLSupportedNISTCurve {
     @inlinable
     static var hashToFieldByteCount: Int { 72 }
 
-    @TaskLocal
     @usableFromInline
     // NOTE: This could be a let when Swift 6.0 is the minimum supported version.
-    static var __ffac = try! FiniteFieldArithmeticContext(fieldSize: P384.group.order)
+    static var __ffac: FiniteFieldArithmeticContext {
+        let key = "com.apple.swift-crypto.P384.__ffac"
+        if let value = Thread.current.threadDictionary[key] as? FiniteFieldArithmeticContext {
+            return value
+        }
+        let value = try! FiniteFieldArithmeticContext(fieldSize: P384.group.order)
+        Thread.current.threadDictionary[key] = value
+        return value
+    }
 }
 
 /// NOTE: This conformance applies to this type from the Crypto module even if it comes from the SDK.
@@ -119,10 +133,17 @@ extension P521: OpenSSLSupportedNISTCurve {
     @inlinable
     static var hashToFieldByteCount: Int { 98 }
 
-    @TaskLocal
     @usableFromInline
     // NOTE: This could be a let when Swift 6.0 is the minimum supported version.
-    static var __ffac = try! FiniteFieldArithmeticContext(fieldSize: P521.group.order)
+    static var __ffac: FiniteFieldArithmeticContext {
+        let key = "com.apple.swift-crypto.P521.__ffac"
+        if let value = Thread.current.threadDictionary[key] as? FiniteFieldArithmeticContext {
+            return value
+        }
+        let value = try! FiniteFieldArithmeticContext(fieldSize: P521.group.order)
+        Thread.current.threadDictionary[key] = value
+        return value
+    }
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Tests/_CryptoExtrasTests/ECToolbox/BoringSSL/ECToolboxBoringSSLTests.swift
+++ b/Tests/_CryptoExtrasTests/ECToolbox/BoringSSL/ECToolboxBoringSSLTests.swift
@@ -1,0 +1,60 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2025 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+import Crypto
+import Foundation
+import XCTest
+
+@testable import _CryptoExtras
+
+final class ECToolboxBoringSSLTests: XCTestCase {
+    func testThreadLocalFFAC() async {
+        await testThreadLocalFFAC(P256.self)
+        await testThreadLocalFFAC(P384.self)
+        await testThreadLocalFFAC(P521.self)
+    }
+
+    func testThreadLocalFFAC(_ Curve: (some OpenSSLSupportedNISTCurve & Sendable).Type) async {
+        let numThreads = 3
+        let numReadsPerThread = 2
+        var threads: [Thread] = []
+        var objectIdentifiers: [(threadID: Int, ffacID: ObjectIdentifier)] = []
+        let lock = NSLock()
+        let expectation = XCTestExpectation(description: "Thread done")
+        expectation.expectedFulfillmentCount = numThreads
+        for i in 1...numThreads {
+            let thread = Thread {
+                lock.withLock {
+                    for _ in 1...numReadsPerThread {
+                        objectIdentifiers.append((i, ObjectIdentifier(Curve.__ffac)))
+                    }
+                }
+                expectation.fulfill()
+            }
+            threads.append(thread)
+            thread.start()
+        }
+        await fulfillment(of: [expectation], timeout: 0.5)
+
+        XCTAssertEqual(objectIdentifiers.count, numThreads * numReadsPerThread)
+        for threadID in 1...numThreads {
+            let partitionBoundary = objectIdentifiers.partition(by: { $0.threadID == threadID })
+            let thisThreadObjIDs = objectIdentifiers[..<partitionBoundary].map(\.ffacID)
+            let otherThreadsObjIDs = objectIdentifiers[partitionBoundary...].map(\.ffacID)
+            let intersection = Set(thisThreadObjIDs).intersection(Set(otherThreadsObjIDs))
+            XCTAssertEqual(thisThreadObjIDs.count, numReadsPerThread, "Thread should read \(numReadsPerThread) times.")
+            XCTAssertEqual(Set(thisThreadObjIDs).count, 1, "Thread should see same object on every read.")
+            XCTAssert(intersection.isEmpty, "Thread should see different objects from other threads.")
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

We were using a `@TaskLocal static var` to hold the `FiniteFieldArithmeticContext` (FFAC) on each of the curve types. The intention here was this would operate as a thread-local value, since task-locals behave like thread locals when the caller is not part of a task context. However, they still require binding, (i.e. the use of e.g. `P256.$__ffac.withValue { ... }`[^1], otherwise they just return the _default_ value, which is globally shared. We were not doing that, nor do we have a sensible place where we could.

This causes crashes when using these values in a multithreaded environment since the same value will be used across threads.

## Modifications

- Use an explicit thread-local API from Foundation to store and read the per-curve FFAC.
- Add a test that shows each thread gets the same value on each read, but distinct from all other threads.

## Result

Fixes crash when using ECToolbox-based APIs in multithreaded code.

[^1]: https://developer.apple.com/documentation/swift/tasklocal#Using-task-local-values-outside-of-tasks