### PR TITLE
Add Argon2id key derivation function

### DIFF
--- a/Sources/CryptoExtras/Key Derivation/Argon2/Argon2.swift
+++ b/Sources/CryptoExtras/Key Derivation/Argon2/Argon2.swift
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
 import Crypto
 import Foundation
 

--- a/Sources/CryptoExtras/Key Derivation/Argon2/Native/Argon2id+Native.swift
+++ b/Sources/CryptoExtras/Key Derivation/Argon2/Native/Argon2id+Native.swift
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
 import Foundation
 import Crypto
 

--- a/Sources/CryptoExtras/Key Derivation/Argon2/Native/Blake2b.swift
+++ b/Sources/CryptoExtras/Key Derivation/Argon2/Native/Blake2b.swift
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
 import Foundation
 import Crypto
 

--- a/Tests/CryptoExtrasTests/Argon2Tests.swift
+++ b/Tests/CryptoExtrasTests/Argon2Tests.swift
@@ -11,6 +11,7 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+
 import XCTest
 import Crypto
 import CryptoExtras


### PR DESCRIPTION
_Add Argon2id key derivation function (RFC 9106)_

<!-- Thanks for contributing to Swift Crypto! Before you submit your issue, please make sure you followed our checklist and check the appropriate boxes by putting an x in the [ ]: [x] -->

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `./scripts/generate_boilerplate_files_with_gyb.sh` and included updated generated files in a commit of this pull request

### Motivation:

_Argon2id is the recommended password hashing algorithm by OWASP and the winner of the Password Hashing Competition. It provides superior resistance to GPU/ASIC attacks compared to bcrypt and PBKDF2. BoringSSL does not currently include Argon2, making a pure Swift implementation necessary for cross-platform support._

### Modifications:

_- Added `KDF.Argon2id` public API following the existing `KDF.Scrypt` pattern_
_- Implemented pure Swift Argon2id (RFC 9106) with internal BLAKE2b primitive (variable-length output of 64–1024 bytes required by Argon2, not available in BoringSSL's fixed BLAKE2b-256)_
_- Added test case verified against official RFC 9106 Section 5.3 test vector_

_**Files added:**_
_- Sources/CryptoExtras/Key Derivation/Argon2/Argon2.swift_
_- Sources/CryptoExtras/Key Derivation/Argon2/Native/Argon2id+Native.swift_
_- Sources/CryptoExtras/Key Derivation/Argon2/Native/Blake2b.swift_
_- Tests/CryptoExtrasTests/Argon2Tests.swift_

### Result:

_Users can derive cryptographic keys using Argon2id:_
```swift
let key = try KDF.Argon2id.deriveKey(
    from: password,
    salt: salt,
    outputByteCount: 32,
    iterations: 3,
    memoryByteCount: 64 * 1024 * 1024,
    parallelism: 4
)
