### PR TITLE
[5.x] Eliminate compiler warnings and enable warnings-as-errors in CI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -146,6 +146,7 @@ let package = Package(
                 .target(name: "CXKCPShims", condition: .when(platforms: nonDarwinPlatforms)),
             ],
             exclude: privacyManifestExclude + [
+                "vendored-sources.txt",
                 "CMakeLists.txt",
                 "Signatures/BoringSSL/MLDSA_boring.swift.gyb",
                 "KEM/BoringSSL/MLKEM_boring.swift.gyb",

--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,7 @@ let nonDarwinPlatforms: [Platform] = [
 let swiftSettings: [SwiftSetting] = [
     .define("CRYPTO_IN_SWIFTPM"),
     .enableExperimentalFeature("Lifetimes"),
+    .enableExperimentalFeature("CheckImplementationOnly"),
 ]
 
 // This doesn't work when cross-compiling: the privacy manifest will be included in the Bundle and

--- a/Package.swift
+++ b/Package.swift
@@ -99,6 +99,10 @@ let package = Package(
                     .when(platforms: [Platform.wasi])
                 ),
                 .define("OPENSSL_NO_ASM", .when(platforms: [Platform.wasi])),
+                // BoringSSL is vendored verbatim; we don't fix its warnings. Xcode enables
+                // -Wshorten-64-to-32 by default (SwiftPM does not), which produces dozens
+                // of warnings. Silence that group here.
+                .disableWarning("shorten-64-to-32"),
             ]
         ),
         .target(

--- a/Sources/CryptoExtras/AES/BoringSSL/AES_GCM_SIV_boring.swift
+++ b/Sources/CryptoExtras/AES/BoringSSL/AES_GCM_SIV_boring.swift
@@ -92,7 +92,7 @@ enum OpenSSLAESGCMSIVImpl {
             )
         }
 
-        return try AES.GCM._SIV.SealedBox(combined: combined, nonceByteCount: nonce.bytes.count)
+        return AES.GCM._SIV.SealedBox(combined: combined, nonceByteCount: nonce.bytes.count)
     }
 
     @inlinable


### PR DESCRIPTION
### Motivation:

The build currently produces a number of complier warnings. We can address these and lock in the win by enabling  warnings-as-errors in CI.

### Modifications:

- package: Enable `CheckImplementationOnly` language feature
- package: Disable `shorten-64-to-32` warnings in BoringSSL target
- extras: Remove unnecessary try to remove a compiler warning
- package: Add `vendored-sources.txt` to excludes

### Result:

Project now builds without warnings.