### PR TITLE
Update cross-platform dependencies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ When building Swift Crypto for use on an Apple platform where CryptoKit is alrea
 When building Swift Crypto for use on Linux or Windows, Swift Crypto builds substantially more code. In particular, we build:
 
 1. A vendored copy of BoringSSL's libcrypto.
-2. The common API of Swift Crypto and CryptoKit.
-3. The backing implementation of this common API, which calls into BoringSSL.
+2. A vendored copy of XKCP's libXKCP.
+3. The common API of Swift Crypto and CryptoKit.
+4. The backing implementation of this common API, which calls into BoringSSL or XKCP.
 
-The API code, and some cryptographic primitives which are directly implemented in Swift, are exactly the same for both Apple CryptoKit and Swift Crypto. The backing BoringSSL-based implementation is unique to Swift Crypto. In addition, there is another product, `CryptoExtras`, which provides additional functionality that is not offered in CryptoKit, which contains cryptographic APIS predominantly useful in the server ecosystem. **Note**: if you depend on CryptoExtras you'll bundle the BoringSSL implementation of the library in your application, no matter the platform.
+The API code, and some cryptographic primitives which are directly implemented in Swift, are exactly the same for both Apple CryptoKit and Swift Crypto. The BoringSSL/XKCP backing implementation is unique to Swift Crypto. In addition, there is another product, `CryptoExtras`, which provides additional functionality that is not offered in CryptoKit, which contains cryptographic APIs predominantly useful in the server ecosystem. **Note**: if you depend on CryptoExtras you'll bundle the BoringSSL/XKCP implementation of the library in your application, no matter the platform.
 
 ## Evolution
 
@@ -48,11 +49,11 @@ Note that Swift Crypto does not intend to support all possible cryptographic pri
 
 ### Code Organisation
 
-Files in this repository are divided into two groups, based on whether they have a name that ends in `_boring` or are in a `BoringSSL` directory, or if they are not.
+Files in this repository are divided into two groups, based on whether they have a name that ends in `_boring`/`_xkcp` or are in a `BoringSSL`/`XKCP` directory, or if they are not.
 
-Files that meet the above criteria are specific to the Swift Crypto implementation. Changes to these files can be made fairly easily, so long as they meet the criteria below. If your file needs to `import CCryptoBoringSSL` or access a BoringSSL API, it needs to be marked this way.
+Files that meet the above criteria are specific to the Swift Crypto implementation. Changes to these files can be made fairly easily, so long as they meet the criteria below. If your file needs to `import CCryptoBoringSSL` or `import CXKCP` or access a BoringSSL or XKCP API, it needs to be marked this way.
 
-Files that do not have the `_boring` suffix are part of the public API of CryptoKit. Changing these requires passing a higher bar, as any change in these files must be accompanied by a change in CryptoKit itself.
+Files that do not have the `_boring` or `_xkcp` suffix are part of the public API of CryptoKit. Changing these requires passing a higher bar, as any change in these files must be accompanied by a change in CryptoKit itself.
 
 ## Contributing
 
@@ -146,3 +147,7 @@ To do so, please use the following dependency in your `Package.swift`:
 
 Swift Crypto normally defers to the OS implementation of CryptoKit on macOS. Naturally, this makes developing Swift Crypto on macOS tricky. To get Swift Crypto to build the open source implementation on macOS, in `Package.swift`, change `let development = false` to `let development = true`, as this will force Swift Crypto to build its public API.
 
+
+## Acknowledgements
+
+This project contains source code from the BoringSSL and XKCP projects.


### PR DESCRIPTION
### Motivation:

Swift Crypto 4.0 included SHA3 APIs, which required a backing implementation on non-Apple platforms. We brought in libXCKP for this purpose, similar to how we use BoringSSL for the implementation of the rest of CryptoKit API on non-Apple platforms. The README includes details of how the code is organised but was not updated to reflect this change.

### Modifications:

- Update the backend implementation section to include XCKP alongside BoringSSL
- Add an acknowledgments section to the README

### Result:

The README now includes details of both our backing dependencies, not just BoringSSL.

Fixes #439.