### PR TITLE
Validate length in X-Wing representations to match CryptoKit

### DIFF
--- a/Sources/Crypto/KEM/BoringSSL/XWing_boring.swift
+++ b/Sources/Crypto/KEM/BoringSSL/XWing_boring.swift
@@ -176,7 +176,11 @@ extension OpenSSLXWingPrivateKeyImpl {
 
             try seedRepresentation.withUnsafeBytes { privateKeyBytes in
                 guard privateKeyBytes.count == Int(XWING_PRIVATE_KEY_BYTES) else {
-                    throw CryptoKitError.incorrectKeySize
+                    if publicKeyHash != nil {
+                        throw CryptoKitError.incorrectParameterSize
+                    } else {
+                        throw CryptoKitError.incorrectKeySize
+                    }
                 }
 
                 var cbs = CBS()

--- a/Sources/Crypto/KEM/BoringSSL/XWing_boring.swift
+++ b/Sources/Crypto/KEM/BoringSSL/XWing_boring.swift
@@ -176,11 +176,7 @@ extension OpenSSLXWingPrivateKeyImpl {
 
             try seedRepresentation.withUnsafeBytes { privateKeyBytes in
                 guard privateKeyBytes.count == Int(XWING_PRIVATE_KEY_BYTES) else {
-                    if publicKeyHash != nil {
-                        throw CryptoKitError.incorrectParameterSize
-                    } else {
-                        throw CryptoKitError.incorrectKeySize
-                    }
+                    throw CryptoKitError.incorrectParameterSize
                 }
 
                 var cbs = CBS()

--- a/Tests/CryptoTests/KEM/Boring/XWingTests_boring.swift
+++ b/Tests/CryptoTests/KEM/Boring/XWingTests_boring.swift
@@ -80,8 +80,33 @@ extension XWingTests {
             try XWingMLKEM768X25519.PrivateKey(integrityCheckedRepresentation: Data(repeating: 0, count: 128)),
             error: CryptoKitError.incorrectParameterSize
         )
+
+        // Validate that seedRepresentation with incorrect byte counts also fails with incorrectParameterSize
+        XCTAssertThrowsError(
+            try XWingMLKEM768X25519.PrivateKey(seedRepresentation: Data(), publicKey: nil),
+            error: CryptoKitError.incorrectParameterSize
+        )
+        XCTAssertThrowsError(
+            try XWingMLKEM768X25519.PrivateKey(seedRepresentation: Data(repeating: 0, count: 31), publicKey: nil),
+            error: CryptoKitError.incorrectParameterSize
+        )
+        XCTAssertThrowsError(
+            try XWingMLKEM768X25519.PrivateKey(seedRepresentation: Data(repeating: 0, count: 33), publicKey: nil),
+            error: CryptoKitError.incorrectParameterSize
+        )
+        let dummy = try XWingMLKEM768X25519.PrivateKey()
+        XCTAssertThrowsError(
+            try XWingMLKEM768X25519.PrivateKey(seedRepresentation: Data(), publicKey: dummy.publicKey),
+            error: CryptoKitError.incorrectParameterSize
+        )
+        XCTAssertThrowsError(
+            try XWingMLKEM768X25519.PrivateKey(
+                seedRepresentation: Data(repeating: 0, count: 31),
+                publicKey: dummy.publicKey
+            ),
+            error: CryptoKitError.incorrectParameterSize
+        )
     }
 }
 
 #endif  // CRYPTO_IN_SWIFTPM
-

--- a/Tests/CryptoTests/KEM/Boring/XWingTests_boring.swift
+++ b/Tests/CryptoTests/KEM/Boring/XWingTests_boring.swift
@@ -12,6 +12,14 @@
 //
 //===----------------------------------------------------------------------===//
 
+import XCTest
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
 #if CRYPTO_IN_SWIFTPM && !CRYPTO_IN_SWIFTPM_FORCE_BUILD_API
 // Skip tests that require @testable imports of CryptoKit.
 #else
@@ -49,4 +57,31 @@ extension XWingMLKEM768X25519.PublicKey {
     }
 }
 
+extension XWingTests {
+    func testIntegrityCheckedRepresentationLengthValidation() throws {
+        // Validate that representations with incorrect byte counts fail fast with incorrectParameterSize
+        XCTAssertThrowsError(
+            try XWingMLKEM768X25519.PrivateKey(integrityCheckedRepresentation: Data()),
+            error: CryptoKitError.incorrectParameterSize
+        )
+        XCTAssertThrowsError(
+            try XWingMLKEM768X25519.PrivateKey(integrityCheckedRepresentation: Data(repeating: 0, count: 32)),
+            error: CryptoKitError.incorrectParameterSize
+        )
+        XCTAssertThrowsError(
+            try XWingMLKEM768X25519.PrivateKey(integrityCheckedRepresentation: Data(repeating: 0, count: 63)),
+            error: CryptoKitError.incorrectParameterSize
+        )
+        XCTAssertThrowsError(
+            try XWingMLKEM768X25519.PrivateKey(integrityCheckedRepresentation: Data(repeating: 0, count: 65)),
+            error: CryptoKitError.incorrectParameterSize
+        )
+        XCTAssertThrowsError(
+            try XWingMLKEM768X25519.PrivateKey(integrityCheckedRepresentation: Data(repeating: 0, count: 128)),
+            error: CryptoKitError.incorrectParameterSize
+        )
+    }
+}
+
 #endif  // CRYPTO_IN_SWIFTPM
+


### PR DESCRIPTION
### Motivation:

CryptoKit throws `CryptoKitError.incorrectParameterSize` whenever the seed representation length is invalid (whether initialized via `integrityCheckedRepresentation`, or via `seedRepresentation` with or without a public key). In the BoringSSL backend, `OpenSSLXWingPrivateKeyImpl` previously threw `CryptoKitError.incorrectKeySize` when seed length was invalid, creating a parity gap with CryptoKit.

Resolves #443.

### Modifications:

1. In `Sources/Crypto/KEM/BoringSSL/XWing_boring.swift`:
   Updated `OpenSSLXWingPrivateKeyImpl.Backing.init(seedRepresentation:publicKeyHash:)` to throw `CryptoKitError.incorrectParameterSize` when the seed length is not `XWING_PRIVATE_KEY_BYTES` (32 bytes), matching CryptoKit behavior.
2. In `Tests/CryptoTests/KEM/Boring/XWingTests_boring.swift`:
   Added unit tests verifying that invalid lengths for both `integrityCheckedRepresentation` and `seedRepresentation` (with and without `publicKey`) consistently throw `CryptoKitError.incorrectParameterSize`.

### Result:

Closes the parity gap between CryptoKit and the BoringSSL backend for X-Wing private key length validation.