### PR TITLE
Validate ciphertext length in AES._CBC.decrypt

### DIFF
--- a/Sources/CryptoExtras/AES/AES_CBC.swift
+++ b/Sources/CryptoExtras/AES/AES_CBC.swift
@@ -124,6 +124,10 @@ extension AES {
                 throw CryptoKitError.incorrectKeySize
             }
 
+            guard ciphertext.count % AES._CBC.blockSize == 0 else {
+                throw CryptoKitError.incorrectParameterSize
+            }
+
             var plaintext = Data()
             plaintext.reserveCapacity(ciphertext.count)
 

--- a/Tests/CryptoExtrasTests/AES_CBCTests.swift
+++ b/Tests/CryptoExtrasTests/AES_CBCTests.swift
@@ -163,6 +163,23 @@ final class CBCTests: XCTestCase {
         }
     }
 
+    func testDecryptRejectsNonBlockAlignedCiphertext() throws {
+        let key = SymmetricKey(data: try Data(hexString: "b6fc08df9b778d11850356b8bfc9561a"))
+        let iv = try AES._CBC.IV(ivBytes: Array(hexString: "00000000000000000000000000000000"))
+
+        // 17 bytes — not a multiple of the 16-byte block size.
+        let nonAligned = try Data(hexString: "00112233445566778899aabbccddeeff00")
+
+        for noPadding in [false, true] {
+            XCTAssertThrowsError(try AES._CBC.decrypt(nonAligned, using: key, iv: iv, noPadding: noPadding)) { error in
+                guard let error = error as? CryptoKitError, case .incorrectParameterSize = error else {
+                    XCTFail("Unexpected error for noPadding=\(noPadding): \(error)")
+                    return
+                }
+            }
+        }
+    }
+
     func testToDataConversion() throws {
         let randomBytes = (0..<16).map { _ in UInt8.random(in: UInt8.min...UInt8.max) }
         let dataIn = Data(randomBytes)


### PR DESCRIPTION
Validate ciphertext length in `AES._CBC.decrypt`

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [[Contribution Guidelines](https://claude.ai/epitaxy/CONTRIBUTING.md)](CONTRIBUTING.md)
- [ ] I've updated the documentation if necessary

#### If you've made changes to `gyb` files
- [ ] I've run `./scripts/generate_boilerplate_files_with_gyb.sh` and included updated generated files in a commit of this pull request

### Motivation:

I noticed `AES._CBC.decrypt` happily accepts ciphertext whose length isn't a multiple of the 16-byte block size, which it really shouldn't, any valid CBC ciphertext is block-aligned by construction.

What happens today is: the decrypt loop slices the ciphertext into 16-byte chunks, but the trailing short chunk gets passed to `Block.init(blockBytes:)`, which silently PKCS#7-pads short inputs to a full block. Those pad bytes then get treated as if they were ciphertext, decrypted, and returned as plaintext. So you don't get an error, you just get garbage bytes appended to the result. The encrypt side already rejects this in `noPadding` mode (`incorrectParameterSize`); the decrypt side was inconsistent.



### Modifications:

Added a single guard at the top of `AES._CBC.decrypt` that throws `CryptoKitError.incorrectParameterSize` if `ciphertext.count % blockSize != 0`. Same error the encrypt path already uses for the symmetric case.

Also added a regression test (`testDecryptRejectsNonBlockAlignedCiphertext`) that feeds a 17-byte ciphertext in both `noPadding=false` and `noPadding=true` modes and asserts the right error is thrown.

### Result:

Mis-aligned ciphertext now throws `CryptoKitError.incorrectParameterSize` instead of silently returning garbage. Behavior on valid (block-aligned) ciphertext is unchanged, verified by running the existing Wycheproof CBC vectors plus the rest of `CBCTests` on Swift 6.3.1 (Windows, x86_64-unknown-windows-msvc), all 7 tests pass.
