### PR TITLE
Support building on platforms without vendored assembly (OPENSSL_NO_ASM fallback, powerpc64le)

### DIFF
--- a/Sources/CCryptoBoringSSL/CMakeLists.txt
+++ b/Sources/CCryptoBoringSSL/CMakeLists.txt
@@ -361,7 +361,10 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Windows" AND CMAKE_SYSTEM_PROCESSOR MATCHES "A
     gen/crypto/chacha-armv8-win.S
     gen/crypto/chacha20_poly1305_armv8-win.S)
 else()
-   message(FATAL_ERROR "platform sources are not defined here for ${CMAKE_SYSTEM_NAME} on ${CMAKE_SYSTEM_PROCESSOR}")
+  # No assembly is vendored for this platform. Fall back to the portable
+  # pure-C implementation; the assembly is only an optimization guarded by
+  # !defined(OPENSSL_NO_ASM).
+  target_compile_definitions(CCryptoBoringSSL PRIVATE OPENSSL_NO_ASM)
 endif()
 
 target_include_directories(CCryptoBoringSSL PUBLIC

--- a/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_target.h
+++ b/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_target.h
@@ -54,6 +54,11 @@
 #define OPENSSL_32_BIT
 #elif defined(__myriad2__)
 #define OPENSSL_32_BIT
+#elif defined(__powerpc64__) && defined(__BYTE_ORDER__) && \
+    __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+// powerpc64le is a standard 64-bit two's-complement little-endian
+// architecture, supported by the portable C code (used with OPENSSL_NO_ASM).
+#define OPENSSL_64_BIT
 #else
 // The list above enumerates the platforms that BoringSSL supports. For these
 // platforms we keep a reasonable bar of not breaking them: automated test

--- a/scripts/patch-4-powerpc64le-target.patch
+++ b/scripts/patch-4-powerpc64le-target.patch
@@ -1,0 +1,16 @@
+diff --git a/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_target.h b/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_target.h
+index 8d4763d..b559151 100644
+--- a/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_target.h
++++ b/Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_target.h
+@@ -54,6 +54,11 @@
+ #define OPENSSL_32_BIT
+ #elif defined(__myriad2__)
+ #define OPENSSL_32_BIT
++#elif defined(__powerpc64__) && defined(__BYTE_ORDER__) && \
++    __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
++// powerpc64le is a standard 64-bit two's-complement little-endian
++// architecture, supported by the portable C code (used with OPENSSL_NO_ASM).
++#define OPENSSL_64_BIT
+ #else
+ // The list above enumerates the platforms that BoringSSL supports. For these
+ // platforms we keep a reasonable bar of not breaking them: automated test

--- a/scripts/vendor-boringssl.sh
+++ b/scripts/vendor-boringssl.sh
@@ -330,6 +330,7 @@ echo "RENAMING header files"
 echo "PATCHING BoringSSL"
 git apply "${HERE}/scripts/patch-1-inttypes.patch"
 git apply "${HERE}/scripts/patch-2-more-inttypes.patch"
+git apply "${HERE}/scripts/patch-4-powerpc64le-target.patch"
 
 # We need to avoid having the stack be executable. BoringSSL does this in its build system, but we can't.
 echo "PROTECTING against executable stacks"


### PR DESCRIPTION
Allow swift-crypto to build on Linux architectures that have no vendored BoringSSL assembly, and restore target detection for powerpc64le.

### Checklist
- [x] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

### Motivation:

The CMake build only defines platform sources for x86_64 and arm64 (plus their Windows variants); every other architecture — 32-bit ARM, i686, powerpc64le, RISC-V, MIPS — hits a hard `message(FATAL_ERROR "platform sources are not defined here ...")` with no way to opt into a portable build, even though BoringSSL fully supports a pure-C configuration via `OPENSSL_NO_ASM` (the assembly is only an optimization guarded by `!defined(OPENSSL_NO_ASM)`).

Additionally, upstream BoringSSL removed powerpc64le from its target detection, so on ppc64le neither `OPENSSL_32_BIT` nor `OPENSSL_64_BIT` gets defined and every header fails with:

```
CCryptoBoringSSL_bn.h:173:2: error: "Must define either OPENSSL_32_BIT or OPENSSL_64_BIT"
```

The comment above that `#error` explicitly says the portable C code works on any standard 32/64-bit two's-complement little-endian architecture and invites carrying a local patch for such targets — powerpc64le qualifies.

We hit both issues cross-compiling swift-crypto with CMake for embedded Linux targets (Buildroot) across armv5/armv6/armv7/i686/aarch64/x86_64/ppc64le; with these two changes the full matrix builds and the `Crypto` module passes a runtime smoke test (`SHA256.hash`) on the non-asm architectures.

### Modifications:

- `Sources/CCryptoBoringSSL/CMakeLists.txt`: replace the `FATAL_ERROR` fallback branch with `target_compile_definitions(CCryptoBoringSSL PRIVATE OPENSSL_NO_ASM)`. Platforms that do have vendored assembly are unaffected.
- `Sources/CCryptoBoringSSL/include/CCryptoBoringSSL_target.h`: add a `__powerpc64__` + little-endian branch defining `OPENSSL_64_BIT`. Since this file is vendored, the change is carried as `scripts/patch-4-powerpc64le-target.patch` and applied by `scripts/vendor-boringssl.sh` (alongside the existing patch-1/2) so it survives re-vendoring. `OPENSSL_PPC64LE` is deliberately not defined so no stale arch-specific code paths are enabled; the generic C implementation is used together with `OPENSSL_NO_ASM`.

### Result:

The CMake build succeeds on Linux architectures without vendored assembly (32-bit ARM, i686, powerpc64le, ...) using BoringSSL's supported pure-C configuration, instead of failing at configure time. x86_64 and arm64 continue to build their vendored assembly exactly as before. The powerpc64le detection fix also benefits SwiftPM builds on that architecture.