### PR TITLE
Avoid TSAN issue in _CryptoExtras/AES/CMAC

### DIFF
--- a/Sources/_CryptoExtras/AES/CMAC.swift
+++ b/Sources/_CryptoExtras/AES/CMAC.swift
@@ -65,6 +65,10 @@ extension AES {
             self.backing.update(bufferPointer)
         }
 
+        // This enhancement can only be present on 6.1 or later because of the
+        // absence of https://github.com/swiftlang/swift/pull/76186 in older
+        // compilers.
+        #if compiler(>=6.1)
         /// Finalizes the message authentication computation and returns the
         /// computed code.
         ///
@@ -77,6 +81,16 @@ extension AES {
             self.cowIfNeeded()
             return self.backing.finalize()
         }
+        #else
+        /// Finalizes the message authentication computation and returns the
+        /// computed code.
+        ///
+        /// - Returns: The message authentication code.
+        public func finalize() -> AES.CMAC.MAC {
+            var `self` = self
+            return self.backing.finalize()
+        }
+        #endif
 
         /// Updates the MAC with data.
         ///


### PR DESCRIPTION
### Motivation:
swift-crypto currently fails to compile with TSAN enabled in 5.10 and 6.0 due to a TSAN error stemming from the use of `consuming` in the `finalize()` method of `_CryptoExtras/AES/CMAC`.

### Modifications:
Like #384, the `consuming finalize()` method in `_CryptoExtras/AES/CMAC` is now wrapped inside a `#if compiler(>=6.1)` condition. A non-consuming variant is used otherwise.

### Result:
`swift-crypto` can successfully compile with TSAN enabled in 5.10 and 6.0.