### PR TITLE
[5.x] Adopt CheckImplementationOnly and CI with -warnings-as-errors

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   soundness:
     name: Soundness
-    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.7
+    uses: swiftlang/github-workflows/.github/workflows/soundness.yml@0.0.13
     with:
       license_header_check_project_name: "SwiftCrypto"
       docs_check_enabled: false

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -19,28 +19,23 @@ jobs:
     name: Unit tests
     uses: apple/swift-nio/.github/workflows/unit_tests.yml@main
     with:
-      linux_5_10_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_6_1_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_6_2_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_6_3_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
-      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
-      windows_6_1_enabled: true
+      linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error"
+      linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error"
+      linux_nightly_next_arguments_override: "--build-system native -Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error"
+      linux_nightly_main_arguments_override: "--build-system native --explicit-target-dependency-import-check error"
       windows_6_2_enabled: true
       windows_6_3_enabled: true
       windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true
-      windows_6_1_arguments_override: "--explicit-target-dependency-import-check error"
-      windows_6_2_arguments_override: "--explicit-target-dependency-import-check error"
-      windows_6_3_arguments_override: "--explicit-target-dependency-import-check error"
-      windows_nightly_next_arguments_override: "--explicit-target-dependency-import-check error"
-      windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
+      windows_6_2_arguments_override: "-Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error"
+      windows_6_3_arguments_override: "-Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error"
+      windows_nightly_next_arguments_override: "--build-system native -Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error"
+      windows_nightly_main_arguments_override: "--build-system native --explicit-target-dependency-import-check error"
 
   release-builds:
     name: Release builds
     uses: apple/swift-nio/.github/workflows/release_builds.yml@main
     with:
-      windows_6_1_enabled: true
       windows_6_2_enabled: true
       windows_6_3_enabled: true
       windows_nightly_next_enabled: true

--- a/Package.swift
+++ b/Package.swift
@@ -146,6 +146,7 @@ let package = Package(
                 .target(name: "CXKCPShims", condition: .when(platforms: nonDarwinPlatforms)),
             ],
             exclude: privacyManifestExclude + [
+                "vendored-sources.txt",
                 "CMakeLists.txt",
                 "Signatures/BoringSSL/MLDSA_boring.swift.gyb",
                 "KEM/BoringSSL/MLKEM_boring.swift.gyb",

--- a/Package.swift
+++ b/Package.swift
@@ -41,6 +41,7 @@ let nonDarwinPlatforms: [Platform] = [
 var swiftSettings: [SwiftSetting] = [
     .define("CRYPTO_IN_SWIFTPM"),
     .enableExperimentalFeature("Lifetimes"),
+    .enableExperimentalFeature("SourceWarningControl"),
 ]
 
 // Only enable CheckImplementationOnly on 6.4 -- 6.3 has the feature, but produces many false positives.

--- a/Package.swift
+++ b/Package.swift
@@ -38,10 +38,15 @@ let nonDarwinPlatforms: [Platform] = [
     .custom("freebsd"),
 ]
 
-let swiftSettings: [SwiftSetting] = [
+var swiftSettings: [SwiftSetting] = [
     .define("CRYPTO_IN_SWIFTPM"),
     .enableExperimentalFeature("Lifetimes"),
 ]
+
+// Only enable CheckImplementationOnly on 6.4 -- 6.3 has the feature, but produces many false positives.
+#if compiler(>=6.4)
+swiftSettings.append(.enableExperimentalFeature("CheckImplementationOnly"))
+#endif
 
 // This doesn't work when cross-compiling: the privacy manifest will be included in the Bundle and
 // Foundation will be linked. This is, however, strictly better than unconditionally adding the

--- a/Package.swift
+++ b/Package.swift
@@ -98,6 +98,10 @@ let package = Package(
                     .when(platforms: [Platform.wasi])
                 ),
                 .define("OPENSSL_NO_ASM", .when(platforms: [Platform.wasi])),
+                // BoringSSL is vendored verbatim; we don't fix its warnings. Xcode enables
+                // -Wshorten-64-to-32 by default (SwiftPM does not), which produces dozens
+                // of warnings. Silence that group here.
+                .disableWarning("shorten-64-to-32"),
             ]
         ),
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -117,6 +117,7 @@ let package = Package(
                 .headerSearchPath("low/KeccakP-1600"),
                 .headerSearchPath("low/common"),
                 .headerSearchPath("common"),
+                .disableWarning("macro-redefined"),
             ]
         ),
         .target(

--- a/Sources/Crypto/AEADs/AES/GCM/BoringSSL/AES-GCM_boring.swift
+++ b/Sources/Crypto/AEADs/AES/GCM/BoringSSL/AES-GCM_boring.swift
@@ -14,7 +14,11 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 import CryptoBoringWrapper
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/Crypto/AEADs/ChachaPoly/BoringSSL/ChaChaPoly_boring.swift
+++ b/Sources/Crypto/AEADs/ChachaPoly/BoringSSL/ChaChaPoly_boring.swift
@@ -14,8 +14,13 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#endif
 import CryptoBoringWrapper
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/Crypto/Digests/BoringSSL/Digest_boring.swift
+++ b/Sources/Crypto/Digests/BoringSSL/Digest_boring.swift
@@ -14,7 +14,11 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 protocol HashFunctionImplementationDetails: HashFunction where Digest: DigestPrivate {}

--- a/Sources/Crypto/Digests/XKCP/Digest_xkcp.swift
+++ b/Sources/Crypto/Digests/XKCP/Digest_xkcp.swift
@@ -14,8 +14,13 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CXKCP
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CXKCPShims
+#else
 @_implementationOnly import CXKCP
 @_implementationOnly import CXKCPShims
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 protocol XKCPBackedHashFunction: HashFunctionImplementationDetails {

--- a/Sources/Crypto/KEM/BoringSSL/MLKEM_boring.swift
+++ b/Sources/Crypto/KEM/BoringSSL/MLKEM_boring.swift
@@ -19,7 +19,11 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/Crypto/KEM/BoringSSL/MLKEM_boring.swift.gyb
+++ b/Sources/Crypto/KEM/BoringSSL/MLKEM_boring.swift.gyb
@@ -19,7 +19,11 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/Crypto/KEM/BoringSSL/MLKEM_wrapper.swift
+++ b/Sources/Crypto/KEM/BoringSSL/MLKEM_wrapper.swift
@@ -15,7 +15,11 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/Crypto/KEM/BoringSSL/XWing_boring.swift
+++ b/Sources/Crypto/KEM/BoringSSL/XWing_boring.swift
@@ -15,7 +15,11 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/Crypto/Key Agreement/BoringSSL/ECDH_boring.swift
+++ b/Sources/Crypto/Key Agreement/BoringSSL/ECDH_boring.swift
@@ -14,7 +14,11 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension P256.KeyAgreement.PrivateKey {

--- a/Sources/Crypto/Key Derivation/ANSIx963.swift
+++ b/Sources/Crypto/Key Derivation/ANSIx963.swift
@@ -17,9 +17,9 @@
 #else
 
 #if canImport(FoundationEssentials)
-public import FoundationEssentials
+import FoundationEssentials
 #else
-public import Foundation
+import Foundation
 #endif
 
 internal struct ANSIKDFx963<H: HashFunction>: Sendable {

--- a/Sources/Crypto/Key Wrapping/BoringSSL/AESWrap_boring.swift
+++ b/Sources/Crypto/Key Wrapping/BoringSSL/AESWrap_boring.swift
@@ -14,7 +14,11 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/Crypto/Keys/EC/BoringSSL/Ed25519_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/Ed25519_boring.swift
@@ -14,8 +14,13 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
@@ -14,8 +14,13 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#endif
 import CryptoBoringWrapper
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/Crypto/Keys/EC/BoringSSL/X25519Keys_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/X25519Keys_boring.swift
@@ -14,8 +14,13 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/Crypto/Signatures/BoringSSL/ECDSASignature_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/ECDSASignature_boring.swift
@@ -14,8 +14,13 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#endif
 import CryptoBoringWrapper
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/Crypto/Signatures/BoringSSL/ECDSA_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/ECDSA_boring.swift
@@ -14,7 +14,11 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 import CryptoBoringWrapper
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/Crypto/Signatures/BoringSSL/EdDSA_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/EdDSA_boring.swift
@@ -14,8 +14,13 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift
@@ -15,7 +15,11 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
@@ -26,7 +30,11 @@ import Foundation
 // any edits of this file WILL be overwritten and thus discarded
 // see section `gyb` in `README` for details.
 
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift.gyb
+++ b/Sources/Crypto/Signatures/BoringSSL/MLDSA_boring.swift.gyb
@@ -15,7 +15,11 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else
@@ -26,7 +30,11 @@ import Foundation
 // any edits of this file WILL be overwritten and thus discarded
 // see section `gyb` in `README` for details.
 
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/Crypto/Signatures/BoringSSL/MLDSA_wrapper.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/MLDSA_wrapper.swift
@@ -15,7 +15,11 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/Crypto/Util/BoringSSL/CryptoKitErrors_boring.swift
+++ b/Sources/Crypto/Util/BoringSSL/CryptoKitErrors_boring.swift
@@ -14,7 +14,11 @@
 #if canImport(CryptoKit)
 @_exported import CryptoKit
 #else
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension CryptoKitError {

--- a/Sources/Crypto/Util/BoringSSL/Zeroization_boring.swift
+++ b/Sources/Crypto/Util/BoringSSL/Zeroization_boring.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 #if !canImport(Darwin)
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 typealias errno_t = CInt

--- a/Sources/CryptoBoringWrapper/AEAD/BoringSSLAEAD.swift
+++ b/Sources/CryptoBoringWrapper/AEAD/BoringSSLAEAD.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#endif
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/CryptoBoringWrapper/CryptoKitErrors_boring.swift
+++ b/Sources/CryptoBoringWrapper/CryptoKitErrors_boring.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 public enum CryptoBoringWrapperError: Error {

--- a/Sources/CryptoBoringWrapper/EC/EllipticCurve.swift
+++ b/Sources/CryptoBoringWrapper/EC/EllipticCurve.swift
@@ -11,7 +11,11 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 
 /// A wrapper around BoringSSL's EC_GROUP object that handles reference counting and
 /// liveness.

--- a/Sources/CryptoBoringWrapper/EC/EllipticCurvePoint.swift
+++ b/Sources/CryptoBoringWrapper/EC/EllipticCurvePoint.swift
@@ -11,8 +11,13 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#endif
 
 #if canImport(FoundationEssentials)
 import protocol FoundationEssentials.ContiguousBytes

--- a/Sources/CryptoBoringWrapper/Util/ArbitraryPrecisionInteger.swift
+++ b/Sources/CryptoBoringWrapper/Util/ArbitraryPrecisionInteger.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#endif
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/CryptoBoringWrapper/Util/FiniteFieldArithmeticContext.swift
+++ b/Sources/CryptoBoringWrapper/Util/FiniteFieldArithmeticContext.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/CryptoExtras/AES/AES_GCM_SIV.swift
+++ b/Sources/CryptoExtras/AES/AES_GCM_SIV.swift
@@ -13,8 +13,13 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#endif
 import CryptoBoringWrapper
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/CryptoExtras/AES/Block Function.swift
+++ b/Sources/CryptoExtras/AES/Block Function.swift
@@ -13,8 +13,13 @@
 //===----------------------------------------------------------------------===//
 
 import Crypto
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#endif
 import CryptoBoringWrapper
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/CryptoExtras/AES/BoringSSL/AES_CFB_boring.swift
+++ b/Sources/CryptoExtras/AES/BoringSSL/AES_CFB_boring.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CCryptoBoringSSL
 import Crypto
+
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
+@_implementationOnly import CCryptoBoringSSL
+#endif
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/CryptoExtras/AES/BoringSSL/AES_CTR_boring.swift
+++ b/Sources/CryptoExtras/AES/BoringSSL/AES_CTR_boring.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CCryptoBoringSSL
 import Crypto
+
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
+@_implementationOnly import CCryptoBoringSSL
+#endif
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/CryptoExtras/AES/BoringSSL/AES_GCM_SIV_boring.swift
+++ b/Sources/CryptoExtras/AES/BoringSSL/AES_GCM_SIV_boring.swift
@@ -92,7 +92,7 @@ enum OpenSSLAESGCMSIVImpl {
             )
         }
 
-        return try AES.GCM._SIV.SealedBox(combined: combined, nonceByteCount: nonce.bytes.count)
+        return AES.GCM._SIV.SealedBox(combined: combined, nonceByteCount: nonce.bytes.count)
     }
 
     @inlinable

--- a/Sources/CryptoExtras/AES/BoringSSL/AES_GCM_SIV_boring.swift
+++ b/Sources/CryptoExtras/AES/BoringSSL/AES_GCM_SIV_boring.swift
@@ -14,10 +14,16 @@
 
 // This is a copy ChaChaPoly_boring just with a different set aes algos
 
-@_implementationOnly import CCryptoBoringSSL
-@_implementationOnly import CCryptoBoringSSLShims
 import Crypto
 import CryptoBoringWrapper
+
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
+#endif
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/CryptoExtras/AES/CMAC.swift
+++ b/Sources/CryptoExtras/AES/CMAC.swift
@@ -11,8 +11,14 @@
 // SPDX-License-Identifier: Apache-2.0
 //
 //===----------------------------------------------------------------------===//
-@_implementationOnly import CCryptoBoringSSL
+
 import Crypto
+
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
+@_implementationOnly import CCryptoBoringSSL
+#endif
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/CryptoExtras/ChaCha20CTR/BoringSSL/ChaCha20CTR_boring.swift
+++ b/Sources/CryptoExtras/ChaCha20CTR/BoringSSL/ChaCha20CTR_boring.swift
@@ -12,10 +12,16 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CCryptoBoringSSL
-@_implementationOnly import CCryptoBoringSSLShims
 import Crypto
 import CryptoBoringWrapper
+
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
+#endif
 
 #if canImport(FoundationEssentials)
 import FoundationEssentials

--- a/Sources/CryptoExtras/ChaCha20CTR/ChaCha20CTR.swift
+++ b/Sources/CryptoExtras/ChaCha20CTR/ChaCha20CTR.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#endif
 import Crypto
 import CryptoBoringWrapper
 #if canImport(FoundationEssentials)

--- a/Sources/CryptoExtras/Digests/BoringSSL/BoringSSLSHA512256Context.swift
+++ b/Sources/CryptoExtras/Digests/BoringSSL/BoringSSLSHA512256Context.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CCryptoBoringSSL
 import Crypto
+
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
+@_implementationOnly import CCryptoBoringSSL
+#endif
 
 #if canImport(Darwin)
 import Darwin

--- a/Sources/CryptoExtras/Digests/BoringSSL/BoringSSLSHA512256HashFunction.swift
+++ b/Sources/CryptoExtras/Digests/BoringSSL/BoringSSLSHA512256HashFunction.swift
@@ -12,8 +12,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CCryptoBoringSSL
 import Crypto
+
+@_implementationOnly import CCryptoBoringSSL
 
 struct BoringSSLSHA512256HashFunction {
     static var digestSize: Int {

--- a/Sources/CryptoExtras/Key Derivation/PBKDF2/BoringSSL/PBKDF2_boring.swift
+++ b/Sources/CryptoExtras/Key Derivation/PBKDF2/BoringSSL/PBKDF2_boring.swift
@@ -20,8 +20,13 @@ import Foundation
 #endif
 
 #if !canImport(CommonCrypto)
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 internal struct BoringSSLPBKDF2 {

--- a/Sources/CryptoExtras/Key Derivation/Scrypt/BoringSSL/Scrypt_boring.swift
+++ b/Sources/CryptoExtras/Key Derivation/Scrypt/BoringSSL/Scrypt_boring.swift
@@ -12,9 +12,15 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Crypto
+
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
-import Crypto
+#endif
 
 #if canImport(FoundationEssentials)
 #if os(Windows)

--- a/Sources/CryptoExtras/RSA/RSA_boring.swift
+++ b/Sources/CryptoExtras/RSA/RSA_boring.swift
@@ -12,11 +12,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-// NOTE: This file is unconditionally compiled because RSABSSA is implemented using BoringSSL on all platforms.
-@_implementationOnly import CCryptoBoringSSL
-@_implementationOnly import CCryptoBoringSSLShims
 import Crypto
 import CryptoBoringWrapper
+
+// NOTE: This file is unconditionally compiled because RSABSSA is implemented using BoringSSL on all platforms.
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
+@_implementationOnly import CCryptoBoringSSL
+@_implementationOnly import CCryptoBoringSSLShims
+#endif
 
 #if canImport(FoundationEssentials)
 #if os(Windows)

--- a/Sources/CryptoExtras/Util/BoringSSL/Zeroization_boring.swift
+++ b/Sources/CryptoExtras/Util/BoringSSL/Zeroization_boring.swift
@@ -12,7 +12,11 @@
 //
 //===----------------------------------------------------------------------===//
 #if !canImport(Darwin)
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 typealias errno_t = CInt

--- a/Sources/CryptoExtras/Util/BoringSSLHelpers.swift
+++ b/Sources/CryptoExtras/Util/BoringSSLHelpers.swift
@@ -13,8 +13,13 @@
 //===----------------------------------------------------------------------===//
 
 // NOTE: This file is unconditionally compiled because RSABSSA is implemented using BoringSSL on all platforms.
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSLShims
+#else
 @_implementationOnly import CCryptoBoringSSL
 @_implementationOnly import CCryptoBoringSSLShims
+#endif
 #if canImport(FoundationEssentials)
 import FoundationEssentials
 #else

--- a/Sources/CryptoExtras/Util/CryptoKitErrors_boring.swift
+++ b/Sources/CryptoExtras/Util/CryptoKitErrors_boring.swift
@@ -12,8 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
-@_implementationOnly import CCryptoBoringSSL
 import Crypto
+
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
+@_implementationOnly import CCryptoBoringSSL
+#endif
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension CryptoKitError {

--- a/Sources/CryptoExtras/Util/DigestType.swift
+++ b/Sources/CryptoExtras/Util/DigestType.swift
@@ -13,7 +13,11 @@
 //===----------------------------------------------------------------------===//
 
 // NOTE: This file is unconditionally compiled because RSABSSA is implemented using BoringSSL on all platforms.
+#if hasFeature(SourceWarningControl)
+@diagnose(ImplementationOnlyDeprecated, as: ignored) @_implementationOnly import CCryptoBoringSSL
+#else
 @_implementationOnly import CCryptoBoringSSL
+#endif
 import Crypto
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)

--- a/Tests/CryptoExtrasTests/AES_CFBTests.swift
+++ b/Tests/CryptoExtrasTests/AES_CFBTests.swift
@@ -45,7 +45,7 @@ final class AES_CFBTests: XCTestCase {
 
     func testVector(_ vector: TestVector) throws {
         let (contiguousPlaintextData, discontiguousPlaintextData) = vector.plaintext.asDataProtocols()
-        for plaintextData in [contiguousPlaintextData as DataProtocol, discontiguousPlaintextData as DataProtocol] {
+        for plaintextData in [contiguousPlaintextData as (any DataProtocol), discontiguousPlaintextData as (any DataProtocol)] {
             let key = SymmetricKey(data: Data(vector.key))
             let iv = try AES._CFB.IV(ivBytes: vector.iv)
             let ciphertext = try AES._CFB.encrypt(plaintextData, using: key, iv: iv)

--- a/Tests/CryptoTests/Authenticated Encryption/AES-GCM-Runner.swift
+++ b/Tests/CryptoTests/Authenticated Encryption/AES-GCM-Runner.swift
@@ -151,7 +151,7 @@ class AESGCMTests: XCTestCase {
         let ciphertext = Array("This pretty clearly isn't ciphertext, but sure why not".utf8)
         let (contiguousCiphertext, discontiguousCiphertext) = ciphertext.asDataProtocols()
 
-        let contiguousSB = try orFail { try AES.GCM.SealedBox(combined: contiguousCiphertext) }
+        let contiguousSB = try orFail { AES.GCM.SealedBox(combined: contiguousCiphertext) }
         let discontiguousSB = try orFail { try AES.GCM.SealedBox(combined: discontiguousCiphertext) }
         XCTAssertEqual(contiguousSB.combined, discontiguousSB.combined)
         XCTAssertEqual(Array(contiguousSB.nonce), Array(discontiguousSB.nonce))


### PR DESCRIPTION

## Motivation

We've long since used `@_implementationOnly import` (IOI) for our vendored C modules (BoringSSL and libXKCP) in an attempt to not leak our dependency into downstream builds. This is important because leaking might cause symbol collisions (build failures) or, worse, layout mismatches (latent runtime failures).

IOI was intended to be used with library evolution, which this project does not support, and use of IOI without library evolution has been soft-deprecated. Users are encouraged to move to `internal import` (II), which is usually the right choice for Swift packages. But II does not provide the same guarantees as IOI and, for this project, we really need the protections given by IOI so we will continue to use it, even with library evolution disabled.

One of the reasons for the soft-deprecation was the implementation of IOI used an incomplete checker, that won't catch all interface leaks without library evolution. However, Swift has also introduced a new feature, `CheckImplementationOnly` (CIO), which enables the stricter interface checking that we need, which we should adopt.

Aside: This feature is visible in 6.3 but is incomplete and the Swift team only recommend adopting in 6.4+. Indeed, this PR is a cut-back version of #452, which which included a lengthy patch and discussion, boxing many types that were a result of false positives from the `CheckImplementationOnly` feature on 6.3.

## Modifications

This patch enables `CheckImplementationOnly`, when building with 6.4, or newer.

Additionally, as we're approaching a new major, it's a good opportunity to get warnings-clean and lock in warnings-as-errors, so this PR does that, suppressing only `ImplementationOnlyDeprecated`, which we cannot eliminate. So we now build in CI using:

    -Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated

However, Swift 6.4 introduces `SourceWarningControl`, which we can use to actually _silence_ these warnings, using `@diagnose(_:as:)`, which we do conditionally:

    #if hasFeature(SourceWarningControl)
    @diagnose(ImplementationOnlyDeprecated, as: ignored)     @_implementationOnly import ...
    #else
    @_implementationOnly import ...
    #endif

When we raise the minimum supported Swift compiler version to one that supports `SourceWarningControl`, we can remove the `#if hasFeature` guards.

We've had to drop to `--build-system native` (vs swift-build) for Swift 6.4 CI because SwiftPM is not stripping the warning-related compiler flags when building dependencies.

## Result

- Stricter checks for not leakingC dependencies from BoringSSL and libXKCP -- project builds cleanly with `CheckImplementationOnly`.
- All other compiler warnings have been addressed and project builds with `-warnings-as-errors -Wwarning ImplementationOnlyDeprecated` in CI.
- On Swift 6.4+, `ImplementationOnlyDeprecated` warnings are completely silenced and the project is completely warnings-free.
