### PR TITLE
Add Wasm build to `pull_request.yml`

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -72,7 +72,9 @@ jobs:
 
   wasm:
     name: Wasm Swift SDK
-    uses: apple/swift-nio/.github/workflows/wasm_sdk.yml@main
+    uses: swiftlang/github-workflows/.github/workflows/swift_package_test.yml@main
     with:
+      enable_wasm_sdk_build: true
+      enable_linux_checks: false
+      enable_windows_checks: false
       swift_flags: --target Crypto
-      swift_nightly_flags: --target Crypto


### PR DESCRIPTION
This ensures that Wasm builds are tested on CI.

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [N/A] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [N/A] I've run `.script/generate_boilerplate_files_with_gyb` and included updated generated files in a commit of this pull request

### Motivation:

The library currently doesn't build for Wasm on CI.

### Modifications:

* Added Wasm Swift SDK job to `pull_request.yml`.
* Renamed `static-sdk`/"Static SDK` job, which is incorrectly named named with vague wording: Musl Swift SDK is not the only one supporting static linking, Wasm is also statically linked by default.

### Result:

Build regressions on Wasm are prevented, jobs are named in a non-ambiguous way.