### PR TITLE
[5.x] Remove native SwiftPM build-system workaround in CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -21,16 +21,16 @@ jobs:
     with:
       linux_6_2_arguments_override: "-Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error"
       linux_6_3_arguments_override: "-Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error"
-      linux_nightly_next_arguments_override: "--build-system native -Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error"
-      linux_nightly_main_arguments_override: "--build-system native --explicit-target-dependency-import-check error"
+      linux_nightly_next_arguments_override: "-Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error"
+      linux_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
       windows_6_2_enabled: true
       windows_6_3_enabled: true
       windows_nightly_next_enabled: true
       windows_nightly_main_enabled: true
       windows_6_2_arguments_override: "-Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error"
       windows_6_3_arguments_override: "-Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error"
-      windows_nightly_next_arguments_override: "--build-system native -Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error"
-      windows_nightly_main_arguments_override: "--build-system native --explicit-target-dependency-import-check error"
+      windows_nightly_next_arguments_override: "-Xswiftc -warnings-as-errors -Xswiftc -Wwarning -Xswiftc ImplementationOnlyDeprecated --explicit-target-dependency-import-check error"
+      windows_nightly_main_arguments_override: "--explicit-target-dependency-import-check error"
 
   release-builds:
     name: Release builds


### PR DESCRIPTION
### Motivation:

Recently we got this branch warnings-as-errors clean[^1]. But, in order to do so on Swift 6.4 and main, we needed to use `--build-system native` because the `swiftbuild` backend wasn't handling warning control flags properly. The SwiftPM fix for this is now available in latest 6.4 and main nightly images.

### Modifications:

- Remove SwiftPM --build-system native workaround in CI

### Result:

CI now builds cleanly with `-warnings-as-errors` with the default SwiftPM build-system.

[^1]: https://github.com/apple/swift-crypto/pull/454
