### PR TITLE
Enforce a 2048-bit minimum on RSA raw number initializers

### DIFF
--- a/Sources/CryptoExtras/RSA/RSA+BlindSigning.swift
+++ b/Sources/CryptoExtras/RSA/RSA+BlindSigning.swift
@@ -105,9 +105,15 @@ extension _RSA.BlindSigning {
         }
 
         /// Construct a RSA public key with the specified parameters.
+        ///
+        /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
+        /// for their use-case.
         public init(n: some ContiguousBytes, e: some ContiguousBytes, parameters: Parameters) throws {
             self.backing = try BackingPublicKey(n: n, e: e)
             self.parameters = parameters
+            guard self.keySizeInBits >= 2048 else {
+                throw CryptoKitError.incorrectParameterSize
+            }
         }
 
         public var pkcs1DERRepresentation: Data {
@@ -206,9 +212,15 @@ extension _RSA.BlindSigning {
         }
 
         /// Construct an RSA private key with the specified parameters.
+        ///
+        /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
+        /// for their use-case.
         public init(n: some ContiguousBytes, e: some ContiguousBytes, d: some ContiguousBytes, p: some ContiguousBytes, q: some ContiguousBytes, parameters: Parameters) throws {
             self.backing = try BackingPrivateKey(n: n, e: e, d: d, p: p, q: q)
             self.parameters = parameters
+            guard self.keySizeInBits >= 2048 else {
+                throw CryptoKitError.incorrectParameterSize
+            }
         }
 
         /// Randomly generate a new RSA private key of a given size.

--- a/Sources/CryptoExtras/RSA/RSA.swift
+++ b/Sources/CryptoExtras/RSA/RSA.swift
@@ -117,8 +117,14 @@ extension _RSA.Signing {
         }
 
         /// Construct an RSA public key with the specified parameters.
+        ///
+        /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
+        /// for their use-case.
         public init(n: some ContiguousBytes, e: some ContiguousBytes) throws {
             self.backing = try BackingPublicKey(n: n, e: e)
+            guard self.keySizeInBits >= 2048 else {
+                throw CryptoKitError.incorrectParameterSize
+            }
         }
 
         public var pkcs1DERRepresentation: Data {
@@ -248,8 +254,14 @@ extension _RSA.Signing {
         }
 
         /// Construct an RSA private key with the specified parameters.
+        ///
+        /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
+        /// for their use-case.
         public init(n: some ContiguousBytes, e: some ContiguousBytes, d: some ContiguousBytes, p: some ContiguousBytes, q: some ContiguousBytes) throws {
             self.backing = try BackingPrivateKey(n: n, e: e, d: d, p: p, q: q)
+            guard self.keySizeInBits >= 2048 else {
+                throw CryptoKitError.incorrectParameterSize
+            }
         }
 
         /// Randomly generate a new RSA private key of a given size.
@@ -570,8 +582,14 @@ extension _RSA.Encryption {
         }
 
         /// Construct an RSA public key with the specified parameters.
+        ///
+        /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
+        /// for their use-case.
         public init(n: some ContiguousBytes, e: some ContiguousBytes) throws {
             self.backing = try BackingPublicKey(n: n, e: e)
+            guard self.keySizeInBits >= 2048 else {
+                throw CryptoKitError.incorrectParameterSize
+            }
         }
 
         public var pkcs1DERRepresentation: Data { self.backing.pkcs1DERRepresentation }
@@ -632,8 +650,14 @@ extension _RSA.Encryption {
 
 
         /// Construct an RSA private key with the specified parameters.
+        ///
+        /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
+        /// for their use-case.
         public init(n: some ContiguousBytes, e: some ContiguousBytes, d: some ContiguousBytes, p: some ContiguousBytes, q: some ContiguousBytes) throws {
             self.backing = try BackingPrivateKey(n: n, e: e, d: d, p: p, q: q)
+            guard self.keySizeInBits >= 2048 else {
+                throw CryptoKitError.incorrectParameterSize
+            }
         }
 
         /// Randomly generate a new RSA private key of a given size.

--- a/Tests/CryptoExtrasTests/TestRSABlindSigning.swift
+++ b/Tests/CryptoExtrasTests/TestRSABlindSigning.swift
@@ -201,6 +201,17 @@ final class TestRSABlindSigning: XCTestCase {
             e: bytesValues.randomElement()!,
             parameters: .RSABSSA_SHA384_PSS_Randomized
         )
+        // Modulus of a 512-bit key: `openssl rsa -in key.pem -noout -modulus`.
+        let _512BitModulus =
+            "e24c4c2c70e673315c2420b0e211542bbccf5b79f2ce6bdaa4aac29650bd064b"
+            + "955ae1613a449c7143e906d7f251e49356771d9d6f8f15bcf4044f87de1c1bed"
+        XCTAssertThrowsError(
+            try _RSA.BlindSigning.PublicKey(
+                n: Data(hexString: _512BitModulus),
+                e: Data(hexString: "010001"),
+                parameters: .RSABSSA_SHA384_PSS_Randomized
+            )
+        )
     }
 
     func testConstructAndUseKeyFromRSANumbersWhileRecoveringPrimes() throws {

--- a/Tests/CryptoExtrasTests/TestRSAEncryption.swift
+++ b/Tests/CryptoExtrasTests/TestRSAEncryption.swift
@@ -111,6 +111,13 @@ final class TestRSAEncryption: XCTestCase {
             n: bytesValues.randomElement()!,
             e: bytesValues.randomElement()!
         )
+        // Modulus of a 512-bit key: `openssl rsa -in key.pem -noout -modulus`.
+        let _512BitModulus =
+            "e24c4c2c70e673315c2420b0e211542bbccf5b79f2ce6bdaa4aac29650bd064b"
+            + "955ae1613a449c7143e906d7f251e49356771d9d6f8f15bcf4044f87de1c1bed"
+        XCTAssertThrowsError(
+            try _RSA.Encryption.PublicKey(n: Data(hexString: _512BitModulus), e: Data(hexString: "010001"))
+        )
     }
 
     func testConstructAndUseKeyFromRSANumbersWhileRecoveringPrimes() throws {

--- a/Tests/CryptoExtrasTests/TestRSASigning.swift
+++ b/Tests/CryptoExtrasTests/TestRSASigning.swift
@@ -770,6 +770,13 @@ final class TestRSASigning: XCTestCase {
             n: bytesValues.randomElement()!,
             e: bytesValues.randomElement()!
         )
+        // Modulus of the 512-bit key above: `openssl rsa -in key.pem -noout -modulus`.
+        let _512BitModulus =
+            "e24c4c2c70e673315c2420b0e211542bbccf5b79f2ce6bdaa4aac29650bd064b"
+            + "955ae1613a449c7143e906d7f251e49356771d9d6f8f15bcf4044f87de1c1bed"
+        XCTAssertThrowsError(
+            try _RSA.Signing.PublicKey(n: Data(hexString: _512BitModulus), e: Data(hexString: "010001"))
+        )
     }
 
     func testConstructAndUseKeyFromRSANumbersWhileRecoveringPrimes() throws {


### PR DESCRIPTION
### Motivation:

The RSA initializers that take raw numbers, e.g. `init(n:e:)` and friends, do not enforce a minimum key size.

Our other public API has two lower bounds: the "safe" APIs, e.g. `init(pemRepresentation:)`, which has a 2048-bit lower bound, and the "unsafe" variants, e.g. `init(unsfafePEMRepresentation:)`, which has a 1024-bit minimum.

Given the raw number initializers do not state they are unsafe, they should probably have a 2048-bit minimum too.

### Modifications:

- Add a 2048-bit minimum key length check to the raw number initializers.
- Update the documentation to match the wording on the PEM and DER initializers.
- Extend the tests.

### Result:

The RSA initializers that take raw numbers, e.g. `init(n:e:)` and friends, now enforce a 2048-bit minimum key length.