### PR TITLE
Improve vendor-boringssl.sh script to make it work better

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -98,7 +98,6 @@ let package = Package(
             name: "CCryptoBoringSSL",
             exclude: privacyManifestExclude + [
                 "hash.txt",
-                "include/boringssl_prefix_symbols_nasm.inc",
                 "CMakeLists.txt",
                 /*
                  * These files are excluded to support WASI libc which doesn't provide <netdb.h>.

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -101,9 +101,9 @@ function mangle_symbols {
         )
 
         # Now cross compile for our targets.
-        docker run -t -i --rm --privileged -v"$(pwd)":/src -w/src --platform linux/arm64 swift:5.10-jammy \
+        docker run -t -i --rm --privileged -v"$(pwd)":/src -w/src --platform linux/arm64 swift:6.0-jammy \
             swift build --product CCryptoBoringSSL
-        docker run -t -i --rm --privileged -v"$(pwd)":/src -w/src --platform linux/amd64 swift:5.10-jammy \
+        docker run -t -i --rm --privileged -v"$(pwd)":/src -w/src --platform linux/amd64 swift:6.0-jammy \
             swift build --product CCryptoBoringSSL
 
         # Now we need to generate symbol mangles for Linux. We can do this in

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -248,7 +248,7 @@ echo "DISABLING assembly on x86 Windows"
     # x86 Windows builds require nasm for acceleration. SwiftPM can't do that right now,
     # so we disable the assembly.
     cd "$DSTROOT"
-    gsed -i "/#define OPENSSL_HEADER_BASE_H/a#if defined(_WIN32) && (defined(__x86_64) || defined(_M_AMD64) || defined(_M_X64) || defined(__x86) || defined(__i386) || defined(__i386__) || defined(_M_IX86))\n#define OPENSSL_NO_ASM\n#endif" "include/openssl/base.h"
+    $sed -i "/#define OPENSSL_HEADER_BASE_H/a#if defined(_WIN32) && (defined(__x86_64) || defined(_M_AMD64) || defined(_M_X64) || defined(__x86) || defined(__i386) || defined(__i386__) || defined(_M_IX86))\n#define OPENSSL_NO_ASM\n#endif" "include/openssl/base.h"
 
 )
 

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -101,9 +101,9 @@ function mangle_symbols {
         )
 
         # Now cross compile for our targets.
-        docker run -t -i --rm --privileged -v"$(pwd)":/src -w/src --platform linux/arm64 swift:6.0-jammy \
+        docker run -t -i --rm --privileged -v"$(pwd)":/src -w/src --platform linux/arm64 swift:5.10-jammy \
             swift build --product CCryptoBoringSSL
-        docker run -t -i --rm --privileged -v"$(pwd)":/src -w/src --platform linux/amd64 swift:6.0-jammy \
+        docker run -t -i --rm --privileged -v"$(pwd)":/src -w/src --platform linux/amd64 swift:5.10-jammy \
             swift build --product CCryptoBoringSSL
 
         # Now we need to generate symbol mangles for Linux. We can do this in

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -170,7 +170,8 @@ echo "CLONING boringssl"
 mkdir -p "$SRCROOT"
 git clone https://boringssl.googlesource.com/boringssl "$SRCROOT"
 cd "$SRCROOT"
-BORINGSSL_REVISION=$(git rev-parse HEAD)
+BORINGSSL_REVISION=035e720641f385e82c72b7b0a9e1d89e58cb5ed5
+git checkout $BORINGSSL_REVISION
 cd "$HERE"
 echo "CLONED boringssl@${BORINGSSL_REVISION}"
 

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -46,7 +46,9 @@ TMPDIR=$(mktemp -d /tmp/.workingXXXXXX)
 SRCROOT="${TMPDIR}/src/boringssl.googlesource.com/boringssl"
 
 # BoringSSL revision can be passed as the first argument to this script.
-BORINGSSL_REVISION=$1
+if [ "$#" -gt 0 ]; then
+    BORINGSSL_REVISION="$1"
+fi
 
 # This function namespaces the awkward inline functions declared in OpenSSL
 # and BoringSSL.
@@ -173,9 +175,9 @@ echo "CLONING boringssl"
 mkdir -p "$SRCROOT"
 git clone https://boringssl.googlesource.com/boringssl "$SRCROOT"
 cd "$SRCROOT"
-if [ $BORINGSSL_REVISION ]; then
+if [ "$BORINGSSL_REVISION" ]; then
     echo "CHECKING OUT boringssl@${BORINGSSL_REVISION}"
-    git checkout $BORINGSSL_REVISION
+    git checkout "$BORINGSSL_REVISION"
 else 
     BORINGSSL_REVISION=$(git rev-parse HEAD)
     echo "CLONED boringssl@${BORINGSSL_REVISION}"

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -45,6 +45,9 @@ DSTROOT=Sources/CCryptoBoringSSL
 TMPDIR=$(mktemp -d /tmp/.workingXXXXXX)
 SRCROOT="${TMPDIR}/src/boringssl.googlesource.com/boringssl"
 
+# BoringSSL revision can be passed as the first argument to this script.
+BORINGSSL_REVISION=$1
+
 # This function namespaces the awkward inline functions declared in OpenSSL
 # and BoringSSL.
 function namespace_inlines {
@@ -170,10 +173,14 @@ echo "CLONING boringssl"
 mkdir -p "$SRCROOT"
 git clone https://boringssl.googlesource.com/boringssl "$SRCROOT"
 cd "$SRCROOT"
-BORINGSSL_REVISION=035e720641f385e82c72b7b0a9e1d89e58cb5ed5
-git checkout $BORINGSSL_REVISION
+if [ $BORINGSSL_REVISION ]; then
+    echo "CHECKING OUT boringssl@${BORINGSSL_REVISION}"
+    git checkout $BORINGSSL_REVISION
+else 
+    BORINGSSL_REVISION=$(git rev-parse HEAD)
+    echo "CLONED boringssl@${BORINGSSL_REVISION}"
+fi
 cd "$HERE"
-echo "CLONED boringssl@${BORINGSSL_REVISION}"
 
 echo "OBTAINING submodules"
 (


### PR DESCRIPTION
Updates for the `scripts/vendor-boringssl.h` script that make it a bit easier to use and ensure you don't accidentally get an update of BoringSSL you don't want.

### Motivation:

I was working on investigating building a Swift SDK for #223 and ran into a couple of things that I saw could be improved. Not all need to be done, but at the very least I feel the boringssl revision lock should be considered. @Lukasa 

### Modifications:

- Add missing invocation of `$sed` in the script- `gsed` was being invoked instead, although everywhere else `$sed` was used (typo).
- Support locking `BORINGSSL_REVISION` to a specific revision number through an argument to the script. This way the script can be re-run without unintentionally upgrading boringssl.
- Remove the non-existent `boringssl_prefix_symbols_nasm.inc` exclude from the `CCryptoBoringSSL` target. I'm guessing it was there for an older version of boringssl, but no longer there with the current revision?

### Result:

The `scripts/vendor_boringssl.sh` script behaves a bit better and can be run without upgrading the boringssl version unless explicitly desired.