### PR TITLE
[5.x] Remove unused internal code path: ECDSASignature.derBytes

### DIFF
--- a/Sources/Crypto/Signatures/BoringSSL/ECDSASignature_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/ECDSASignature_boring.swift
@@ -99,21 +99,6 @@ class ECDSASignature {
         )
     }
 
-    @usableFromInline
-    var derBytes: Data {
-        var dataPtr: UnsafeMutablePointer<UInt8>?
-        var length = 0
-        guard CCryptoBoringSSL_ECDSA_SIG_to_bytes(&dataPtr, &length, self._baseSig) == 1 else {
-            fatalError("Unable to marshal signature to DER")
-        }
-        defer {
-            // We must free this pointer.
-            CCryptoBoringSSL_OPENSSL_free(dataPtr)
-        }
-
-        return Data(UnsafeBufferPointer(start: dataPtr, count: length))
-    }
-
     func withUnsafeSignaturePointer<T>(
         _ body: (UnsafeMutablePointer<ECDSA_SIG>) throws -> T
     )

--- a/Sources/Crypto/Signatures/BoringSSL/ECDSA_boring.swift
+++ b/Sources/Crypto/Signatures/BoringSSL/ECDSA_boring.swift
@@ -68,17 +68,6 @@ extension Data {
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-extension P256.Signing.ECDSASignature {
-    init<D: DataProtocol>(openSSLDERSignature derRepresentation: D) throws {
-        self.rawRepresentation = try Data(derSignature: derRepresentation, over: P256.self)
-    }
-
-    var openSSLDERRepresentation: Data {
-        try! ECDSASignature(rawRepresentation: self.rawRepresentation).derBytes
-    }
-}
-
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension P256.Signing.PrivateKey {
     func openSSLSignature<D: Digest>(for digest: D) throws -> P256.Signing.ECDSASignature {
         let baseSignature = try self.impl.key.sign(digest: digest)
@@ -105,17 +94,6 @@ extension P256.Signing.PublicKey {
 }
 
 @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-extension P384.Signing.ECDSASignature {
-    init<D: DataProtocol>(openSSLDERSignature derRepresentation: D) throws {
-        self.rawRepresentation = try Data(derSignature: derRepresentation, over: P384.self)
-    }
-
-    var openSSLDERRepresentation: Data {
-        try! ECDSASignature(rawRepresentation: self.rawRepresentation).derBytes
-    }
-}
-
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
 extension P384.Signing.PrivateKey {
     func openSSLSignature<D: Digest>(for digest: D) throws -> P384.Signing.ECDSASignature {
         let baseSignature = try self.impl.key.sign(digest: digest)
@@ -138,17 +116,6 @@ extension P384.Signing.PublicKey {
         }
 
         return self.impl.key.isValidSignature(baseSignature, for: digest)
-    }
-}
-
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-extension P521.Signing.ECDSASignature {
-    init<D: DataProtocol>(openSSLDERSignature derRepresentation: D) throws {
-        self.rawRepresentation = try Data(derSignature: derRepresentation, over: P521.self)
-    }
-
-    var openSSLDERRepresentation: Data {
-        try! ECDSASignature(rawRepresentation: self.rawRepresentation).derBytes
     }
 }
 


### PR DESCRIPTION
### Motivation

I was just investigating the way this code path handled it's `Data` allocation and C call and then noticed that it isn't
called anywhere, or from any test. So rather than fix it, we can just remove it.

### Modifications:

- Remove unused internal code path: `ECDSASignature.derBytes`

### Result:

Removed unused code -- less code to maintain.
