### PR TITLE
Match the documented parameter names to the signatures

### DIFF
--- a/Sources/CryptoExtras/AES/AES_GCM_SIV.swift
+++ b/Sources/CryptoExtras/AES/AES_GCM_SIV.swift
@@ -63,7 +63,6 @@ extension AES.GCM {
         /// - Parameters:
         ///   - sealedBox: The sealed box to authenticate and decrypt
         ///   - key: An encryption key of 128 or 256 bits
-        ///   - nonce: An Nonce for AES-GCM-SIV encryption. The nonce must be unique for every use of the key to seal data. It can be safely generated with AES.GCM.Nonce().
         ///   - authenticatedData: Data that was authenticated as part of the seal
         /// - Returns: The ciphertext if opening was successful
         /// - Throws: CipherError errors. If the authentication of the sealed box failed, incorrectTag is thrown.
@@ -77,7 +76,6 @@ extension AES.GCM {
         /// - Parameters:
         ///   - sealedBox: The sealed box to authenticate and decrypt
         ///   - key: An encryption key of 128 or 256 bits
-        ///   - nonce: An Nonce for AES-GCM-SIV encryption. The nonce must be unique for every use of the key to seal data. It can be safely generated with AES.GCM.Nonce().
         /// - Returns: The ciphertext if opening was successful
         /// - Throws: CipherError errors. If the authentication of the sealed box failed, incorrectTag is thrown.
         public static func open(_ sealedBox: SealedBox, using key: SymmetricKey) throws -> Data {

--- a/Sources/CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
+++ b/Sources/CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
@@ -161,7 +161,7 @@ struct OpenSSLGroupScalar<C: OpenSSLSupportedNISTCurve>: GroupScalar, CustomStri
 
     /// Deserializes a scalar from data.
     /// - Parameters:
-    ///   - data: The serialized scalar
+    ///   - bytes: The serialized scalar
     ///   - reductionIsModOrder: Resulting number is taken "mod q" (characteristic) by default. Override by setting true if "mod p" (order) is desired.
     /// - Returns: The deserialized scalar
     init(bytes: Data, reductionIsModOrder: Bool = false) throws {

--- a/Sources/CryptoExtras/RSA/RSA_boring.swift
+++ b/Sources/CryptoExtras/RSA/RSA_boring.swift
@@ -260,7 +260,6 @@ extension BoringSSLRSAPublicKey {
             }
         }
 
-
         fileprivate convenience init<Bytes: DataProtocol>(derRepresentation: Bytes) throws {
             if derRepresentation.regions.count == 1 {
                 try self.init(contiguousDerRepresentation: derRepresentation.regions.first!)


### PR DESCRIPTION
_Match the documented parameter names to the signatures in Crypto and CryptoExtras_

### Checklist
- [ ] I've run tests to see all new and existing tests pass
- [x] I've followed the code style of the rest of the project
- [x] I've read the [Contribution Guidelines](CONTRIBUTING.md)
- [x] I've updated the documentation if necessary

### Motivation:

Both `AES.GCM._SIV.open` overloads document a nonce, with the paragraph about keeping it unique for every use of the key, and neither of them takes one -- it arrives inside the sealed box. That paragraph is copied down from `seal`, where it belongs. In a crypto API this seems worse than a typo, since it sends the reader looking for a parameter that is not there. `Cipher.open` carries the same copy. The other four look like plain name drift.

### Modifications:

Dropped the three nonce entries, renamed four entries to the names the signatures use. Comments only, no code touched.

### Result:

The parameter lists match the signatures.
