### PR TITLE
[5.x] Mark some class types as final

### DIFF
--- a/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
+++ b/Sources/Crypto/Keys/EC/BoringSSL/NISTCurvesKeys_boring.swift
@@ -146,7 +146,7 @@ struct OpenSSLNISTCurvePublicKeyImpl<Curve: OpenSSLSupportedNISTCurve>: Sendable
 /// allows some helper operations.
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-class BoringSSLECPrivateKeyWrapper<Curve: OpenSSLSupportedNISTCurve>: @unchecked Sendable {
+final class BoringSSLECPrivateKeyWrapper<Curve: OpenSSLSupportedNISTCurve>: @unchecked Sendable {
     @usableFromInline
     let key: OpaquePointer
 
@@ -351,7 +351,7 @@ class BoringSSLECPrivateKeyWrapper<Curve: OpenSSLSupportedNISTCurve>: @unchecked
 /// allows some helper operations.
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-class BoringSSLECPublicKeyWrapper<Curve: OpenSSLSupportedNISTCurve>: @unchecked Sendable {
+final class BoringSSLECPublicKeyWrapper<Curve: OpenSSLSupportedNISTCurve>: @unchecked Sendable {
     @usableFromInline
     let key: OpaquePointer
 

--- a/Sources/Crypto/Signatures/BoringSSL/ECDSASignature_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/ECDSASignature_boring.swift
@@ -28,7 +28,7 @@ import Foundation
 
 /// A wrapper around BoringSSL's ECDSA_SIG with some lifetime management.
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-class ECDSASignature {
+final class ECDSASignature {
     private var _baseSig: UnsafeMutablePointer<ECDSA_SIG>
 
     init<ContiguousBuffer: ContiguousBytes>(contiguousDERBytes derBytes: ContiguousBuffer) throws {

--- a/Sources/CryptoBoringWrapper/AEAD/BoringSSLAEAD.swift
+++ b/Sources/CryptoBoringWrapper/AEAD/BoringSSLAEAD.swift
@@ -41,7 +41,7 @@ extension BoringSSLAEAD {
     // Arguably this class is excessive, but it's probably better for this API to be as safe as possible
     // rather than rely on defer statements for our cleanup.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-    public class AEADContext {
+    public final class AEADContext {
         private var context: EVP_AEAD_CTX
 
         public init<Key: ContiguousBytes>(cipher: BoringSSLAEAD, key: Key) throws {

--- a/Sources/CryptoBoringWrapper/Util/FiniteFieldArithmeticContext.swift
+++ b/Sources/CryptoBoringWrapper/Util/FiniteFieldArithmeticContext.swift
@@ -37,7 +37,7 @@ import Foundation
 /// ourselves.
 @usableFromInline
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-package class FiniteFieldArithmeticContext: @unchecked Sendable {
+package final class FiniteFieldArithmeticContext: @unchecked Sendable {
     private let fieldSize: ArbitraryPrecisionInteger
     package let bnCtx: OpaquePointer
 

--- a/Sources/CryptoExtras/Util/ThreadSpecific/ThreadSpecific.swift
+++ b/Sources/CryptoExtras/Util/ThreadSpecific/ThreadSpecific.swift
@@ -29,7 +29,7 @@ final class ThreadSpecificVariable<Value: AnyObject> {
     // the actual type in there is `Box<(ThreadSpecificVariable<T>, T)>` but we can't use that as C functions can't capture (even types)
     private typealias BoxedType = Box<(AnyObject, AnyObject)>
 
-    private class Key {
+    private final class Key {
         private var underlyingKey: ThreadOpsSystem.ThreadSpecificKey
 
         internal init(destructor: @escaping ThreadOpsSystem.ThreadSpecificKeyDestructor) {


### PR DESCRIPTION
### Motivation

There are a number of reference types in the codebase that aren't marked `final`. While we won't expect a perf win by
marking them final because they don't cross the module boundary of our public API, I'm not sure why they're not marked
`final` and marking them such cleans up the intent.

### Modifications

Mark some reference class types as final.

### Result

Cleaner internal types.
