### PR TITLE
[5.x] Catchup merge main into 5.x branch

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,18 @@ your contribution to Apple and the community, and agree by submitting the patch
 that your contributions are licensed under the Apache 2.0 license (see
 `LICENSE.txt`).
 
+## AI tools
+
+Human discourse is an essential part of open source development. To encourage
+productive collaboration between contributors and maintainers, please refrain
+from using AI tools for the following:
+
+- Issues: titles, bodies, and comments.
+- Pull requests: titles, descriptions, and comments.
+
+Contributors who feel more comfortable writing in another language may use
+automated translation tools, but must include their original content in their
+preferred language.
 
 ## How to submit a bug report
 
@@ -44,19 +56,27 @@ $ uname -a
 Linux beefy.machine 4.4.0-101-generic #124-Ubuntu SMP Fri Nov 10 18:29:59 UTC 2017 x86_64 x86_64 x86_64 GNU/Linux
 ```
 
-## Writing a Patch
+## Contributing a pull request
 
-A good swift-crypto patch is:
+> [!IMPORTANT]
+> To ensure productive use of contributor and maintainer time and resources,
+> contributors must first agree their proposed change with a maintainer in an
+> issue. Pull requests opened without prior discussion may be closed without
+> review.
 
-1. Concise, and contains as few changes as needed to achieve the end result.
-2. Tested, ensuring that any tests provided failed before the patch and pass after it.
-3. Documented, adding API documentation as needed to cover new functions and properties.
-4. Accompanied by a great commit message, using our commit message template.
+If there is no issue already tracking the problem or feature request, please
+file a new one using your own voice (see "AI tools" usage above).
 
+Once an issue is assigned to you, follow these steps:
 
-## How to contribute your work
-
-Please open a pull request at https://github.com/apple/swift-crypto. Make sure the CI passes, and then wait for code review.
+- Prepare your change, keeping in mind that a good patch is:
+  - Concise, and contains as few changes as needed to achieve the end result.
+  - Tested, ensuring that any tests provided failed before the patch and pass
+    after it.
+  - Documented, adding API documentation as needed to cover new functions and
+    properties.
+  - Accompanied by a great commit message.
+- Open a pull request and wait for code review by the maintainers.
 
 ### How to update CMakeLists files
 

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ When building Swift Crypto for use on an Apple platform where CryptoKit is alrea
 When building Swift Crypto for use on Linux or Windows, Swift Crypto builds substantially more code. In particular, we build:
 
 1. A vendored copy of BoringSSL's libcrypto.
-2. The common API of Swift Crypto and CryptoKit.
-3. The backing implementation of this common API, which calls into BoringSSL.
+2. A vendored copy of XKCP's libXKCP.
+3. The common API of Swift Crypto and CryptoKit.
+4. The backing implementation of this common API, which calls into BoringSSL or XKCP.
 
-The API code, and some cryptographic primitives which are directly implemented in Swift, are exactly the same for both Apple CryptoKit and Swift Crypto. The backing BoringSSL-based implementation is unique to Swift Crypto. In addition, there is another product, `CryptoExtras`, which provides additional functionality that is not offered in CryptoKit, which contains cryptographic APIS predominantly useful in the server ecosystem. **Note**: if you depend on CryptoExtras you'll bundle the BoringSSL implementation of the library in your application, no matter the platform.
+The API code, and some cryptographic primitives which are directly implemented in Swift, are exactly the same for both Apple CryptoKit and Swift Crypto. The BoringSSL/XKCP backing implementation is unique to Swift Crypto. In addition, there is another product, `CryptoExtras`, which provides additional functionality that is not offered in CryptoKit, which contains cryptographic APIs predominantly useful in the server ecosystem. **Note**: if you depend on CryptoExtras you'll bundle the BoringSSL/XKCP implementation of the library in your application, no matter the platform.
 
 ## Evolution
 
@@ -48,11 +49,11 @@ Note that Swift Crypto does not intend to support all possible cryptographic pri
 
 ### Code Organisation
 
-Files in this repository are divided into two groups, based on whether they have a name that ends in `_boring` or are in a `BoringSSL` directory, or if they are not.
+Files in this repository are divided into two groups, based on whether they have a name that ends in `_boring`/`_xkcp` or are in a `BoringSSL`/`XKCP` directory, or if they are not.
 
-Files that meet the above criteria are specific to the Swift Crypto implementation. Changes to these files can be made fairly easily, so long as they meet the criteria below. If your file needs to `import CCryptoBoringSSL` or access a BoringSSL API, it needs to be marked this way.
+Files that meet the above criteria are specific to the Swift Crypto implementation. Changes to these files can be made fairly easily, so long as they meet the criteria below. If your file needs to `import CCryptoBoringSSL` or `import CXKCP` or access a BoringSSL or XKCP API, it needs to be marked this way.
 
-Files that do not have the `_boring` suffix are part of the public API of CryptoKit. Changing these requires passing a higher bar, as any change in these files must be accompanied by a change in CryptoKit itself.
+Files that do not have the `_boring` or `_xkcp` suffix are part of the public API of CryptoKit. Changing these requires passing a higher bar, as any change in these files must be accompanied by a change in CryptoKit itself.
 
 ## Contributing
 
@@ -146,3 +147,7 @@ To do so, please use the following dependency in your `Package.swift`:
 
 Swift Crypto normally defers to the OS implementation of CryptoKit on macOS. Naturally, this makes developing Swift Crypto on macOS tricky. To get Swift Crypto to build the open source implementation on macOS, in `Package.swift`, change `let development = false` to `let development = true`, as this will force Swift Crypto to build its public API.
 
+
+## Acknowledgements
+
+This project contains source code from the BoringSSL and XKCP projects.

--- a/Sources/CryptoExtras/AES/AES_CBC.swift
+++ b/Sources/CryptoExtras/AES/AES_CBC.swift
@@ -25,19 +25,6 @@ extension AES {
     /// suite.
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     public enum _CBC {
-        private static var blockSize: Int { 16 }
-
-        private static func encryptBlockInPlace(
-            _ plaintext: inout Block,
-            priorCiphertextBlock: Block,
-            using key: SymmetricKey
-        ) throws {
-            assert([128, 192, 256].contains(key.bitCount))
-
-            plaintext ^= priorCiphertextBlock
-            try AES.permute(&plaintext, key: key)
-        }
-
         /// Encrypts data using AES-CBC.
         ///
         /// - Parameters:
@@ -60,44 +47,7 @@ extension AES {
         ///
         /// - Note: If `noPadding` is set to `true`, `plainText` has to be a multiple of the blockSize (16 bytes). Otherwise an error will be thrown.
         public static func encrypt<Plaintext: DataProtocol>(_ plaintext: Plaintext, using key: SymmetricKey, iv: AES._CBC.IV, noPadding: Bool) throws -> Data {
-            guard [128, 192, 256].contains(key.bitCount) else {
-                throw CryptoKitError.incorrectKeySize
-            }
-
-            let requiresFullPaddingBlock = (plaintext.count % AES._CBC.blockSize) == 0
-
-            if noPadding && !requiresFullPaddingBlock {
-                throw CryptoKitError.incorrectParameterSize
-            }
-
-            var ciphertext = Data()
-            ciphertext.reserveCapacity(plaintext.count + Self.blockSize)  // Room for padding.
-
-            var previousBlock = Block(iv)
-            var plaintext = plaintext[...]
-
-            while plaintext.count > 0 {
-                var block = Block(blockBytes: plaintext.prefix(Self.blockSize))
-                try Self.encryptBlockInPlace(&block, priorCiphertextBlock: previousBlock, using: key)
-                ciphertext.append(contentsOf: block)
-                previousBlock = block
-                plaintext = plaintext.dropFirst(Self.blockSize)
-            }
-
-            if requiresFullPaddingBlock && !noPadding {
-                var block = Block.paddingBlock
-                try Self.encryptBlockInPlace(&block, priorCiphertextBlock: previousBlock, using: key)
-                ciphertext.append(contentsOf: block)
-            }
-
-            return ciphertext
-        }
-
-        private static func decryptBlockInPlace(_ ciphertext: inout Block, priorCiphertextBlock: Block, using key: SymmetricKey) throws {
-            assert([128, 192, 256].contains(key.bitCount))
-
-            try AES.inversePermute(&ciphertext, key: key)
-            ciphertext ^= priorCiphertextBlock
+            try OpenSSLAESCBCImpl.encrypt(plaintext, using: key, iv: iv, noPadding: noPadding)
         }
 
         /// Decrypts data using AES-CBC.
@@ -120,29 +70,7 @@ extension AES {
         ///   - noPadding: If this is set to `true`, padding won't be removed.
         /// - Returns: The decrypted message.
         public static func decrypt<Ciphertext: DataProtocol>(_ ciphertext: Ciphertext, using key: SymmetricKey, iv: AES._CBC.IV, noPadding: Bool) throws -> Data {
-            guard [128, 192, 256].contains(key.bitCount) else {
-                throw CryptoKitError.incorrectKeySize
-            }
-
-            var plaintext = Data()
-            plaintext.reserveCapacity(ciphertext.count)
-
-            var previousBlock = Block(iv)
-            var ciphertext = ciphertext[...]
-
-            while ciphertext.count > 0 {
-                let ctBlock = Block(blockBytes: ciphertext.prefix(Self.blockSize))
-                var block = ctBlock
-                try Self.decryptBlockInPlace(&block, priorCiphertextBlock: previousBlock, using: key)
-                plaintext.append(contentsOf: block)
-                previousBlock = ctBlock
-                ciphertext = ciphertext.dropFirst(Self.blockSize)
-            }
-
-            if !noPadding {
-                try plaintext.trimPadding()
-            }
-            return plaintext
+            try OpenSSLAESCBCImpl.decrypt(ciphertext, using: key, iv: iv, noPadding: noPadding)
         }
     }
 }
@@ -194,7 +122,7 @@ extension AES._CBC {
                 0, 0, 0, 0, 0, 0, 0, 0
             )
 
-            withUnsafeMutableBytes(of: &self.ivBytes) { bytesPtr in
+            Swift.withUnsafeMutableBytes(of: &self.ivBytes) { bytesPtr in
                 bytesPtr.copyBytes(from: ivBytes)
             }
         }
@@ -205,24 +133,10 @@ extension AES._CBC {
                 Array(unsafeRawBufferPointer).makeIterator()
             }
         }
-    }
-}
 
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-extension Data {
-    fileprivate mutating func trimPadding() throws {
-        guard let paddingBytes = self.last else {
-            // Degenerate case, empty string. This is forbidden:
-            // we must always pad.
-            throw CryptoKitError.incorrectParameterSize
+        mutating func withUnsafeMutableBytes<ReturnType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ReturnType) rethrows -> ReturnType {
+            return try Swift.withUnsafeMutableBytes(of: &self.ivBytes, body)
         }
 
-        guard paddingBytes > 0 &&
-              self.count >= paddingBytes &&
-              self.suffix(Int(paddingBytes)).allSatisfy({ $0 == paddingBytes }) else {
-            throw CryptoKitError.incorrectParameterSize
-        }
-
-        self = self.dropLast(Int(paddingBytes))
     }
 }

--- a/Sources/CryptoExtras/AES/AES_GCM_SIV.swift
+++ b/Sources/CryptoExtras/AES/AES_GCM_SIV.swift
@@ -63,7 +63,6 @@ extension AES.GCM {
         /// - Parameters:
         ///   - sealedBox: The sealed box to authenticate and decrypt
         ///   - key: An encryption key of 128 or 256 bits
-        ///   - nonce: An Nonce for AES-GCM-SIV encryption. The nonce must be unique for every use of the key to seal data. It can be safely generated with AES.GCM.Nonce().
         ///   - authenticatedData: Data that was authenticated as part of the seal
         /// - Returns: The ciphertext if opening was successful
         /// - Throws: CipherError errors. If the authentication of the sealed box failed, incorrectTag is thrown.
@@ -77,7 +76,6 @@ extension AES.GCM {
         /// - Parameters:
         ///   - sealedBox: The sealed box to authenticate and decrypt
         ///   - key: An encryption key of 128 or 256 bits
-        ///   - nonce: An Nonce for AES-GCM-SIV encryption. The nonce must be unique for every use of the key to seal data. It can be safely generated with AES.GCM.Nonce().
         /// - Returns: The ciphertext if opening was successful
         /// - Throws: CipherError errors. If the authentication of the sealed box failed, incorrectTag is thrown.
         public static func open(_ sealedBox: SealedBox, using key: SymmetricKey) throws -> Data {

--- a/Sources/CryptoExtras/AES/Block Function.swift
+++ b/Sources/CryptoExtras/AES/Block Function.swift
@@ -118,8 +118,6 @@ extension AES {
 
     @available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
     struct Block {
-        private static var blockSize: Int { 16 }
-
         typealias BlockBytes = (
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8,
             UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8, UInt8
@@ -135,69 +133,8 @@ extension AES {
             )
         }
 
-        init(_ blockBytes: BlockBytes) {
-            self.blockBytes = blockBytes
-        }
-
-        init(_ iv: AES._CBC.IV) {
-            self.blockBytes = iv.ivBytes
-        }
-
-        init<BlockBytes: Collection>(blockBytes: BlockBytes) where BlockBytes.Element == UInt8 {
-            // The block size is always 16. Pad out past there.
-            precondition(blockBytes.count <= Self.blockSize)
-
-            self.blockBytes = (
-                0, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0
-            )
-
-            Swift.withUnsafeMutableBytes(of: &self.blockBytes) { bytesPtr in
-                bytesPtr.copyBytes(from: blockBytes)
-
-                // Early exit here.
-                if blockBytes.count == Self.blockSize {
-                    return
-                }
-
-                var remainingBytes = bytesPtr.dropFirst(blockBytes.count)
-                let padByte = UInt8(remainingBytes.count)
-
-                for index in remainingBytes.indices {
-                    remainingBytes[index] = padByte
-                }
-            }
-        }
-
-        static var paddingBlock: Block {
-            // The padding block is a full block of value blocksize.
-            let value = UInt8(truncatingIfNeeded: Self.blockSize)
-            return Block((
-                value, value, value, value, value, value, value, value,
-                value, value, value, value, value, value, value, value
-            ))
-        }
-
-        func withUnsafeBytes<ReturnType>(_ body: (UnsafeRawBufferPointer) throws -> ReturnType) rethrows -> ReturnType {
-            return try Swift.withUnsafeBytes(of: self.blockBytes, body)
-        }
-
         mutating func withUnsafeMutableBytes<ReturnType>(_ body: (UnsafeMutableRawBufferPointer) throws -> ReturnType) rethrows -> ReturnType {
             return try Swift.withUnsafeMutableBytes(of: &self.blockBytes, body)
-        }
-
-        static func ^= (lhs: inout Block, rhs: Block) {
-            // Ideally we'd not use raw pointers for this.
-            lhs.withUnsafeMutableBytes { lhsPtr in
-                rhs.withUnsafeBytes { rhsPtr in
-                    assert(lhsPtr.count == Self.blockSize)
-                    assert(rhsPtr.count == Self.blockSize)
-
-                    for index in 0..<Self.blockSize {
-                        lhsPtr[index] ^= rhsPtr[index]
-                    }
-                }
-            }
         }
     }
 
@@ -207,55 +144,6 @@ extension AES {
             return true
         default:
             return false
-        }
-    }
-}
-
-@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
-extension AES.Block: RandomAccessCollection, MutableCollection {
-    var startIndex: Int {
-        0
-    }
-
-    var endIndex: Int {
-        Self.blockSize
-    }
-
-    subscript(position: Int) -> UInt8 {
-        get {
-            precondition(position >= 0)
-            precondition(position < Self.blockSize)
-
-            return self.withUnsafeBytes { $0[position] }
-        }
-
-        set {
-            precondition(position >= 0)
-            precondition(position < Self.blockSize)
-
-            self.withUnsafeMutableBytes { $0[position] = newValue }
-        }
-    }
-
-    func withContiguousStorageIfAvailable<ReturnValue>(
-        _ body: (UnsafeBufferPointer<UInt8>) throws -> ReturnValue)
-    rethrows -> ReturnValue? {
-        return try withUnsafePointer(to: self.blockBytes) { tuplePtr in
-            // Homogeneous tuples are always bound to the element type as well as to their own type.
-            let retyped = UnsafeRawPointer(tuplePtr).assumingMemoryBound(to: UInt8.self)
-            let bufferised = UnsafeBufferPointer(start: retyped, count: Self.blockSize)
-            return try body(bufferised)
-        }
-    }
-
-    mutating func withContiguousMutableStorageIfAvailable<ReturnValue>(
-        _ body: (inout UnsafeMutableBufferPointer<UInt8>) throws -> ReturnValue)
-    rethrows -> ReturnValue? {
-        return try withUnsafeMutablePointer(to: &self.blockBytes) { tuplePtr in
-            // Homogeneous tuples are always bound to the element type as well as to their own type.
-            let retyped = UnsafeMutableRawPointer(tuplePtr).assumingMemoryBound(to: UInt8.self)
-            var bufferised = UnsafeMutableBufferPointer(start: retyped, count: Self.blockSize)
-            return try body(&bufferised)
         }
     }
 }

--- a/Sources/CryptoExtras/AES/BoringSSL/AES_CBC_boring.swift
+++ b/Sources/CryptoExtras/AES/BoringSSL/AES_CBC_boring.swift
@@ -1,0 +1,189 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the SwiftCrypto open source project
+//
+// Copyright (c) 2026 Apple Inc. and the SwiftCrypto project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of SwiftCrypto project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@_implementationOnly import CCryptoBoringSSL
+import Crypto
+
+#if canImport(FoundationEssentials)
+import FoundationEssentials
+#else
+import Foundation
+#endif
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+@usableFromInline
+enum OpenSSLAESCBCImpl {
+    private static let blockSize = 16
+
+    @usableFromInline
+    enum Direction {
+        case encrypt
+        case decrypt
+
+        @usableFromInline
+        var _boringSSLParameter: Int32 {
+            switch self {
+            case .encrypt: AES_ENCRYPT
+            case .decrypt: AES_DECRYPT
+            }
+        }
+    }
+
+    /// Encrypts plaintext using AES-CBC.
+    ///
+    /// PKCS#7 padding is added unless `noPadding` is set, in which case the plaintext must
+    /// already be a whole number of blocks.
+    static func encrypt<Plaintext: DataProtocol>(
+        _ plaintext: Plaintext,
+        using key: SymmetricKey,
+        iv: AES._CBC.IV,
+        noPadding: Bool
+    ) throws -> Data {
+        guard [128, 192, 256].contains(key.bitCount) else {
+            throw CryptoKitError.incorrectKeySize
+        }
+        // With padding disabled the input must be a whole number of blocks.
+        if noPadding && (plaintext.count % Self.blockSize != 0) {
+            throw CryptoKitError.incorrectParameterSize
+        }
+
+        // AES_cbc_encrypt performs no padding, so PKCS#7 is applied here.
+        var padded = Data(plaintext)
+        if !noPadding {
+            // PKCS#7 always appends 1...blockSize bytes (a full block when already aligned).
+            let padLength = Self.blockSize - (plaintext.count % Self.blockSize)
+            let padding = repeatElement(UInt8(padLength), count: padLength)
+            padded.append(contentsOf: padding)
+        }
+
+        return padded.withUnsafeBytes { plaintextPtr in
+            Self._cipher(.encrypt, plaintextPtr, using: key, iv: iv)
+        }
+    }
+
+    /// Decrypts ciphertext using AES-CBC.
+    ///
+    /// BoringSSL runs with padding disabled and, unless `noPadding` is set, PKCS#7 padding is
+    /// removed here in constant time. BoringSSL's own PKCS#7 removal is not constant-time (it is a
+    /// documented padding oracle absent authentication), so it must not be delegated.
+    static func decrypt<Ciphertext: DataProtocol>(
+        _ ciphertext: Ciphertext,
+        using key: SymmetricKey,
+        iv: AES._CBC.IV,
+        noPadding: Bool
+    ) throws -> Data {
+        guard [128, 192, 256].contains(key.bitCount) else {
+            throw CryptoKitError.incorrectKeySize
+        }
+        // CBC ciphertext is always a whole number of non-empty blocks.
+        guard ciphertext.count > 0, ciphertext.count % Self.blockSize == 0 else {
+            throw CryptoKitError.incorrectParameterSize
+        }
+
+        let contiguousCiphertext = Data(ciphertext)
+        let plaintext = contiguousCiphertext.withUnsafeBytes { ciphertextPtr in
+            Self._cipher(.decrypt, ciphertextPtr, using: key, iv: iv)
+        }
+
+        return noPadding ? plaintext : try plaintext.removingPKCS7PaddingConstantTime(blockSize: Self.blockSize)
+    }
+
+    /// Runs raw AES-CBC in the given direction over a single contiguous buffer.
+    ///
+    /// `AES_cbc_encrypt` performs no padding, so `input` must be a whole number of blocks and the
+    /// output has the same length. PKCS#7 is applied and removed by the callers.
+    @usableFromInline
+    static func _cipher(
+        _ direction: Direction,
+        _ input: UnsafeRawBufferPointer,
+        using key: SymmetricKey,
+        iv: AES._CBC.IV
+    ) -> Data {
+        precondition(input.count % Self.blockSize == 0)
+
+        var output = Data(count: input.count)
+        var iv = iv
+        key.withUnsafeBytes { keyPtr in
+            // AES_cbc_encrypt advances the IV in place, so operate on our own copy.
+            iv.withUnsafeMutableBytes { ivPtr in
+                var key = AES_KEY()
+                switch direction {
+                case .encrypt:
+                    precondition(
+                        CCryptoBoringSSL_AES_set_encrypt_key(keyPtr.baseAddress, UInt32(keyPtr.count * 8), &key) == 0
+                    )
+                case .decrypt:
+                    precondition(
+                        CCryptoBoringSSL_AES_set_decrypt_key(keyPtr.baseAddress, UInt32(keyPtr.count * 8), &key) == 0
+                    )
+                }
+                output.withUnsafeMutableBytes { outputPtr in
+                    CCryptoBoringSSL_AES_cbc_encrypt(
+                        input.baseAddress,
+                        outputPtr.baseAddress,
+                        input.count,
+                        &key,
+                        ivPtr.baseAddress,
+                        direction._boringSSLParameter
+                    )
+                }
+            }
+        }
+
+        return output
+    }
+}
+
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+extension Data {
+    /// Removes PKCS#7 padding in constant time with respect to the padding bytes.
+    fileprivate func removingPKCS7PaddingConstantTime(blockSize: Int = 16) throws -> Data {
+        // The total length is not secret, so branching on it is safe.
+        guard self.count >= blockSize, self.count % blockSize == 0 else {
+            throw CryptoKitError.incorrectParameterSize
+        }
+
+        let padLength = self.last!
+        let lastBlock = self.suffix(blockSize)
+
+        // Validate padding in constant time.
+        var bad: UInt32 = 0
+        // A valid PKCS#7 pad length is 1...blockSize.
+        bad |= constantTimeLessThanOrEqual(padLength, 0)
+        bad |= constantTimeLessThanOrEqual(UInt8(blockSize + 1), padLength)
+        // We MUST operate on every byte in the block, and each byte in the padding region MUST equal `padLength`.
+        for index in lastBlock.indices {
+            let byte = UInt32(lastBlock[index])
+            let distanceFromEnd = self.endIndex - index
+            let inPadding = constantTimeLessThanOrEqual(UInt8(distanceFromEnd), padLength)
+            bad |= inPadding & (byte ^ UInt32(padLength))
+        }
+
+        // Throw if padding was invalid.
+        guard bad == 0 else {
+            throw CryptoKitError.incorrectParameterSize
+        }
+
+        // Drop the padding.
+        return self.dropLast(Int(padLength))
+    }
+}
+
+/// Returns `0xFFFFFFFF` if `lhs <= rhs`, otherwise `0`, without a data-dependent branch.
+@available(macOS 10.15, iOS 13, watchOS 6, tvOS 13, macCatalyst 13, visionOS 1.0, *)
+private func constantTimeLessThanOrEqual(_ lhs: UInt8, _ rhs: UInt8) -> UInt32 {
+    // `lhs - rhs - 1` is negative iff `lhs <= rhs`; propagate its sign bit across the word.
+    let difference = Int32(lhs) - Int32(rhs) - 1
+    return UInt32(bitPattern: difference >> 31)
+}

--- a/Sources/CryptoExtras/CMakeLists.txt
+++ b/Sources/CryptoExtras/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(CryptoExtras
   "AES/AES_CTR.swift"
   "AES/AES_GCM_SIV.swift"
   "AES/Block Function.swift"
+  "AES/BoringSSL/AES_CBC_boring.swift"
   "AES/BoringSSL/AES_CFB_boring.swift"
   "AES/BoringSSL/AES_CTR_boring.swift"
   "AES/BoringSSL/AES_GCM_SIV_boring.swift"

--- a/Sources/CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
+++ b/Sources/CryptoExtras/ECToolbox/BoringSSL/ECToolbox_boring.swift
@@ -161,7 +161,7 @@ struct OpenSSLGroupScalar<C: OpenSSLSupportedNISTCurve>: GroupScalar, CustomStri
 
     /// Deserializes a scalar from data.
     /// - Parameters:
-    ///   - data: The serialized scalar
+    ///   - bytes: The serialized scalar
     ///   - reductionIsModOrder: Resulting number is taken "mod q" (characteristic) by default. Override by setting true if "mod p" (order) is desired.
     /// - Returns: The deserialized scalar
     init(bytes: Data, reductionIsModOrder: Bool = false) throws {

--- a/Sources/CryptoExtras/RSA/RSA+BlindSigning.swift
+++ b/Sources/CryptoExtras/RSA/RSA+BlindSigning.swift
@@ -105,9 +105,15 @@ extension _RSA.BlindSigning {
         }
 
         /// Construct a RSA public key with the specified parameters.
+        ///
+        /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
+        /// for their use-case.
         public init(n: some ContiguousBytes, e: some ContiguousBytes, parameters: Parameters) throws {
             self.backing = try BackingPublicKey(n: n, e: e)
             self.parameters = parameters
+            guard self.keySizeInBits >= 2048 else {
+                throw CryptoKitError.incorrectParameterSize
+            }
         }
 
         public var pkcs1DERRepresentation: Data {
@@ -206,9 +212,15 @@ extension _RSA.BlindSigning {
         }
 
         /// Construct an RSA private key with the specified parameters.
+        ///
+        /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
+        /// for their use-case.
         public init(n: some ContiguousBytes, e: some ContiguousBytes, d: some ContiguousBytes, p: some ContiguousBytes, q: some ContiguousBytes, parameters: Parameters) throws {
             self.backing = try BackingPrivateKey(n: n, e: e, d: d, p: p, q: q)
             self.parameters = parameters
+            guard self.keySizeInBits >= 2048 else {
+                throw CryptoKitError.incorrectParameterSize
+            }
         }
 
         /// Randomly generate a new RSA private key of a given size.

--- a/Sources/CryptoExtras/RSA/RSA.swift
+++ b/Sources/CryptoExtras/RSA/RSA.swift
@@ -535,6 +535,7 @@ extension _RSA.Encryption {
         ///
         /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
         /// for their use-case.
+        /// The key's modulus bit length must also be a multiple of 8.
         public init(pemRepresentation: String) throws {
             self.backing = try BackingPublicKey(pemRepresentation: pemRepresentation)
             guard self.keySizeInBits >= 2048, self.keySizeInBits % 8 == 0 else { throw CryptoKitError.incorrectParameterSize }
@@ -544,6 +545,7 @@ extension _RSA.Encryption {
         ///
         /// This constructor supports key sizes of 1024 bits or more. Users should validate that key sizes are appropriate
         /// for their use-case.
+        /// The key's modulus bit length must also be a multiple of 8.
         /// - Warning: Key sizes less than 2048 are not recommended and should only be used for compatibility reasons.
         public init(unsafePEMRepresentation pemRepresentation: String) throws {
             self.backing = try BackingPublicKey(pemRepresentation: pemRepresentation)
@@ -554,6 +556,7 @@ extension _RSA.Encryption {
         ///
         /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
         /// for their use-case.
+        /// The key's modulus bit length must also be a multiple of 8.
         public init<Bytes: DataProtocol>(derRepresentation: Bytes) throws {
             self.backing = try BackingPublicKey(derRepresentation: derRepresentation)
             guard self.keySizeInBits >= 2048, self.keySizeInBits % 8 == 0 else { throw CryptoKitError.incorrectParameterSize }
@@ -563,6 +566,7 @@ extension _RSA.Encryption {
         ///
         /// This constructor supports key sizes of 1024 bits or more. Users should validate that key sizes are appropriate
         /// for their use-case.
+        /// The key's modulus bit length must also be a multiple of 8.
         /// - Warning: Key sizes less than 2048 are not recommended and should only be used for compatibility reasons.
         public init<Bytes: DataProtocol>(unsafeDERRepresentation derRepresentation: Bytes) throws {
             self.backing = try BackingPublicKey(derRepresentation: derRepresentation)
@@ -579,6 +583,7 @@ extension _RSA.Encryption {
         public var derRepresentation: Data { self.backing.derRepresentation }
         public var pemRepresentation: String { self.backing.pemRepresentation }
         public var keySizeInBits: Int { self.backing.keySizeInBits }
+        internal var modulusByteCount: Int { self.backing.modulusByteCount }
         fileprivate init(_ backing: BackingPublicKey) { self.backing = backing }
 
         public func getKeyPrimitives() throws -> Primitives {
@@ -596,6 +601,7 @@ extension _RSA.Encryption {
         ///
         /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
         /// for their use-case.
+        /// The key's modulus bit length must also be a multiple of 8.
         public init(pemRepresentation: String) throws {
             self.backing = try BackingPrivateKey(pemRepresentation: pemRepresentation)
             guard self.keySizeInBits >= 2048, self.keySizeInBits % 8 == 0 else { throw CryptoKitError.incorrectParameterSize }
@@ -605,6 +611,7 @@ extension _RSA.Encryption {
         ///
         /// This constructor supports key sizes of 1024 bits or more. Users should validate that key sizes are appropriate
         /// for their use-case.
+        /// The key's modulus bit length must also be a multiple of 8.
         /// - Warning: Key sizes less than 2048 are not recommended and should only be used for compatibility reasons.
         public init(unsafePEMRepresentation pemRepresentation: String) throws {
             self.backing = try BackingPrivateKey(pemRepresentation: pemRepresentation)
@@ -615,6 +622,7 @@ extension _RSA.Encryption {
         ///
         /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
         /// for their use-case.
+        /// The key's modulus bit length must also be a multiple of 8.
         public init<Bytes: DataProtocol>(derRepresentation: Bytes) throws {
             self.backing = try BackingPrivateKey(derRepresentation: derRepresentation)
             guard self.keySizeInBits >= 2048, self.keySizeInBits % 8 == 0 else { throw CryptoKitError.incorrectParameterSize }
@@ -624,6 +632,7 @@ extension _RSA.Encryption {
         ///
         /// This constructor supports key sizes of 1024 bits or more. Users should validate that key sizes are appropriate
         /// for their use-case.
+        /// The key's modulus bit length must also be a multiple of 8.
         /// - Warning: Key sizes less than 2048 are not recommended and should only be used for compatibility reasons.
         public init<Bytes: DataProtocol>(unsafeDERRepresentation derRepresentation: Bytes) throws {
             self.backing = try BackingPrivateKey(derRepresentation: derRepresentation)
@@ -741,8 +750,8 @@ extension _RSA.Encryption {
 extension _RSA.Encryption.PrivateKey {
     /// Decrypt a message encrypted with this key's public key and using the specified padding mode.
     ///
-    /// > Important: The size of the data to decrypt must be equal to the block size of the key (e.g.
-    ///   `keySizeInBits / 8`). Attempting to decrypt data of the wrong size will fail.
+    /// > Important: The size of the data to decrypt must be equal to the block size of the key.
+    ///   Attempting to decrypt data of the wrong size will fail.
     public func decrypt<D: DataProtocol>(_ data: D, padding: _RSA.Encryption.Padding) throws -> Data {
         return try self.backing.decrypt(data, padding: padding)
     }
@@ -764,17 +773,17 @@ extension _RSA.Encryption.PublicKey {
         switch padding.backing {
         case ._weakAndInsecure_pkcs1v1_5:
             // https://www.rfc-editor.org/rfc/rfc8017#section-7.2
-            return (self.keySizeInBits / 8) - 11
+            return self.modulusByteCount - 11
         case let .pkcs1_oaep(Digest):
             // https://datatracker.ietf.org/doc/html/rfc8017#section-7.1.1
-            return (self.keySizeInBits / 8) - (2 * Digest.hashBitLength / 8) - 2
+            return self.modulusByteCount - (2 * Digest.hashBitLength / 8) - 2
         }
     }
     
     /// Encrypt a message with this key, using the specified padding mode.
     ///
-    /// > Important: The size of the data to encrypt _must_ not exceed the modulus of the key (e.g.
-    ///   `keySizeInBits / 8`), minus any additional space required by the padding mode. Attempting to
+    /// > Important: The size of the data to encrypt _must_ not exceed the block size of the key,
+    ///   minus any additional space required by the padding mode. Attempting to
     ///   encrypt data larger than this will fail. Use ``maximumEncryptSize(with:)`` to determine
     ///   exactly how many bytes can be encrypted by the key.
     public func encrypt<D: DataProtocol>(_ data: D, padding: _RSA.Encryption.Padding) throws -> Data {

--- a/Sources/CryptoExtras/RSA/RSA.swift
+++ b/Sources/CryptoExtras/RSA/RSA.swift
@@ -117,8 +117,14 @@ extension _RSA.Signing {
         }
 
         /// Construct an RSA public key with the specified parameters.
+        ///
+        /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
+        /// for their use-case.
         public init(n: some ContiguousBytes, e: some ContiguousBytes) throws {
             self.backing = try BackingPublicKey(n: n, e: e)
+            guard self.keySizeInBits >= 2048 else {
+                throw CryptoKitError.incorrectParameterSize
+            }
         }
 
         public var pkcs1DERRepresentation: Data {
@@ -248,8 +254,14 @@ extension _RSA.Signing {
         }
 
         /// Construct an RSA private key with the specified parameters.
+        ///
+        /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
+        /// for their use-case.
         public init(n: some ContiguousBytes, e: some ContiguousBytes, d: some ContiguousBytes, p: some ContiguousBytes, q: some ContiguousBytes) throws {
             self.backing = try BackingPrivateKey(n: n, e: e, d: d, p: p, q: q)
+            guard self.keySizeInBits >= 2048 else {
+                throw CryptoKitError.incorrectParameterSize
+            }
         }
 
         /// Randomly generate a new RSA private key of a given size.
@@ -574,8 +586,14 @@ extension _RSA.Encryption {
         }
 
         /// Construct an RSA public key with the specified parameters.
+        ///
+        /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
+        /// for their use-case.
         public init(n: some ContiguousBytes, e: some ContiguousBytes) throws {
             self.backing = try BackingPublicKey(n: n, e: e)
+            guard self.keySizeInBits >= 2048 else {
+                throw CryptoKitError.incorrectParameterSize
+            }
         }
 
         public var pkcs1DERRepresentation: Data { self.backing.pkcs1DERRepresentation }
@@ -641,8 +659,14 @@ extension _RSA.Encryption {
 
 
         /// Construct an RSA private key with the specified parameters.
+        ///
+        /// This constructor supports key sizes of 2048 bits or more. Users should validate that key sizes are appropriate
+        /// for their use-case.
         public init(n: some ContiguousBytes, e: some ContiguousBytes, d: some ContiguousBytes, p: some ContiguousBytes, q: some ContiguousBytes) throws {
             self.backing = try BackingPrivateKey(n: n, e: e, d: d, p: p, q: q)
+            guard self.keySizeInBits >= 2048 else {
+                throw CryptoKitError.incorrectParameterSize
+            }
         }
 
         /// Randomly generate a new RSA private key of a given size.

--- a/Sources/CryptoExtras/RSA/RSA_boring.swift
+++ b/Sources/CryptoExtras/RSA/RSA_boring.swift
@@ -222,17 +222,17 @@ extension BoringSSLRSAPublicKey {
             self.pointer = pointer
         }
 
-        fileprivate init(copying other: Backing) {
-            self.pointer = CCryptoBoringSSL_EVP_PKEY_new()
+        fileprivate convenience init(copying other: Backing) {
+            self.init(takingOwnershipOf: CCryptoBoringSSL_EVP_PKEY_new())
             let rsaPublicKey = CCryptoBoringSSL_RSAPublicKey_dup(
                 CCryptoBoringSSL_EVP_PKEY_get0_RSA(other.pointer)
             )
             CCryptoBoringSSL_EVP_PKEY_assign_RSA(self.pointer, rsaPublicKey)
         }
 
-        fileprivate init(pemRepresentation: String) throws {
+        fileprivate convenience init(pemRepresentation: String) throws {
+            self.init(takingOwnershipOf: CCryptoBoringSSL_EVP_PKEY_new())
             var pemRepresentation = pemRepresentation
-            self.pointer = CCryptoBoringSSL_EVP_PKEY_new()
 
             // There are two encodings for RSA public keys: PKCS#1 and the SPKI form.
             // The SPKI form is what we support for EC keys, so we try that first, then we
@@ -248,22 +248,18 @@ extension BoringSSLRSAPublicKey {
                 }
                 CCryptoBoringSSL_EVP_PKEY_assign_RSA(self.pointer, rsaPublicKey)
             } catch {
-                do {
-                    let rsaPublicKey = try pemRepresentation.withUTF8 { utf8Ptr in
-                        try BIOHelper.withReadOnlyMemoryBIO(wrapping: utf8Ptr) { bio in
-                            guard let key = CCryptoBoringSSL_PEM_read_bio_RSAPublicKey(bio, nil, nil, nil) else {
-                                throw CryptoKitError.internalBoringSSLError()
-                            }
-                            return key
+                let rsaPublicKey = try pemRepresentation.withUTF8 { utf8Ptr in
+                    try BIOHelper.withReadOnlyMemoryBIO(wrapping: utf8Ptr) { bio in
+                        guard let key = CCryptoBoringSSL_PEM_read_bio_RSAPublicKey(bio, nil, nil, nil) else {
+                            throw CryptoKitError.internalBoringSSLError()
                         }
+                        return key
                     }
-                    CCryptoBoringSSL_EVP_PKEY_assign_RSA(self.pointer, rsaPublicKey)
-                } catch {
-                    CCryptoBoringSSL_EVP_PKEY_free(self.pointer)
-                    throw error
                 }
+                CCryptoBoringSSL_EVP_PKEY_assign_RSA(self.pointer, rsaPublicKey)
             }
         }
+
 
         fileprivate convenience init<Bytes: DataProtocol>(derRepresentation: Bytes) throws {
             if derRepresentation.regions.count == 1 {
@@ -274,8 +270,8 @@ extension BoringSSLRSAPublicKey {
             }
         }
 
-        private init<Bytes: ContiguousBytes>(contiguousDerRepresentation: Bytes) throws {
-            self.pointer = CCryptoBoringSSL_EVP_PKEY_new()
+        private convenience init<Bytes: ContiguousBytes>(contiguousDerRepresentation: Bytes) throws {
+            self.init(takingOwnershipOf: CCryptoBoringSSL_EVP_PKEY_new())
             // There are two encodings for RSA public keys: PKCS#1 and the SPKI form.
             // The SPKI form is what we support for EC keys, so we try that first, then we
             // fall back to the PKCS#1 form if that parse fails.
@@ -290,25 +286,20 @@ extension BoringSSLRSAPublicKey {
                 }
                 CCryptoBoringSSL_EVP_PKEY_assign_RSA(self.pointer, rsaPublicKey)
             } catch {
-                do {
-                    let rsaPublicKey = try contiguousDerRepresentation.withUnsafeBytes { derPtr in
-                        try BIOHelper.withReadOnlyMemoryBIO(wrapping: derPtr) { bio in
-                            guard let key = CCryptoBoringSSL_d2i_RSAPublicKey_bio(bio, nil) else {
-                                throw CryptoKitError.internalBoringSSLError()
-                            }
-                            return key
+                let rsaPublicKey = try contiguousDerRepresentation.withUnsafeBytes { derPtr in
+                    try BIOHelper.withReadOnlyMemoryBIO(wrapping: derPtr) { bio in
+                        guard let key = CCryptoBoringSSL_d2i_RSAPublicKey_bio(bio, nil) else {
+                            throw CryptoKitError.internalBoringSSLError()
                         }
+                        return key
                     }
-                    CCryptoBoringSSL_EVP_PKEY_assign_RSA(self.pointer, rsaPublicKey)
-                } catch {
-                    CCryptoBoringSSL_EVP_PKEY_free(self.pointer)
-                    throw error
                 }
+                CCryptoBoringSSL_EVP_PKEY_assign_RSA(self.pointer, rsaPublicKey)
             }
         }
 
-        fileprivate init(n: some ContiguousBytes, e: some ContiguousBytes) throws {
-            self.pointer = CCryptoBoringSSL_EVP_PKEY_new()
+        fileprivate convenience init(n: some ContiguousBytes, e: some ContiguousBytes) throws {
+            self.init(takingOwnershipOf: CCryptoBoringSSL_EVP_PKEY_new())
             let n = try ArbitraryPrecisionInteger(bytes: n)
             let e = try ArbitraryPrecisionInteger(bytes: e)
 

--- a/Sources/CryptoExtras/RSA/RSA_boring.swift
+++ b/Sources/CryptoExtras/RSA/RSA_boring.swift
@@ -77,6 +77,10 @@ internal struct BoringSSLRSAPublicKey: Sendable {
         self.backing.keySizeInBits
     }
 
+    var modulusByteCount: Int {
+        self.backing.modulusByteCount
+    }
+
     fileprivate init(_ backing: Backing) {
         self.backing = backing
     }
@@ -345,7 +349,12 @@ extension BoringSSLRSAPublicKey {
 
         fileprivate var keySizeInBits: Int {
             let rsaPublicKey = CCryptoBoringSSL_EVP_PKEY_get0_RSA(self.pointer)
-            return Int(CCryptoBoringSSL_RSA_size(rsaPublicKey)) * 8
+            return Int(CCryptoBoringSSL_RSA_bits(rsaPublicKey))
+        }
+
+        fileprivate var modulusByteCount: Int {
+            let rsaPublicKey = CCryptoBoringSSL_EVP_PKEY_get0_RSA(self.pointer)
+            return Int(CCryptoBoringSSL_RSA_size(rsaPublicKey))
         }
 
         fileprivate func isValidSignature<D: Digest>(
@@ -457,7 +466,6 @@ extension BoringSSLRSAPublicKey {
             parameters: _RSA.BlindSigning.Parameters<H>
         ) throws -> _RSA.BlindSigning.BlindingResult {
             let rsaPublicKey = CCryptoBoringSSL_EVP_PKEY_get0_RSA(self.pointer)
-            let modulusByteCount = Int(CCryptoBoringSSL_RSA_size(rsaPublicKey))
             let e = try ArbitraryPrecisionInteger(copying: CCryptoBoringSSL_RSA_get0_e(rsaPublicKey))
             let n = try ArbitraryPrecisionInteger(copying: CCryptoBoringSSL_RSA_get0_n(rsaPublicKey))
             let finiteField = try FiniteFieldArithmeticContext(fieldSize: n)
@@ -515,7 +523,6 @@ extension BoringSSLRSAPublicKey {
             parameters: _RSA.BlindSigning.Parameters<H>
         ) throws -> _RSA.Signing.RSASignature {
             let rsaPublicKey = CCryptoBoringSSL_EVP_PKEY_get0_RSA(self.pointer)
-            let modulusByteCount = Int(CCryptoBoringSSL_RSA_size(rsaPublicKey))
             let n = try ArbitraryPrecisionInteger(copying: CCryptoBoringSSL_RSA_get0_n(rsaPublicKey))
             let finiteField = try FiniteFieldArithmeticContext(fieldSize: n)
 
@@ -815,7 +822,7 @@ extension BoringSSLRSAPrivateKey {
 
         fileprivate var keySizeInBits: Int {
             let rsaPrivateKey = CCryptoBoringSSL_EVP_PKEY_get0_RSA(self.pointer)
-            return Int(CCryptoBoringSSL_RSA_size(rsaPrivateKey)) * 8
+            return Int(CCryptoBoringSSL_RSA_bits(rsaPrivateKey))
         }
 
         fileprivate var publicKey: BoringSSLRSAPublicKey {

--- a/Sources/CryptoExtras/RSA/RSA_boring.swift
+++ b/Sources/CryptoExtras/RSA/RSA_boring.swift
@@ -260,7 +260,6 @@ extension BoringSSLRSAPublicKey {
             }
         }
 
-
         fileprivate convenience init<Bytes: DataProtocol>(derRepresentation: Bytes) throws {
             if derRepresentation.regions.count == 1 {
                 try self.init(contiguousDerRepresentation: derRepresentation.regions.first!)

--- a/Tests/CryptoExtrasTests/AES_CBCTests.swift
+++ b/Tests/CryptoExtrasTests/AES_CBCTests.swift
@@ -163,6 +163,85 @@ final class CBCTests: XCTestCase {
         }
     }
 
+    func testDecryptRejectsPaddingLengthGreaterThanBlockSize() throws {
+        // A plaintext whose final block claims a PKCS#7 pad length of 17 (0x11)
+        // is invalid for a 16-byte block: the maximum valid PKCS#7 pad is one
+        // full block (16). Correct unpadding must reject it. Regression guard:
+        // the previous `trimPadding` accepted any pad length up to 255 and
+        // scanned across blocks, so it wrongly stripped 17 bytes here.
+        let key = SymmetricKey(data: try Data(hexString: "b6fc08df9b778d11850356b8bfc9561a"))
+        let iv = try AES._CBC.IV(ivBytes: Array(hexString: "00000000000000000000000000000000"))
+
+        // 32-byte (block-multiple) plaintext ending in 17 bytes of 0x11.
+        var plaintext = Data(repeating: 0xAB, count: 15)
+        plaintext.append(Data(repeating: 0x11, count: 17))
+        precondition(plaintext.count == 32)
+
+        let ciphertext = try AES._CBC.encrypt(plaintext, using: key, iv: iv, noPadding: true)
+
+        XCTAssertThrowsError(
+            try AES._CBC.decrypt(ciphertext, using: key, iv: iv, noPadding: false)
+        ) { error in
+            guard let error = error as? CryptoKitError, case .incorrectParameterSize = error else {
+                XCTFail("Unexpected error: \(error)")
+                return
+            }
+        }
+    }
+
+    func testUnpadAcceptsAllValidPaddingLengths() throws {
+        let key = SymmetricKey(data: try Data(hexString: "b6fc08df9b778d11850356b8bfc9561a"))
+        let iv = try AES._CBC.IV(ivBytes: Array(hexString: "00000000000000000000000000000000"))
+
+        // For every valid PKCS#7 pad length (1...16), round-trip a message that
+        // pads to exactly that length and assert exact recovery.
+        for padLength in 1...16 {
+            let messageLength = 32 - padLength  // pads to 32 bytes (two blocks)
+            let message = Data((0..<messageLength).map { UInt8(truncatingIfNeeded: $0) })
+
+            let ciphertext = try AES._CBC.encrypt(message, using: key, iv: iv, noPadding: false)
+            let decrypted = try AES._CBC.decrypt(ciphertext, using: key, iv: iv, noPadding: false)
+            XCTAssertEqual(decrypted, message, "round-trip failed for pad length \(padLength)")
+        }
+    }
+
+    func testUnpadRejectsCorruptedPaddingByte() throws {
+        let key = SymmetricKey(data: try Data(hexString: "b6fc08df9b778d11850356b8bfc9561a"))
+        let iv = try AES._CBC.IV(ivBytes: Array(hexString: "00000000000000000000000000000000"))
+
+        // Build a validly-padded block-multiple plaintext, then corrupt each
+        // padding byte except the last (which encodes the claimed length). The
+        // constant-time scan must reject a mismatch at any position.
+        for padLength in 2...16 {
+            var padded = Data((0..<(32 - padLength)).map { UInt8(truncatingIfNeeded: $0) })
+            padded.append(Data(repeating: UInt8(padLength), count: padLength))
+            precondition(padded.count == 32)
+
+            for position in (32 - padLength)..<31 {
+                var corrupted = padded
+                corrupted[position] = UInt8(padLength) ^ 0xFF  // guaranteed != padLength
+                let ciphertext = try AES._CBC.encrypt(corrupted, using: key, iv: iv, noPadding: true)
+
+                XCTAssertThrowsError(
+                    try AES._CBC.decrypt(ciphertext, using: key, iv: iv, noPadding: false),
+                    "corruption at pad length \(padLength), position \(position) was not rejected"
+                )
+            }
+        }
+    }
+
+    func testUnpadRejectsZeroPaddingLength() throws {
+        let key = SymmetricKey(data: try Data(hexString: "b6fc08df9b778d11850356b8bfc9561a"))
+        let iv = try AES._CBC.IV(ivBytes: Array(hexString: "00000000000000000000000000000000"))
+
+        // A final byte of 0x00 claims a pad length of zero, which is invalid PKCS#7.
+        var padded = Data((0..<31).map { UInt8(truncatingIfNeeded: $0) })
+        padded.append(0x00)
+        let ciphertext = try AES._CBC.encrypt(padded, using: key, iv: iv, noPadding: true)
+
+        XCTAssertThrowsError(try AES._CBC.decrypt(ciphertext, using: key, iv: iv, noPadding: false))
+    }
+
     func testToDataConversion() throws {
         let randomBytes = (0..<16).map { _ in UInt8.random(in: UInt8.min...UInt8.max) }
         let dataIn = Data(randomBytes)

--- a/Tests/CryptoExtrasTests/TestRSABlindSigning.swift
+++ b/Tests/CryptoExtrasTests/TestRSABlindSigning.swift
@@ -201,6 +201,17 @@ final class TestRSABlindSigning: XCTestCase {
             e: bytesValues.randomElement()!,
             parameters: .RSABSSA_SHA384_PSS_Randomized
         )
+        // Modulus of a 512-bit key: `openssl rsa -in key.pem -noout -modulus`.
+        let _512BitModulus =
+            "e24c4c2c70e673315c2420b0e211542bbccf5b79f2ce6bdaa4aac29650bd064b"
+            + "955ae1613a449c7143e906d7f251e49356771d9d6f8f15bcf4044f87de1c1bed"
+        XCTAssertThrowsError(
+            try _RSA.BlindSigning.PublicKey(
+                n: Data(hexString: _512BitModulus),
+                e: Data(hexString: "010001"),
+                parameters: .RSABSSA_SHA384_PSS_Randomized
+            )
+        )
     }
 
     func testConstructAndUseKeyFromRSANumbersWhileRecoveringPrimes() throws {

--- a/Tests/CryptoExtrasTests/TestRSAEncryption.swift
+++ b/Tests/CryptoExtrasTests/TestRSAEncryption.swift
@@ -111,6 +111,13 @@ final class TestRSAEncryption: XCTestCase {
             n: bytesValues.randomElement()!,
             e: bytesValues.randomElement()!
         )
+        // Modulus of a 512-bit key: `openssl rsa -in key.pem -noout -modulus`.
+        let _512BitModulus =
+            "e24c4c2c70e673315c2420b0e211542bbccf5b79f2ce6bdaa4aac29650bd064b"
+            + "955ae1613a449c7143e906d7f251e49356771d9d6f8f15bcf4044f87de1c1bed"
+        XCTAssertThrowsError(
+            try _RSA.Encryption.PublicKey(n: Data(hexString: _512BitModulus), e: Data(hexString: "010001"))
+        )
     }
 
     func testConstructAndUseKeyFromRSANumbersWhileRecoveringPrimes() throws {

--- a/Tests/CryptoExtrasTests/TestRSAEncryption.swift
+++ b/Tests/CryptoExtrasTests/TestRSAEncryption.swift
@@ -170,6 +170,77 @@ final class TestRSAEncryption: XCTestCase {
         XCTAssertEqual(190, pubKey2048.maximumEncryptSize(with: .PKCS1_OAEP_SHA256))
     }
 
+    // The encryption key initializers require the modulus bit length to be a multiple of 8.
+    func testRejectKeysWithNonByteAlignedModulus() throws {
+        // Equivalent key: `openssl genrsa -traditional 2050`, converted to the encodings below.
+        let _2050BitRSAPrivateKeyPEM = """
+            -----BEGIN RSA PRIVATE KEY-----
+            MIIEpAIBAAKCAQECxVSlteS7/eN5dXzn+RdyApV8JJILQaXaZOgxl/FELWhXq4lY
+            Uk6+0keFtdLvSsdsBAZlq7VT8vHyfxqhcpb0RkjThWfVhR2BjzO8TNLA+mlKGKZJ
+            foTE3r7o99Ev4X+H4QxCyAC8oyAKy1lyDA4wT7OFBBXtXJmeQ/PbYCuMMyqrCWUg
+            VL48rK150QxHQ0U9XsGCnF70X/PMPebKY60OS36pTYhmi77h0maiY4yW2kHNfgeG
+            Mbc3XQ19Sr42f5zKe0AIQfzK91v6M5PaEIpJAfm+JPDNWf2+RKEVa93gNiuTZ2+p
+            gUjf7ut8mY5MEn7fZhCeZeNBjNTuKXj3JqdP3wIDAQABAoIBAQC252vPakq7XeOc
+            0vdx+ISye99GAs6aP+z/pgvbtR+yYbxxg/ndR2bXDBBDYT/I1YFZzFh9HUWnWJIC
+            CljlFl2onfDE7pBVQdV9moaMfK+8Ilgz4PUEhbHKCgpClJM3H05nTmUN83qwyXtf
+            EhJhX2s/sfezpP/Op+HyfbfspW4CZrrJmv1zfqIjDiV7LMaoDDU+UDHexcgwoXCa
+            HKC/U7RcbNYE3hOg/Fjx+nevprXthhf8mpnkAzTcpXsMcATuvh7sSqdFnHkF9egw
+            CBnlx+iH9J/6Q3VwoZgwggi9S6qT5yrS0/JVWVic4KaiE81dDr+KLmXIpOFRNuYf
+            8sP79cfRAoGBAcwBZ+XfX5H8Ii7tSjCJWJ+sw6cevH4YQhYWDEgodsmzj2hDRoRj
+            EaGdATP5dry7RWePTuhN0KlvMYX/xI2kvoRrK6sR4bad0V2J8lKBFxAil55w531L
+            wZUAhxzAChWZ6uRMR694yati/8wIG+BMdwBPA+00+pMH2Kd9HGN8xoBHAoGBAYrA
+            0sfOCNqvkf7OsoiShjSdeTYkTqjHrVR7m6DJg2FUL6E9VnaSLG0esnAYGAozKfFl
+            rQz7gEGckMG2dILOAY9z3wv4ltX12RxmAJMHoO/ENDVxiqSKC7utiKzcii9qy626
+            RIuAvOwSOeU25VVTOzOm35wabuLAThMYBqdYl9epAoGAYsWKgZlM9BOnY1wgKfvT
+            w7Vc7W10G78psYRabsQBfZ3IlSKc6aA8EO+daoOOM0gixvHGh6rtuvPdNmCM270c
+            C2LXpYvZY1TPt73/Aiglw5kp5SNpEUZK8quCV3IEuE6sWQjn+418AAjp0+2Jzsec
+            ZbyRo0VU6G0u4AfFKLeKB9ECgYAURk8NIBHoWXggJDGbPhtSfHwLQdYgaREH88lM
+            es0apJ5Fo8bbFCrf9+GmTDZ/35zZ3yUCM7CkrgvpRxu41CfUXFkqXjwxBQ1/neWN
+            p6imZ+dej1RVmxl7LDCG4FTglpWbeKOonpYVceIzWZxxw3KY9ospk1n6n3HjHSrK
+            UYyK8QKBgQDWsxq+0VhPgMRDUKg2p1gdnluX9I5lmZVwy1No6QfChJUo/RCRYcIe
+            jLXlpoAW9UUR5JCx3/hKyKvbl34J/LV3Tc/63vHxOGnh8eAySyCcpFJFmyciIZdY
+            iRLB6wzq+zLIZkK7+5TdHCZ9jIi5oKyk2YDT6LSTUnuG9DlGpcSmqA==
+            -----END RSA PRIVATE KEY-----
+            """
+
+        let _2050BitRSAPublicKeyPEM = """
+            -----BEGIN PUBLIC KEY-----
+            MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQECxVSlteS7/eN5dXzn+Rdy
+            ApV8JJILQaXaZOgxl/FELWhXq4lYUk6+0keFtdLvSsdsBAZlq7VT8vHyfxqhcpb0
+            RkjThWfVhR2BjzO8TNLA+mlKGKZJfoTE3r7o99Ev4X+H4QxCyAC8oyAKy1lyDA4w
+            T7OFBBXtXJmeQ/PbYCuMMyqrCWUgVL48rK150QxHQ0U9XsGCnF70X/PMPebKY60O
+            S36pTYhmi77h0maiY4yW2kHNfgeGMbc3XQ19Sr42f5zKe0AIQfzK91v6M5PaEIpJ
+            Afm+JPDNWf2+RKEVa93gNiuTZ2+pgUjf7ut8mY5MEn7fZhCeZeNBjNTuKXj3JqdP
+            3wIDAQAB
+            -----END PUBLIC KEY-----
+            """
+
+        XCTAssertThrowsError(try _RSA.Encryption.PrivateKey(pemRepresentation: _2050BitRSAPrivateKeyPEM))
+        XCTAssertThrowsError(try _RSA.Encryption.PrivateKey(unsafePEMRepresentation: _2050BitRSAPrivateKeyPEM))
+        XCTAssertThrowsError(try _RSA.Encryption.PublicKey(pemRepresentation: _2050BitRSAPublicKeyPEM))
+        XCTAssertThrowsError(try _RSA.Encryption.PublicKey(unsafePEMRepresentation: _2050BitRSAPublicKeyPEM))
+    }
+
+    // The raw number encryption key initializers do not require the key  modulus bit length to be a multiple of 8.
+    func testMaximumEncryptSizeWithNonByteAlignedModulus() throws {
+        // Modulus of a 2050-bit key: `openssl rsa -in key.pem -noout -modulus`.
+        let _2050BitModulus = Data(
+            base64Encoded:
+                "AsVUpbXku/3jeXV85/kXcgKVfCSSC0Gl2mToMZfxRC1oV6uJWFJOvtJHhbX" +
+                "S70rHbAQGZau1U/Lx8n8aoXKW9EZI04Vn1YUdgY8zvEzSwPppShimSX6ExN" +
+                "6+6PfRL+F/h+EMQsgAvKMgCstZcgwOME+zhQQV7VyZnkPz22ArjDMqqwllI" +
+                "FS+PKytedEMR0NFPV7Bgpxe9F/zzD3mymOtDkt+qU2IZou+4dJmomOMltpB" +
+                "zX4HhjG3N10NfUq+Nn+cyntACEH8yvdb+jOT2hCKSQH5viTwzVn9vkShFWv" +
+                "d4DYrk2dvqYFI3+7rfJmOTBJ+32YQnmXjQYzU7il49yanT98="
+        )!
+        let publicExponent = Data(base64Encoded: "AQAB")!
+
+        let publicKey = try _RSA.Encryption.PublicKey(n: _2050BitModulus, e: publicExponent)
+        XCTAssertEqual(2050, publicKey.keySizeInBits)
+        XCTAssertEqual(215, publicKey.maximumEncryptSize(with: .PKCS1_OAEP))
+        XCTAssertEqual(191, publicKey.maximumEncryptSize(with: .PKCS1_OAEP_SHA256))
+    }
+
     func testPKCS1() throws {
         let pubKeyPEM = """
             -----BEGIN RSA PUBLIC KEY-----

--- a/Tests/CryptoExtrasTests/TestRSASigning.swift
+++ b/Tests/CryptoExtrasTests/TestRSASigning.swift
@@ -361,8 +361,10 @@ final class TestRSASigning: XCTestCase {
         try XCTAssertThrowsError((_RSA.Signing.PrivateKey(keySize: .init(bitCount: 1024)), 1024))
     }
 
-    func testRejectSmallKeys() throws {
-        let smallRSAPrivateKeyPEM = """
+    // The default initializers require a modulus of at least 2048 bits.
+    func testRejectKeysBelow2048BitMinimum() throws {
+        // Equivalent key: `openssl genrsa -traditional 512`, converted to the encodings below.
+        let _512BitRSAPrivateKeyPEM = """
         -----BEGIN RSA PRIVATE KEY-----
         MIIBPAIBAAJBAOJMTCxw5nMxXCQgsOIRVCu8z1t58s5r2qSqwpZQvQZLlVrhYTpE
         nHFD6QbX8lHkk1Z3HZ1vjxW89ARPh94cG+0CAwEAAQJBAMdmOVyTYswvuyPuVk3s
@@ -374,14 +376,14 @@ final class TestRSASigning: XCTestCase {
         -----END RSA PRIVATE KEY-----
         """
 
-        let smallRSAPublicKeyPEM = """
+        let _512BitRSAPublicKeyPEM = """
         -----BEGIN PUBLIC KEY-----
         MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAOJMTCxw5nMxXCQgsOIRVCu8z1t58s5r
         2qSqwpZQvQZLlVrhYTpEnHFD6QbX8lHkk1Z3HZ1vjxW89ARPh94cG+0CAwEAAQ==
         -----END PUBLIC KEY-----
         """
 
-        let smallRSAPrivateKeyPKCS8PEM = """
+        let _512BitRSAPrivateKeyPKCS8PEM = """
         -----BEGIN PRIVATE KEY-----
         MIIBVgIBADANBgkqhkiG9w0BAQEFAASCAUAwggE8AgEAAkEA4kxMLHDmczFcJCCw
         4hFUK7zPW3nyzmvapKrCllC9BkuVWuFhOkSccUPpBtfyUeSTVncdnW+PFbz0BE+H
@@ -394,7 +396,7 @@ final class TestRSASigning: XCTestCase {
         -----END PRIVATE KEY-----
         """
 
-        let smallRSAPrivateKeyDER = Data(base64Encoded:
+        let _512BitRSAPrivateKeyDER = Data(base64Encoded:
             "MIIBPAIBAAJBAOJMTCxw5nMxXCQgsOIRVCu8z1t58s5r2qSqwpZQvQZLlVr" +
             "hYTpEnHFD6QbX8lHkk1Z3HZ1vjxW89ARPh94cG+0CAwEAAQJBAMdmOVyTYs" +
             "wvuyPuVk3svQEJDqFpFATFTlP4TxuKKvTmbdQuVCorMmLLKThDI3pDNWKuA" +
@@ -405,7 +407,7 @@ final class TestRSASigning: XCTestCase {
             "7MWbrFpUouirbQ="
         )!
 
-        let smallRSAPrivateKeyPKCS8DER = Data(base64Encoded:
+        let _512BitRSAPrivateKeyPKCS8DER = Data(base64Encoded:
             "MIIBVgIBADANBgkqhkiG9w0BAQEFAASCAUAwggE8AgEAAkEA4kxMLHDmczF" +
             "cJCCw4hFUK7zPW3nyzmvapKrCllC9BkuVWuFhOkSccUPpBtfyUeSTVncdnW" +
             "+PFbz0BE+H3hwb7QIDAQABAkEAx2Y5XJNizC+7I+5WTey9AQkOoWkUBMVOU" +
@@ -416,18 +418,282 @@ final class TestRSASigning: XCTestCase {
             "w8CIQCNHhOCOnp3lmwZQr0gcaw1Y/XJKtqDsxZusWlSi6KttA=="
         )!
 
-        let smallRSAPublicKeyDER = Data(base64Encoded:
+        let _512BitRSAPublicKeyDER = Data(base64Encoded:
             "MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAOJMTCxw5nMxXCQgsOIRVCu8z1t" +
             "58s5r2qSqwpZQvQZLlVrhYTpEnHFD6QbX8lHkk1Z3HZ1vjxW89ARPh94cG+" +
             "0CAwEAAQ=="
         )!
 
-        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(pemRepresentation: smallRSAPrivateKeyPEM))
-        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(pemRepresentation: smallRSAPrivateKeyPKCS8PEM))
-        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(derRepresentation: smallRSAPrivateKeyDER))
-        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(derRepresentation: smallRSAPrivateKeyPKCS8DER))
-        XCTAssertThrowsError(try _RSA.Signing.PublicKey(pemRepresentation: smallRSAPublicKeyPEM))
-        XCTAssertThrowsError(try _RSA.Signing.PublicKey(derRepresentation: smallRSAPublicKeyDER))
+        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(pemRepresentation: _512BitRSAPrivateKeyPEM))
+        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(pemRepresentation: _512BitRSAPrivateKeyPKCS8PEM))
+        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(derRepresentation: _512BitRSAPrivateKeyDER))
+        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(derRepresentation: _512BitRSAPrivateKeyPKCS8DER))
+        XCTAssertThrowsError(try _RSA.Signing.PublicKey(pemRepresentation: _512BitRSAPublicKeyPEM))
+        XCTAssertThrowsError(try _RSA.Signing.PublicKey(derRepresentation: _512BitRSAPublicKeyDER))
+
+        // Generated via `openssl genrsa -traditional 2047`, then converted to the encodings below.
+        let _2047BitRSAPrivateKeyPEM = """
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEoAIBAAKCAQBXog86uwpuCobeXXokHAePMu15O2Cwfvwx7/EzZl6jY70ConNX
+        mzR5U39kQQpFa0dxRQdgUA8YpU5/8aILp3Yv0S2BssiuqdL5IkzdBzLNRhSQabuM
+        +vyCQjImHF/bA28+5DKJ9uzIhywA9JS2o/4TtE6mLqWbFAY+dM716llarKJgzLh/
+        Vg0mH6H5vDoo4D6z+M2jQRiUbV+yIiiaY8/SMyLltsZeEl/hx/NyACPSUAClVlsj
+        vRRZzQl8oDybMVvUAbrIwR+ZVQltdqVgx5zVf8G3BHi7lUdyqxIt0QWQRBTTd1tY
+        sSOKmVhYB+DvPv2IJKGXqKo+XKQBLmm9UIuxAgMBAAECggEAN/6hZJGnNHEdhHCO
+        XwxZ+DI+czxxp9U8KFx87q72wcg1Ob27nbraaLvlppW4jmriF4pYED6XptPZuP8Y
+        4AF9D0jFnx4yBQkWeYJlQsYau/ePpEcrRAYL2t+ZU6jFxxgGuVTuxiE1Y1ybzXB6
+        pclbzBNmPeGIh/LfmoDgzVmVBs6FhBrl8z+eWciISgskTaESkboiV+HAzDBJ23gP
+        LD0fjk69Dw75MS7QHBYm5jDIpXFvh+nPJOfwIAuaEQ9ZaF3Uh8zjBOyhtOSO9cdV
+        wXME4sIvA7IqlGoacxUtjyoWarPqk/V4UWl7/Q8gZlRagqjaJ+DqpqrD6UFCxwvw
+        KCyJ0QKBgQDTV7joBHuuw/RuDe8VwxUuRJTIcdrn6g2Kn3CxV9YLJhxr1doEmw3Y
+        DASY7zddkgJjssbkub5FhySAlqOIz5ok62erHMsyC90VXqWDC1uFHW6EQh/N/S/A
+        vgEuyIJ/dtxXYLFyozm0Az98A37nGGTSt9tphKsTPiHS1jOB3f9DbwKBgGomcW7T
+        Slq0+VSGniD+ciB71UMrW9FcF9qsnTPXQGZV4JqpLvE/tEq7uyr/Dp6l3mstVmtL
+        tBjkPef32oz3JXo32IWS37VZlu+3I2v7VQThFLnc3F0KUcZmH1Uy1my8itjP6jIf
+        wNwiUObilCubgiGEVxfMb0G7juMETZYyuRLfAoGAVwIFcRfvZ4rrBagc5yOyg6Le
+        cgtVqSbVvl1Xwts7lslw6ABZyo2fTHPeLKxHafFjpHIEqkPCDtPNdlcOKpP1jP+R
+        ZYPsL8VslpCpqWKyogH07uReParfzwUqbX1FJH7lxd9cDqseZXr01vSFeVS0pX/m
+        B/IDkF+DA08GU4/2uGcCgYAV1CP9e1vN/WtMc4ZvGIQVpAF+F5uBGSQapuaI85nd
+        sYlHpMTvfX8w4xwhQmQaQdfUSHV+CQpXGBCW9EQwOt6tHHDdPw/b9jlwwEN7gCrC
+        nxqpAf8a7vVUDEojNhocMEWJQnBRsG/zlOb4I93+fbMr+1ABp9u1M8G1c3wVCAdB
+        FwKBgF8sJlG58EKSfdvhVNDRq4hC/yjcI6987rg2fmeX9QUYiwReniaesEoBdeHz
+        OYWR3DtC5SNiDKuj7QmnRvNcbFwBz5dGOdiXytRtLkpwDArY/hV/hqeSH1nHU0fp
+        LUScnTZr95HkLFIle1JCFXw0viGHKEBkdFvcuXIFON9KNTA/
+        -----END RSA PRIVATE KEY-----
+        """
+
+        let _2047BitRSAPublicKeyPEM = """
+        -----BEGIN PUBLIC KEY-----
+        MIIBITANBgkqhkiG9w0BAQEFAAOCAQ4AMIIBCQKCAQBXog86uwpuCobeXXokHAeP
+        Mu15O2Cwfvwx7/EzZl6jY70ConNXmzR5U39kQQpFa0dxRQdgUA8YpU5/8aILp3Yv
+        0S2BssiuqdL5IkzdBzLNRhSQabuM+vyCQjImHF/bA28+5DKJ9uzIhywA9JS2o/4T
+        tE6mLqWbFAY+dM716llarKJgzLh/Vg0mH6H5vDoo4D6z+M2jQRiUbV+yIiiaY8/S
+        MyLltsZeEl/hx/NyACPSUAClVlsjvRRZzQl8oDybMVvUAbrIwR+ZVQltdqVgx5zV
+        f8G3BHi7lUdyqxIt0QWQRBTTd1tYsSOKmVhYB+DvPv2IJKGXqKo+XKQBLmm9UIux
+        AgMBAAE=
+        -----END PUBLIC KEY-----
+        """
+
+        let _2047BitRSAPrivateKeyPKCS8PEM = """
+        -----BEGIN PRIVATE KEY-----
+        MIIEugIBADANBgkqhkiG9w0BAQEFAASCBKQwggSgAgEAAoIBAFeiDzq7Cm4Kht5d
+        eiQcB48y7Xk7YLB+/DHv8TNmXqNjvQKic1ebNHlTf2RBCkVrR3FFB2BQDxilTn/x
+        ogundi/RLYGyyK6p0vkiTN0HMs1GFJBpu4z6/IJCMiYcX9sDbz7kMon27MiHLAD0
+        lLaj/hO0TqYupZsUBj50zvXqWVqsomDMuH9WDSYfofm8OijgPrP4zaNBGJRtX7Ii
+        KJpjz9IzIuW2xl4SX+HH83IAI9JQAKVWWyO9FFnNCXygPJsxW9QBusjBH5lVCW12
+        pWDHnNV/wbcEeLuVR3KrEi3RBZBEFNN3W1ixI4qZWFgH4O8+/YgkoZeoqj5cpAEu
+        ab1Qi7ECAwEAAQKCAQA3/qFkkac0cR2EcI5fDFn4Mj5zPHGn1TwoXHzurvbByDU5
+        vbudutpou+WmlbiOauIXilgQPpem09m4/xjgAX0PSMWfHjIFCRZ5gmVCxhq794+k
+        RytEBgva35lTqMXHGAa5VO7GITVjXJvNcHqlyVvME2Y94YiH8t+agODNWZUGzoWE
+        GuXzP55ZyIhKCyRNoRKRuiJX4cDMMEnbeA8sPR+OTr0PDvkxLtAcFibmMMilcW+H
+        6c8k5/AgC5oRD1loXdSHzOME7KG05I71x1XBcwTiwi8DsiqUahpzFS2PKhZqs+qT
+        9XhRaXv9DyBmVFqCqNon4OqmqsPpQULHC/AoLInRAoGBANNXuOgEe67D9G4N7xXD
+        FS5ElMhx2ufqDYqfcLFX1gsmHGvV2gSbDdgMBJjvN12SAmOyxuS5vkWHJICWo4jP
+        miTrZ6scyzIL3RVepYMLW4UdboRCH839L8C+AS7Ign923FdgsXKjObQDP3wDfucY
+        ZNK322mEqxM+IdLWM4Hd/0NvAoGAaiZxbtNKWrT5VIaeIP5yIHvVQytb0VwX2qyd
+        M9dAZlXgmqku8T+0Sru7Kv8OnqXeay1Wa0u0GOQ95/fajPclejfYhZLftVmW77cj
+        a/tVBOEUudzcXQpRxmYfVTLWbLyK2M/qMh/A3CJQ5uKUK5uCIYRXF8xvQbuO4wRN
+        ljK5Et8CgYBXAgVxF+9niusFqBznI7KDot5yC1WpJtW+XVfC2zuWyXDoAFnKjZ9M
+        c94srEdp8WOkcgSqQ8IO0812Vw4qk/WM/5Flg+wvxWyWkKmpYrKiAfTu5F49qt/P
+        BSptfUUkfuXF31wOqx5levTW9IV5VLSlf+YH8gOQX4MDTwZTj/a4ZwKBgBXUI/17
+        W839a0xzhm8YhBWkAX4Xm4EZJBqm5ojzmd2xiUekxO99fzDjHCFCZBpB19RIdX4J
+        ClcYEJb0RDA63q0ccN0/D9v2OXDAQ3uAKsKfGqkB/xru9VQMSiM2GhwwRYlCcFGw
+        b/OU5vgj3f59syv7UAGn27UzwbVzfBUIB0EXAoGAXywmUbnwQpJ92+FU0NGriEL/
+        KNwjr3zuuDZ+Z5f1BRiLBF6eJp6wSgF14fM5hZHcO0LlI2IMq6PtCadG81xsXAHP
+        l0Y52JfK1G0uSnAMCtj+FX+Gp5IfWcdTR+ktRJydNmv3keQsUiV7UkIVfDS+IYco
+        QGR0W9y5cgU430o1MD8=
+        -----END PRIVATE KEY-----
+        """
+
+        let _2047BitRSAPrivateKeyDER = Data(base64Encoded:
+            "MIIEoAIBAAKCAQBXog86uwpuCobeXXokHAePMu15O2Cwfvwx7/EzZl6jY70" +
+            "ConNXmzR5U39kQQpFa0dxRQdgUA8YpU5/8aILp3Yv0S2BssiuqdL5IkzdBz" +
+            "LNRhSQabuM+vyCQjImHF/bA28+5DKJ9uzIhywA9JS2o/4TtE6mLqWbFAY+d" +
+            "M716llarKJgzLh/Vg0mH6H5vDoo4D6z+M2jQRiUbV+yIiiaY8/SMyLltsZe" +
+            "El/hx/NyACPSUAClVlsjvRRZzQl8oDybMVvUAbrIwR+ZVQltdqVgx5zVf8G" +
+            "3BHi7lUdyqxIt0QWQRBTTd1tYsSOKmVhYB+DvPv2IJKGXqKo+XKQBLmm9UI" +
+            "uxAgMBAAECggEAN/6hZJGnNHEdhHCOXwxZ+DI+czxxp9U8KFx87q72wcg1O" +
+            "b27nbraaLvlppW4jmriF4pYED6XptPZuP8Y4AF9D0jFnx4yBQkWeYJlQsYa" +
+            "u/ePpEcrRAYL2t+ZU6jFxxgGuVTuxiE1Y1ybzXB6pclbzBNmPeGIh/LfmoD" +
+            "gzVmVBs6FhBrl8z+eWciISgskTaESkboiV+HAzDBJ23gPLD0fjk69Dw75MS" +
+            "7QHBYm5jDIpXFvh+nPJOfwIAuaEQ9ZaF3Uh8zjBOyhtOSO9cdVwXME4sIvA" +
+            "7IqlGoacxUtjyoWarPqk/V4UWl7/Q8gZlRagqjaJ+DqpqrD6UFCxwvwKCyJ" +
+            "0QKBgQDTV7joBHuuw/RuDe8VwxUuRJTIcdrn6g2Kn3CxV9YLJhxr1doEmw3" +
+            "YDASY7zddkgJjssbkub5FhySAlqOIz5ok62erHMsyC90VXqWDC1uFHW6EQh" +
+            "/N/S/AvgEuyIJ/dtxXYLFyozm0Az98A37nGGTSt9tphKsTPiHS1jOB3f9Db" +
+            "wKBgGomcW7TSlq0+VSGniD+ciB71UMrW9FcF9qsnTPXQGZV4JqpLvE/tEq7" +
+            "uyr/Dp6l3mstVmtLtBjkPef32oz3JXo32IWS37VZlu+3I2v7VQThFLnc3F0" +
+            "KUcZmH1Uy1my8itjP6jIfwNwiUObilCubgiGEVxfMb0G7juMETZYyuRLfAo" +
+            "GAVwIFcRfvZ4rrBagc5yOyg6LecgtVqSbVvl1Xwts7lslw6ABZyo2fTHPeL" +
+            "KxHafFjpHIEqkPCDtPNdlcOKpP1jP+RZYPsL8VslpCpqWKyogH07uReParf" +
+            "zwUqbX1FJH7lxd9cDqseZXr01vSFeVS0pX/mB/IDkF+DA08GU4/2uGcCgYA" +
+            "V1CP9e1vN/WtMc4ZvGIQVpAF+F5uBGSQapuaI85ndsYlHpMTvfX8w4xwhQm" +
+            "QaQdfUSHV+CQpXGBCW9EQwOt6tHHDdPw/b9jlwwEN7gCrCnxqpAf8a7vVUD" +
+            "EojNhocMEWJQnBRsG/zlOb4I93+fbMr+1ABp9u1M8G1c3wVCAdBFwKBgF8s" +
+            "JlG58EKSfdvhVNDRq4hC/yjcI6987rg2fmeX9QUYiwReniaesEoBdeHzOYW" +
+            "R3DtC5SNiDKuj7QmnRvNcbFwBz5dGOdiXytRtLkpwDArY/hV/hqeSH1nHU0" +
+            "fpLUScnTZr95HkLFIle1JCFXw0viGHKEBkdFvcuXIFON9KNTA/"
+        )!
+
+        let _2047BitRSAPrivateKeyPKCS8DER = Data(base64Encoded:
+            "MIIEugIBADANBgkqhkiG9w0BAQEFAASCBKQwggSgAgEAAoIBAFeiDzq7Cm4" +
+            "Kht5deiQcB48y7Xk7YLB+/DHv8TNmXqNjvQKic1ebNHlTf2RBCkVrR3FFB2" +
+            "BQDxilTn/xogundi/RLYGyyK6p0vkiTN0HMs1GFJBpu4z6/IJCMiYcX9sDb" +
+            "z7kMon27MiHLAD0lLaj/hO0TqYupZsUBj50zvXqWVqsomDMuH9WDSYfofm8" +
+            "OijgPrP4zaNBGJRtX7IiKJpjz9IzIuW2xl4SX+HH83IAI9JQAKVWWyO9FFn" +
+            "NCXygPJsxW9QBusjBH5lVCW12pWDHnNV/wbcEeLuVR3KrEi3RBZBEFNN3W1" +
+            "ixI4qZWFgH4O8+/YgkoZeoqj5cpAEuab1Qi7ECAwEAAQKCAQA3/qFkkac0c" +
+            "R2EcI5fDFn4Mj5zPHGn1TwoXHzurvbByDU5vbudutpou+WmlbiOauIXilgQ" +
+            "Ppem09m4/xjgAX0PSMWfHjIFCRZ5gmVCxhq794+kRytEBgva35lTqMXHGAa" +
+            "5VO7GITVjXJvNcHqlyVvME2Y94YiH8t+agODNWZUGzoWEGuXzP55ZyIhKCy" +
+            "RNoRKRuiJX4cDMMEnbeA8sPR+OTr0PDvkxLtAcFibmMMilcW+H6c8k5/AgC" +
+            "5oRD1loXdSHzOME7KG05I71x1XBcwTiwi8DsiqUahpzFS2PKhZqs+qT9XhR" +
+            "aXv9DyBmVFqCqNon4OqmqsPpQULHC/AoLInRAoGBANNXuOgEe67D9G4N7xX" +
+            "DFS5ElMhx2ufqDYqfcLFX1gsmHGvV2gSbDdgMBJjvN12SAmOyxuS5vkWHJI" +
+            "CWo4jPmiTrZ6scyzIL3RVepYMLW4UdboRCH839L8C+AS7Ign923FdgsXKjO" +
+            "bQDP3wDfucYZNK322mEqxM+IdLWM4Hd/0NvAoGAaiZxbtNKWrT5VIaeIP5y" +
+            "IHvVQytb0VwX2qydM9dAZlXgmqku8T+0Sru7Kv8OnqXeay1Wa0u0GOQ95/f" +
+            "ajPclejfYhZLftVmW77cja/tVBOEUudzcXQpRxmYfVTLWbLyK2M/qMh/A3C" +
+            "JQ5uKUK5uCIYRXF8xvQbuO4wRNljK5Et8CgYBXAgVxF+9niusFqBznI7KDo" +
+            "t5yC1WpJtW+XVfC2zuWyXDoAFnKjZ9Mc94srEdp8WOkcgSqQ8IO0812Vw4q" +
+            "k/WM/5Flg+wvxWyWkKmpYrKiAfTu5F49qt/PBSptfUUkfuXF31wOqx5levT" +
+            "W9IV5VLSlf+YH8gOQX4MDTwZTj/a4ZwKBgBXUI/17W839a0xzhm8YhBWkAX" +
+            "4Xm4EZJBqm5ojzmd2xiUekxO99fzDjHCFCZBpB19RIdX4JClcYEJb0RDA63" +
+            "q0ccN0/D9v2OXDAQ3uAKsKfGqkB/xru9VQMSiM2GhwwRYlCcFGwb/OU5vgj" +
+            "3f59syv7UAGn27UzwbVzfBUIB0EXAoGAXywmUbnwQpJ92+FU0NGriEL/KNw" +
+            "jr3zuuDZ+Z5f1BRiLBF6eJp6wSgF14fM5hZHcO0LlI2IMq6PtCadG81xsXA" +
+            "HPl0Y52JfK1G0uSnAMCtj+FX+Gp5IfWcdTR+ktRJydNmv3keQsUiV7UkIVf" +
+            "DS+IYcoQGR0W9y5cgU430o1MD8="
+        )!
+
+        let _2047BitRSAPublicKeyDER = Data(base64Encoded:
+            "MIIBITANBgkqhkiG9w0BAQEFAAOCAQ4AMIIBCQKCAQBXog86uwpuCobeXXo" +
+            "kHAePMu15O2Cwfvwx7/EzZl6jY70ConNXmzR5U39kQQpFa0dxRQdgUA8YpU" +
+            "5/8aILp3Yv0S2BssiuqdL5IkzdBzLNRhSQabuM+vyCQjImHF/bA28+5DKJ9" +
+            "uzIhywA9JS2o/4TtE6mLqWbFAY+dM716llarKJgzLh/Vg0mH6H5vDoo4D6z" +
+            "+M2jQRiUbV+yIiiaY8/SMyLltsZeEl/hx/NyACPSUAClVlsjvRRZzQl8oDy" +
+            "bMVvUAbrIwR+ZVQltdqVgx5zVf8G3BHi7lUdyqxIt0QWQRBTTd1tYsSOKmV" +
+            "hYB+DvPv2IJKGXqKo+XKQBLmm9UIuxAgMBAAE="
+        )!
+
+        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(pemRepresentation: _2047BitRSAPrivateKeyPEM))
+        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(pemRepresentation: _2047BitRSAPrivateKeyPKCS8PEM))
+        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(derRepresentation: _2047BitRSAPrivateKeyDER))
+        XCTAssertThrowsError(try _RSA.Signing.PrivateKey(derRepresentation: _2047BitRSAPrivateKeyPKCS8DER))
+        XCTAssertThrowsError(try _RSA.Signing.PublicKey(pemRepresentation: _2047BitRSAPublicKeyPEM))
+        XCTAssertThrowsError(try _RSA.Signing.PublicKey(derRepresentation: _2047BitRSAPublicKeyDER))
+    }
+
+    // The unsafe initializers require a modulus of at least 1024 bits. 1017 bits occupies 128 bytes,
+    // the same as 1024.
+    func testRejectKeysBelow1024BitMinimum() throws {
+        // Generated via `openssl genrsa -traditional 1017`, then converted to the encodings below.
+        let _1017BitRSAPrivateKeyPEM = """
+        -----BEGIN RSA PRIVATE KEY-----
+        MIICWAIBAAKBgAFVByFodT87fB0oWSEkwybEeqayqUavihFHLu3Ss/XuUxVosi5z
+        lnzxbta17k8WXJYXa7OZC4jicxQer5xrZr9Op1k99zlJUbMtznl+BiSRKoAOjmsQ
+        mLPU5er1hF1MnHUJsS1SgoTbR0CLPFNh4ai7WtOY6bWv/k9B03xNPeRVAgMBAAEC
+        gYAAhvHcYWZL0DELpKSoPdDPLV5PSlE7fEjJD37dcsvtXBIaXaRsRybcZ/jxE2qq
+        dvHKHphqp/vtfZYF9yKMZd9xcsxceGTRWR9kxQdKe6r9y1gzF1piRAyU4UcyjzFc
+        h4w4psX3AqqN4qpQJgYUZamSRnnoJ3Vq7u/oR3W0P+PL3QJAGTnDt6UAHahmdryj
+        KMFyQan+GU/eo6KDD84blk1L8axsEHtKUvtVBOWPRaR2WJI+q26adZbVvp707brW
+        8sa+9wJADYTjZOw5A2C+mXlbBwV78cLrXwsZ/+5zrlGH5dMuDYbuJH3InXK/SguL
+        f/OqQmrtUwSmL5QfQ//QPbUpsioIEwJABg1h8/HWsUbyLpLb4q9nJnIO0SvkkwYu
+        w+ADpnAtRHLGCr5J+tbqcx5Q3biz3FRaTO9gh84EwpOI2HD3mZAtyQJABk3sRQor
+        5DlfaO7A1ltmW23MmXvx2fn3FFmNCE4c8c30jCvkPBhgwET1/utAgMygc9B9Nz7Z
+        /bn0AHLVSPJ05QJAFJqFaLd6j9v/WK7noJk0f7lWTZnfeRkZPxJh4AobfnGKV1yO
+        +mB6mLJo/StOBrM82IdCBXTHRYYS2zUCCoJG1Q==
+        -----END RSA PRIVATE KEY-----
+        """
+
+        let _1017BitRSAPublicKeyPEM = """
+        -----BEGIN PUBLIC KEY-----
+        MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgAFVByFodT87fB0oWSEkwybEeqay
+        qUavihFHLu3Ss/XuUxVosi5zlnzxbta17k8WXJYXa7OZC4jicxQer5xrZr9Op1k9
+        9zlJUbMtznl+BiSRKoAOjmsQmLPU5er1hF1MnHUJsS1SgoTbR0CLPFNh4ai7WtOY
+        6bWv/k9B03xNPeRVAgMBAAE=
+        -----END PUBLIC KEY-----
+        """
+
+        let _1017BitRSAPrivateKeyPKCS8PEM = """
+        -----BEGIN PRIVATE KEY-----
+        MIICcgIBADANBgkqhkiG9w0BAQEFAASCAlwwggJYAgEAAoGAAVUHIWh1Pzt8HShZ
+        ISTDJsR6prKpRq+KEUcu7dKz9e5TFWiyLnOWfPFu1rXuTxZclhdrs5kLiOJzFB6v
+        nGtmv06nWT33OUlRsy3OeX4GJJEqgA6OaxCYs9Tl6vWEXUycdQmxLVKChNtHQIs8
+        U2HhqLta05jpta/+T0HTfE095FUCAwEAAQKBgACG8dxhZkvQMQukpKg90M8tXk9K
+        UTt8SMkPft1yy+1cEhpdpGxHJtxn+PETaqp28coemGqn++19lgX3Ioxl33FyzFx4
+        ZNFZH2TFB0p7qv3LWDMXWmJEDJThRzKPMVyHjDimxfcCqo3iqlAmBhRlqZJGeegn
+        dWru7+hHdbQ/48vdAkAZOcO3pQAdqGZ2vKMowXJBqf4ZT96jooMPzhuWTUvxrGwQ
+        e0pS+1UE5Y9FpHZYkj6rbpp1ltW+nvTtutbyxr73AkANhONk7DkDYL6ZeVsHBXvx
+        wutfCxn/7nOuUYfl0y4Nhu4kfcidcr9KC4t/86pCau1TBKYvlB9D/9A9tSmyKggT
+        AkAGDWHz8daxRvIuktvir2cmcg7RK+STBi7D4AOmcC1EcsYKvkn61upzHlDduLPc
+        VFpM72CHzgTCk4jYcPeZkC3JAkAGTexFCivkOV9o7sDWW2ZbbcyZe/HZ+fcUWY0I
+        ThzxzfSMK+Q8GGDARPX+60CAzKBz0H03Ptn9ufQActVI8nTlAkAUmoVot3qP2/9Y
+        ruegmTR/uVZNmd95GRk/EmHgCht+cYpXXI76YHqYsmj9K04GszzYh0IFdMdFhhLb
+        NQIKgkbV
+        -----END PRIVATE KEY-----
+        """
+
+        let _1017BitRSAPrivateKeyDER = Data(base64Encoded:
+            "MIICWAIBAAKBgAFVByFodT87fB0oWSEkwybEeqayqUavihFHLu3Ss/XuUxV" +
+            "osi5zlnzxbta17k8WXJYXa7OZC4jicxQer5xrZr9Op1k99zlJUbMtznl+Bi" +
+            "SRKoAOjmsQmLPU5er1hF1MnHUJsS1SgoTbR0CLPFNh4ai7WtOY6bWv/k9B0" +
+            "3xNPeRVAgMBAAECgYAAhvHcYWZL0DELpKSoPdDPLV5PSlE7fEjJD37dcsvt" +
+            "XBIaXaRsRybcZ/jxE2qqdvHKHphqp/vtfZYF9yKMZd9xcsxceGTRWR9kxQd" +
+            "Ke6r9y1gzF1piRAyU4UcyjzFch4w4psX3AqqN4qpQJgYUZamSRnnoJ3Vq7u" +
+            "/oR3W0P+PL3QJAGTnDt6UAHahmdryjKMFyQan+GU/eo6KDD84blk1L8axsE" +
+            "HtKUvtVBOWPRaR2WJI+q26adZbVvp707brW8sa+9wJADYTjZOw5A2C+mXlb" +
+            "BwV78cLrXwsZ/+5zrlGH5dMuDYbuJH3InXK/SguLf/OqQmrtUwSmL5QfQ//" +
+            "QPbUpsioIEwJABg1h8/HWsUbyLpLb4q9nJnIO0SvkkwYuw+ADpnAtRHLGCr" +
+            "5J+tbqcx5Q3biz3FRaTO9gh84EwpOI2HD3mZAtyQJABk3sRQor5DlfaO7A1" +
+            "ltmW23MmXvx2fn3FFmNCE4c8c30jCvkPBhgwET1/utAgMygc9B9Nz7Z/bn0" +
+            "AHLVSPJ05QJAFJqFaLd6j9v/WK7noJk0f7lWTZnfeRkZPxJh4AobfnGKV1y" +
+            "O+mB6mLJo/StOBrM82IdCBXTHRYYS2zUCCoJG1Q=="
+        )!
+
+        let _1017BitRSAPrivateKeyPKCS8DER = Data(base64Encoded:
+            "MIICcgIBADANBgkqhkiG9w0BAQEFAASCAlwwggJYAgEAAoGAAVUHIWh1Pzt" +
+            "8HShZISTDJsR6prKpRq+KEUcu7dKz9e5TFWiyLnOWfPFu1rXuTxZclhdrs5" +
+            "kLiOJzFB6vnGtmv06nWT33OUlRsy3OeX4GJJEqgA6OaxCYs9Tl6vWEXUycd" +
+            "QmxLVKChNtHQIs8U2HhqLta05jpta/+T0HTfE095FUCAwEAAQKBgACG8dxh" +
+            "ZkvQMQukpKg90M8tXk9KUTt8SMkPft1yy+1cEhpdpGxHJtxn+PETaqp28co" +
+            "emGqn++19lgX3Ioxl33FyzFx4ZNFZH2TFB0p7qv3LWDMXWmJEDJThRzKPMV" +
+            "yHjDimxfcCqo3iqlAmBhRlqZJGeegndWru7+hHdbQ/48vdAkAZOcO3pQAdq" +
+            "GZ2vKMowXJBqf4ZT96jooMPzhuWTUvxrGwQe0pS+1UE5Y9FpHZYkj6rbpp1" +
+            "ltW+nvTtutbyxr73AkANhONk7DkDYL6ZeVsHBXvxwutfCxn/7nOuUYfl0y4" +
+            "Nhu4kfcidcr9KC4t/86pCau1TBKYvlB9D/9A9tSmyKggTAkAGDWHz8daxRv" +
+            "Iuktvir2cmcg7RK+STBi7D4AOmcC1EcsYKvkn61upzHlDduLPcVFpM72CHz" +
+            "gTCk4jYcPeZkC3JAkAGTexFCivkOV9o7sDWW2ZbbcyZe/HZ+fcUWY0IThzx" +
+            "zfSMK+Q8GGDARPX+60CAzKBz0H03Ptn9ufQActVI8nTlAkAUmoVot3qP2/9" +
+            "YruegmTR/uVZNmd95GRk/EmHgCht+cYpXXI76YHqYsmj9K04GszzYh0IFdM" +
+            "dFhhLbNQIKgkbV"
+        )!
+
+        let _1017BitRSAPublicKeyDER = Data(base64Encoded:
+            "MIGeMA0GCSqGSIb3DQEBAQUAA4GMADCBiAKBgAFVByFodT87fB0oWSEkwyb" +
+            "EeqayqUavihFHLu3Ss/XuUxVosi5zlnzxbta17k8WXJYXa7OZC4jicxQer5" +
+            "xrZr9Op1k99zlJUbMtznl+BiSRKoAOjmsQmLPU5er1hF1MnHUJsS1SgoTbR" +
+            "0CLPFNh4ai7WtOY6bWv/k9B03xNPeRVAgMBAAE="
+        )!
+
+        XCTAssertThrowsError(
+            try _RSA.Signing.PrivateKey(unsafePEMRepresentation: _1017BitRSAPrivateKeyPEM)
+        )
+        XCTAssertThrowsError(
+            try _RSA.Signing.PrivateKey(unsafePEMRepresentation: _1017BitRSAPrivateKeyPKCS8PEM)
+        )
+        XCTAssertThrowsError(
+            try _RSA.Signing.PrivateKey(unsafeDERRepresentation: _1017BitRSAPrivateKeyDER)
+        )
+        XCTAssertThrowsError(
+            try _RSA.Signing.PrivateKey(unsafeDERRepresentation: _1017BitRSAPrivateKeyPKCS8DER)
+        )
+        XCTAssertThrowsError(
+            try _RSA.Signing.PublicKey(unsafePEMRepresentation: _1017BitRSAPublicKeyPEM)
+        )
+        XCTAssertThrowsError(
+            try _RSA.Signing.PublicKey(unsafeDERRepresentation: _1017BitRSAPublicKeyDER)
+        )
     }
 
     func testHandlingNonStandardKeys() throws {
@@ -575,12 +841,12 @@ final class TestRSASigning: XCTestCase {
             "En7fZhCeZeNBjNTuKXj3JqdP3wIDAQAB"
         )!
 
-        XCTAssertEqual(try _RSA.Signing.PrivateKey(pemRepresentation: awkwardRSAPrivateKeyPEM).keySizeInBits, 2056)
-        XCTAssertEqual(try _RSA.Signing.PrivateKey(pemRepresentation: awkwardRSAPrivateKeyPKCS8PEM).keySizeInBits, 2056)
-        XCTAssertEqual(try _RSA.Signing.PrivateKey(derRepresentation: awkwardRSAPrivateKeyDER).keySizeInBits, 2056)
-        XCTAssertEqual(try _RSA.Signing.PrivateKey(derRepresentation: awkwardRSAPrivateKeyPKCS8DER).keySizeInBits, 2056)
-        XCTAssertEqual(try _RSA.Signing.PublicKey(pemRepresentation: awkwardRSAPublicKeyPEM).keySizeInBits, 2056)
-        XCTAssertEqual(try _RSA.Signing.PublicKey(derRepresentation: awkwardRSAPublicKeyDER).keySizeInBits, 2056)
+        XCTAssertEqual(try _RSA.Signing.PrivateKey(pemRepresentation: awkwardRSAPrivateKeyPEM).keySizeInBits, 2050)
+        XCTAssertEqual(try _RSA.Signing.PrivateKey(pemRepresentation: awkwardRSAPrivateKeyPKCS8PEM).keySizeInBits, 2050)
+        XCTAssertEqual(try _RSA.Signing.PrivateKey(derRepresentation: awkwardRSAPrivateKeyDER).keySizeInBits, 2050)
+        XCTAssertEqual(try _RSA.Signing.PrivateKey(derRepresentation: awkwardRSAPrivateKeyPKCS8DER).keySizeInBits, 2050)
+        XCTAssertEqual(try _RSA.Signing.PublicKey(pemRepresentation: awkwardRSAPublicKeyPEM).keySizeInBits, 2050)
+        XCTAssertEqual(try _RSA.Signing.PublicKey(derRepresentation: awkwardRSAPublicKeyDER).keySizeInBits, 2050)
     }
 
     func testMangledPKCS8DERKey() throws {

--- a/Tests/CryptoExtrasTests/TestRSASigning.swift
+++ b/Tests/CryptoExtrasTests/TestRSASigning.swift
@@ -910,6 +910,23 @@ final class TestRSASigning: XCTestCase {
 
         return pemLines.joined(separator: "\n")
     }
+
+    func test_invalidDERPublicKeyThrowsWithoutDoubleFree() throws {
+        // SEQUENCE { INTEGER 0, INTEGER 0 }
+        let badBase64 = "MAYCAQACAQ=="
+        let badDER = Array(Data(base64Encoded: badBase64)!)
+        XCTAssertThrowsError(try BoringSSLRSAPublicKey(derRepresentation: badDER))
+    }
+
+    func test_invalidPEMPublicKeyThrowsWithoutDoubleFree() throws {
+        // SEQUENCE { INTEGER 0, INTEGER 0 }
+        let badPEM = """
+            -----BEGIN PUBLIC KEY-----
+            MAYCAQACAQ==
+            -----END PUBLIC KEY-----
+            """
+        XCTAssertThrowsError(try BoringSSLRSAPublicKey(pemRepresentation: badPEM))
+    }
 }
 
 

--- a/Tests/CryptoExtrasTests/TestRSASigning.swift
+++ b/Tests/CryptoExtrasTests/TestRSASigning.swift
@@ -1036,6 +1036,13 @@ final class TestRSASigning: XCTestCase {
             n: bytesValues.randomElement()!,
             e: bytesValues.randomElement()!
         )
+        // Modulus of the 512-bit key above: `openssl rsa -in key.pem -noout -modulus`.
+        let _512BitModulus =
+            "e24c4c2c70e673315c2420b0e211542bbccf5b79f2ce6bdaa4aac29650bd064b"
+            + "955ae1613a449c7143e906d7f251e49356771d9d6f8f15bcf4044f87de1c1bed"
+        XCTAssertThrowsError(
+            try _RSA.Signing.PublicKey(n: Data(hexString: _512BitModulus), e: Data(hexString: "010001"))
+        )
     }
 
     func testConstructAndUseKeyFromRSANumbersWhileRecoveringPrimes() throws {


### PR DESCRIPTION
## Motivation

Before we merge the 5.x branch back to main, we need to merge from main to 5.x to account for the incoming files on main that may not have had the 5.x improvements.

That seems to be just `AES_CBC_boring.swift`, but it will need the `@diagnose`-dance on the `@_implementationOnly import` and formatting with the newer formatter used on the 5.x branch, so we should expect the PR to fail CI until a follow up commit is added after the merge commit.

## Modifications

- Merge main into 5.x.
- One small commit on top to wrap the new file.

## Result

After this is merged, 5.x should merge cleanly into main.

